### PR TITLE
Make package psr-4 compliant. Classes autoload with composers autoloader...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
     "autoload": {
         "psr-0": {
             "PHPPowerPoint": "src/"
+        },
+        "psr-4": {
+            "PhpOffice\\PhpPowerpoint\\": "src/PhpPowerpoint/"
         }
     }
 }


### PR DESCRIPTION
This change will make this package to be able to use composers autoloader. When you use composer this package will be autoloaded out of the box.

This is legacy change, and we still can use package autoloader when composer is not included in project.

With composer this is not needed anymore:

```
require_once 'path/to/PhpPowerpoint/src/PhpPowerpoint/Autoloader.php';
\PhpOffice\PhpPowerpoint\Autoloader::register();
```

After this change README should be adopted to this change.
