### PR TITLE
[feat/richtext-fill] fixed unset fill color for rich text shapes

### DIFF
--- a/src/PhpPowerpoint/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPowerpoint/Writer/PowerPoint2007/Slide.php
@@ -412,6 +412,8 @@ class Slide extends AbstractPart
         $objWriter->writeAttribute('prst', 'rect');
         $objWriter->endElement();
 
+        $this->writeFill($objWriter, $shape->getFill());
+
         $objWriter->endElement();
 
         // p:txBody


### PR DESCRIPTION
RichText fills are ignored by the Slide writer for now.
This PR fixes that.
