### PR TITLE
Fix incorrect variable assignment

### DIFF
--- a/Classes/PHPPowerPoint/DocumentLayout.php
+++ b/Classes/PHPPowerPoint/DocumentLayout.php
@@ -189,7 +189,7 @@ class PHPPowerPoint_DocumentLayout
      * @return PHPPowerPoint_DocumentLayout
      */
     public function setLayoutYmilli(integer $pValue) {
-		$this->_cx = $pValue * 36000;
+		$this->_cy = $pValue * 36000;
 		$this->_layout = PHPPowerPoint_DocumentLayout::LAYOUT_CUSTOM;
     	return $this;
     }


### PR DESCRIPTION
Fixing a typo in the Document Layout class that impacts when custom slide sizes are used
