### PR TITLE
Add appear animation to phppresentation for Powerpoint2007 writer

### DIFF
--- a/src/PhpPresentation/Slide.php
+++ b/src/PhpPresentation/Slide.php
@@ -521,25 +521,27 @@ class Slide implements ComparableInterface, ShapeContainerInterface
         $this->background = $background;
         return $this;
     }
-	
-	  /**
+    
+    /**
      * Add an animation to the slide
      *
-     * @param  \PhpOffice\PhpPresentation\Slide\Animation 
-     * @return \PhpOffice\PhpPresentation\Slide\Animation 
+     * @param  \PhpOffice\PhpPresentation\Slide\Animation
+     * @return \PhpOffice\PhpPresentation\Slide\Animation
      */
-	public function addAnimation($animation){
-		$this->animations[] = $animation;
-		return $animation;
-	}
-	
-	/**
+    public function addAnimation($animation)
+    {
+        $this->animations[] = $animation;
+        return $animation;
+    }
+    
+    /**
      * Get collection of animations
      *
-     * @return \PhpOffice\PhpPresentation\Slide\Animation 
+     * @return \PhpOffice\PhpPresentation\Slide\Animation
      */
-	
-	public function getAnimations(){
-		return $this->animations;
-	}
+    
+    public function getAnimations()
+    {
+        return $this->animations;
+    }
 }

--- a/src/PhpPresentation/Slide.php
+++ b/src/PhpPresentation/Slide.php
@@ -79,7 +79,13 @@ class Slide implements ComparableInterface, ShapeContainerInterface
      * @var \PhpOffice\PhpPresentation\Slide\Transition
      */
     private $slideTransition;
-    
+  
+	/**
+     *
+     * @var \PhpOffice\PhpPresentation\Slide\Animation
+     */
+	private $animations = ARRAY();
+	
     /**
      * Hash index
      *
@@ -157,7 +163,7 @@ class Slide implements ComparableInterface, ShapeContainerInterface
     {
         return $this->shapeCollection;
     }
-
+	
     /**
      * Add shape to slide
      *
@@ -515,4 +521,25 @@ class Slide implements ComparableInterface, ShapeContainerInterface
         $this->background = $background;
         return $this;
     }
+	
+	  /**
+     * Add an animation to the slide
+     *
+     * @param  \PhpOffice\PhpPresentation\Slide\Animation 
+     * @return \PhpOffice\PhpPresentation\Slide\Animation 
+     */
+	public function addAnimation($animation){
+		$this->animations[] = $animation;
+		return $animation;
+	}
+	
+	/**
+     * Get collection of animations
+     *
+     * @return \PhpOffice\PhpPresentation\Slide\Animation 
+     */
+	
+	public function getAnimations(){
+		return $this->animations;
+	}
 }

--- a/src/PhpPresentation/Slide.php
+++ b/src/PhpPresentation/Slide.php
@@ -80,12 +80,12 @@ class Slide implements ComparableInterface, ShapeContainerInterface
      */
     private $slideTransition;
   
-	/**
+    /**
      *
      * @var \PhpOffice\PhpPresentation\Slide\Animation
      */
-	private $animations = ARRAY();
-	
+    private $animations = array();
+    
     /**
      * Hash index
      *
@@ -163,7 +163,7 @@ class Slide implements ComparableInterface, ShapeContainerInterface
     {
         return $this->shapeCollection;
     }
-	
+    
     /**
      * Add shape to slide
      *

--- a/src/PhpPresentation/Slide/Animation.php
+++ b/src/PhpPresentation/Slide/Animation.php
@@ -20,5 +20,5 @@ class Animation
     public function getShapeCollection()
     {
         return $this->shapeCollection;
-    }   
+    }
 }

--- a/src/PhpPresentation/Slide/Animation.php
+++ b/src/PhpPresentation/Slide/Animation.php
@@ -1,23 +1,24 @@
 <?php
 namespace PhpOffice\PhpPresentation\Slide;
-class Animation{
-	private $shapeCollection = ARRAY();
-	
-    public function __construct(){
-		
-	}
-	
-	public function addShape($shape){
-		$this->shapeCollection[] = $shape;
-		
-		return $shape;
-	}
-	
-	public function getShapeCollection(){
-        return $this->shapeCollection;
-    }
-	
-	
-}
 
-?>	
+class Animation
+{
+    private $shapeCollection = array();
+   
+    public function __construct()
+    {
+        
+    }
+    
+    public function addShape($shape)
+    {
+        $this->shapeCollection[] = $shape;
+        
+        return $shape;
+    }
+    
+    public function getShapeCollection()
+    {
+        return $this->shapeCollection;
+    }   
+}

--- a/src/PhpPresentation/Slide/Animation.php
+++ b/src/PhpPresentation/Slide/Animation.php
@@ -1,0 +1,23 @@
+<?php
+namespace PhpOffice\PhpPresentation\Slide;
+class Animation{
+	private $shapeCollection = ARRAY();
+	
+    public function __construct(){
+		
+	}
+	
+	public function addShape($shape){
+		$this->shapeCollection[] = $shape;
+		
+		return $shape;
+	}
+	
+	public function getShapeCollection(){
+        return $this->shapeCollection;
+    }
+	
+	
+}
+
+?>	

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -313,7 +313,7 @@ class Slide extends AbstractPart
 
                 $shapesInAnimation = $animation->getShapeCollection();
 
-                $firstShapeInAnimation = true;
+                $firstInAni = true;
 
                 foreach ($shapesInAnimation as $shape) {
                     $hash = $shape->getHashCode();
@@ -330,7 +330,7 @@ class Slide extends AbstractPart
                     $objWriter->writeAttribute("presetSubtype", "0");
                     $objWriter->writeAttribute("grpId", "0");
 
-                    $nodeType = $firstShapeInAnimation ? "clickEffect" : "withEffect";
+                    $nodeType = $firstInAni ? "clickEffect" : "withEffect";
 
                     $objWriter->writeAttribute("nodeType", $nodeType);
 
@@ -399,7 +399,7 @@ class Slide extends AbstractPart
 
                     $objWriter->endElement();
 
-                    $firstShapeInAnimation = false;
+                    $firstInAni = false;
                 }
 
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -275,7 +275,7 @@ class Slide extends AbstractPart
             $objWriter->startElement("p:childTnLst");
 
             //each animation has multiple shapes
-            foreach( $animations as $animation ){
+            foreach ($animations as $animation) {
 
                 $objWriter->startElement("p:par");
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -266,7 +266,7 @@ class Slide extends AbstractPart
             $objWriter->writeAttribute('concurrent', '1');
             $objWriter->writeAttribute('nextAc', 'seek');
 
-            $objWriter->startElement('p:cTn'); 
+            $objWriter->startElement('p:cTn');
             $objWriter->writeAttribute('id', $idCount);
             $idCount += 1;
             $objWriter->writeAttribute('dur', 'indefinite');
@@ -275,7 +275,7 @@ class Slide extends AbstractPart
             $objWriter->startElement("p:childTnLst");
 
             //each animation has multiple shapes
-            foreach($animations as $animation){
+            foreach( $animations as $animation ){
 
                 $objWriter->startElement("p:par");
 
@@ -317,7 +317,7 @@ class Slide extends AbstractPart
 
                 foreach ($shapesInAnimation as $shape) {
                     $hash = $shape->getHashCode();
-                    $shapeId = $hashToIdMap[$hash]; 
+                    $shapeId = $hashToIdMap[$hash];
 
                     $objWriter->startElement("p:par");
 
@@ -348,7 +348,7 @@ class Slide extends AbstractPart
 
                     $objWriter->startElement("p:cBhvr");
 
-                    $objWriter->startElement("p:cTn"); 
+                    $objWriter->startElement("p:cTn");
                     $objWriter->writeAttribute("id", $idCount);
                     $idCount +=  1;
                     $objWriter->writeAttribute("dur", "1");
@@ -360,7 +360,7 @@ class Slide extends AbstractPart
                     $objWriter->writeAttribute("delay", "0");
                     $objWriter->endElement();
 
-                    $objWriter->endElement(); 
+                    $objWriter->endElement();
 
 
 
@@ -369,7 +369,7 @@ class Slide extends AbstractPart
                     $objWriter->startElement("p:tgtEl");
 
                     $objWriter->startElement("p:spTgt");
-                    //shape id 
+                    //shape id
                     $objWriter->writeAttribute("spid", $shapeId);
                     $objWriter->endElement();
 
@@ -403,11 +403,11 @@ class Slide extends AbstractPart
                 }
 
 
-                $objWriter->endElement(); //end child lst 
+                $objWriter->endElement(); //end child lst
 
-                $objWriter->endElement(); //end ctn	
+                $objWriter->endElement(); //end ctn
 
-                $objWriter->endElement(); //end par 
+                $objWriter->endElement(); //end par
 
 
                 $objWriter->endElement(); //end childtnlist
@@ -481,7 +481,7 @@ class Slide extends AbstractPart
 
             $objWriter->endElement(); // end bldLst
 
-            $objWriter->endElement(); //end timing	
+            $objWriter->endElement(); //end timing
 
             $objWriter->endElement();
         }

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -1596,8 +1596,8 @@ class Slide extends AbstractPart
         // Check slide
         if (is_null($pNote)) {
             throw new \Exception("Invalid \PhpOffice\PhpPresentation\Slide\Note object passed.");
-        }
-
+        }   
+        
         // Create XML writer
         $objWriter = $this->getXMLWriter();
 
@@ -1644,31 +1644,134 @@ class Slide extends AbstractPart
         $objWriter->startElement('a:off');
         $objWriter->writeAttribute('x', CommonDrawing::pixelsToEmu($pNote->getOffsetX()));
         $objWriter->writeAttribute('y', CommonDrawing::pixelsToEmu($pNote->getOffsetY()));
-        $objWriter->endElement(); // a:off
+        $objWriter->endElement();// a:off
 
         // a:ext
         $objWriter->startElement('a:ext');
         $objWriter->writeAttribute('cx', CommonDrawing::pixelsToEmu($pNote->getExtentX()));
         $objWriter->writeAttribute('cy', CommonDrawing::pixelsToEmu($pNote->getExtentY()));
-        $objWriter->endElement(); // a:ext
+        $objWriter->endElement();// a:ext
 
         // a:chOff
         $objWriter->startElement('a:chOff');
         $objWriter->writeAttribute('x', CommonDrawing::pixelsToEmu($pNote->getOffsetX()));
         $objWriter->writeAttribute('y', CommonDrawing::pixelsToEmu($pNote->getOffsetY()));
-        $objWriter->endElement(); // a:chOff
+        $objWriter->endElement();// a:chOff
 
         // a:chExt
         $objWriter->startElement('a:chExt');
         $objWriter->writeAttribute('cx', CommonDrawing::pixelsToEmu($pNote->getExtentX()));
         $objWriter->writeAttribute('cy', CommonDrawing::pixelsToEmu($pNote->getExtentY()));
-        $objWriter->endElement(); // a:chExt
+        $objWriter->endElement();// a:chExt
 
         // ## a:xfrm
         $objWriter->endElement();
 
         // ## p:grpSpPr
         $objWriter->endElement();
+
+        //ADD IN rectangle display section
+
+        //p:sp
+        $objWriter->startElement('p:sp');
+
+        //p:nvSpPr
+        $objWriter->startElement('p:nvSpPr');
+
+        //p:cNvPr
+        $objWriter->startElement('p:cNvPr');
+        $objWriter->writeAttribute('id','2');
+        $objWriter->writeAttribute('name', 'Slide Image Placeholder 1');
+        $objWriter->endElement();
+
+        //p:cNvSpPr
+        $objWriter->startElement('p:cNvSpPr');
+
+        //a:spLocks
+        $objWriter->startElement('a:spLocks');
+        $objWriter->writeAttribute('noGrp', '1');
+        $objWriter->writeAttribute('noRot', '1'); 
+        $objWriter->writeAttribute('noChangeAspect', '1');
+        $objWriter->endElement();
+
+        //end p:cNvSpPr
+        $objWriter->endElement();
+
+        //p:nvPr
+        $objWriter->startElement('p:nvPr');
+
+        //p:ph
+        $objWriter->startElement('p:ph'); 
+        $objWriter->writeAttribute('type', 'sldImg');
+        $objWriter->endElement();
+
+        //end p:nvPr
+        $objWriter->endElement();
+
+        //end p:nvSpPr
+        $objWriter->endElement();
+
+        //p:spPr
+        $objWriter->startElement('p:spPr');
+
+        //a:xfrm
+        $objWriter->startElement('a:xfrm');
+
+        //a:off
+        $objWriter->startElement('a:off');
+        $objWriter->writeAttribute('x', CommonDrawing::pixelsToEmu($pNote->getOffsetX()));
+        $objWriter->writeAttribute('y', CommonDrawing::pixelsToEmu($pNote->getOffsetY()));
+        $objWriter->endElement();
+
+        //a:ext
+        $objWriter->startElement('a:ext');
+        $objWriter->writeAttribute('cx', CommonDrawing::pixelsToEmu(round($pNote->getExtentX()/2)));
+        $objWriter->writeAttribute('cy', CommonDrawing::pixelsToEmu(round($pNote->getExtentY()/2)));
+        
+        
+        $objWriter->endElement();
+
+        //a:xfrm
+        $objWriter->endElement();
+
+        //a:prstGeom
+        $objWriter->startElement('a:prstGeom');
+        $objWriter->writeAttribute('prst','rect');
+
+        //a:avLst
+        $objWriter->writeElement('a:avLst', null);
+
+        //end prstGeom
+        $objWriter->endElement();
+
+        //a:noFill
+        $objWriter->writeElement('a:noFill', null);
+
+        //a:ln
+        $objWriter->startElement('a:ln');
+        $objWriter->writeAttribute('w','12700');
+
+        //a:solidFill
+        $objWriter->startElement('a:solidFill');
+
+        //a:prstClr
+        $objWriter->startElement('a:prstClr');
+        $objWriter->writeAttribute('val','black');
+        $objWriter->endElement();
+
+        //end a:solidFill
+        $objWriter->endElement();
+
+        //end a:ln
+        $objWriter->endElement(); 
+        
+        //end p:spPr
+        $objWriter->endElement();
+        
+        //end p:sp
+        $objWriter->endElement();
+        
+        //end slide preview display
 
         // p:sp
         $objWriter->startElement('p:sp');
@@ -1677,7 +1780,7 @@ class Slide extends AbstractPart
         $objWriter->startElement('p:nvSpPr');
 
         $objWriter->startElement('p:cNvPr');
-        $objWriter->writeAttribute('id', '1');
+        $objWriter->writeAttribute('id', '3');
         $objWriter->writeAttribute('name', 'Notes Placeholder');
         $objWriter->endElement();
 
@@ -1705,8 +1808,43 @@ class Slide extends AbstractPart
 
         // ## p:nvSpPr
         $objWriter->endElement();
+        
+        //START notes print below rectangle section
+        //p:spPr
+        $objWriter->startElement('p:spPr');
+        
+        //a:xfrm
+        $objWriter->startElement('a:xfrm');
+        
+        //a:off
+        $objWriter->startElement('a:off');
+        $objWriter->writeAttribute('x',CommonDrawing::pixelsToEmu($pNote->getOffsetX()));
+        $objWriter->writeAttribute('y',CommonDrawing::pixelsToEmu(ROUND($pNote->getExtentY()/2)));
+        $objWriter->endElement(); 
+        
+        //a:ext
+        $objWriter->startElement('a:ext');
+        $objWriter->writeAttribute('cx','5486400');
+        $objWriter->writeAttribute('cy','3600450');
+        $objWriter->endElement(); 
+        
+        //end a:xfrm
+        $objWriter->endElement();
+        
+        //a:prstGeom
+        $objWriter->startElement('a:prstGeom');
+        $objWriter->writeAttribute('prst','rect');
+        
+        //a:avLst
+        $objWriter->writeElement('a:avLst',null);
+        
+        //end a:prstGeom
+        $objWriter->endElement();
+        
+        //end p:spPr
+        $objWriter->endElement();
 
-        $objWriter->writeElement('p:spPr', null);
+        //$objWriter->writeElement('p:spPr', null);
 
         // p:txBody
         $objWriter->startElement('p:txBody');

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -180,7 +180,7 @@ class Slide extends AbstractPart
         $objWriter->endElement();
 
         // Loop shapes
-        $shapeId = 0;
+        $shapeId = 1;
         $shapes  = $pSlide->getShapeCollection();
         foreach ($shapes as $shape) {
             // Increment $shapeId
@@ -217,7 +217,276 @@ class Slide extends AbstractPart
 
         if (!is_null($pSlide->getTransition())) {
             $this->writeTransition($objWriter, $pSlide->getTransition());
-        }
+		}
+		
+		//do animation writing 
+		$shapeId = 1;
+        $shapes  = $pSlide->getShapeCollection();
+		
+		$animations = $pSlide->getAnimations();
+
+		if(count($animations) > 0){
+			
+			$hashToIdMap = ARRAY(); 
+
+			foreach($shapes as $shape){
+				$shapeId += 1; 
+				$hash = $shape->getHashCode();
+				$hashToIdMap[$hash] = $shapeId;
+			}
+
+			$animationIds = ARRAY();
+
+			foreach($animations as $animation){
+				$shapesInAnimation = $animation->getShapeCollection(); 
+				foreach($shapesInAnimation as $shape){
+					$hash = $shape->getHashCode();
+					$animationIds[] = $hashToIdMap[$hash];
+				}
+			}
+
+
+			$idCount = 1;
+
+			$objWriter->startElement('p:timing');
+
+			$objWriter->startElement('p:tnLst');
+
+			$objWriter->startElement('p:par');
+
+			$objWriter->startElement('p:cTn');
+			$objWriter->writeAttribute('id',$idCount);
+			$idCount += 1;
+			$objWriter->writeAttribute('dur','indefinite');
+			$objWriter->writeAttribute('restart','never');
+			$objWriter->writeAttribute('nodeType','tmRoot');
+
+			$objWriter->startElement('p:childTnLst');
+
+			$objWriter->startElement('p:seq');
+			$objWriter->writeAttribute('concurrent','1');
+			$objWriter->writeAttribute('nextAc','seek');
+
+			$objWriter->startElement('p:cTn'); 
+			$objWriter->writeAttribute('id',$idCount);
+			$idCount += 1;
+			$objWriter->writeAttribute('dur','indefinite');
+			$objWriter->writeAttribute('nodeType','mainSeq');
+
+			$objWriter->startElement("p:childTnLst");
+
+			//each animation has multiple shapes
+			foreach($animations as $animation){
+
+				$objWriter->startElement("p:par");
+
+				$objWriter->startElement("p:cTn");
+				$objWriter->writeAttribute("id",$idCount);
+				$idCount += 1;
+				$objWriter->writeAttribute("fill","hold");
+
+				$objWriter->startElement('p:stCondLst');
+
+				$objWriter->startElement('p:cond');
+				$objWriter->writeAttribute("delay","indefinite");
+				$objWriter->endElement();
+
+				$objWriter->endElement();
+
+				$objWriter->startElement("p:childTnLst");
+
+				$objWriter->startElement("p:par");
+
+				$objWriter->startElement("p:cTn");
+				$objWriter->writeAttribute("id",$idCount);
+				$idCount += 1;
+				$objWriter->writeAttribute("fill","hold");
+
+				$objWriter->startElement('p:stCondLst');
+
+				$objWriter->startElement('p:cond');
+				$objWriter->writeAttribute("delay","0");
+				$objWriter->endElement();
+
+				$objWriter->endElement();
+
+				$objWriter->startElement("p:childTnLst");
+
+				$shapesInAnimation = $animation->getShapeCollection();
+
+				$firstShapeInAnimation = true;		
+				
+				foreach($shapesInAnimation as $shape){
+					$hash = $shape->getHashCode();
+					$shapeId = $hashToIdMap[$hash]; 
+
+					$objWriter->startElement("p:par");
+
+					$objWriter->startElement("p:cTn");
+					$objWriter->writeAttribute("id", $idCount); 
+					$idCount += 1;
+					$objWriter->writeAttribute("presetID", "1");			
+					$objWriter->writeAttribute("presetClass", "entr");
+					$objWriter->writeAttribute("fill", "hold");
+					$objWriter->writeAttribute("presetSubtype", "0");
+					$objWriter->writeAttribute("grpId", "0");
+
+					$nodeType = $firstShapeInAnimation ? "clickEffect" : "withEffect";
+
+					$objWriter->writeAttribute("nodeType",$nodeType);
+
+					$objWriter->startElement("p:stCondLst");
+
+					$objWriter->startElement("p:cond");
+					$objWriter->writeAttribute("delay","0");
+					$objWriter->endElement();
+
+					$objWriter->endElement(); 	
+
+					$objWriter->startElement("p:childTnLst");
+
+					$objWriter->startElement("p:set");
+
+					$objWriter->startElement("p:cBhvr");
+
+					$objWriter->startElement("p:cTn"); 
+					$objWriter->writeAttribute("id",$idCount);
+					$idCount +=  1;
+					$objWriter->writeAttribute("dur","1");
+					$objWriter->writeAttribute("fill","hold");
+
+					$objWriter->startElement("p:stCondLst");
+						
+					$objWriter->startElement("p:cond");
+					$objWriter->writeAttribute("delay","0");
+					$objWriter->endElement();
+
+					$objWriter->endElement(); 								
+
+
+
+					$objWriter->endElement();
+
+					$objWriter->startElement("p:tgtEl");
+
+					$objWriter->startElement("p:spTgt");
+					//shape id 
+					$objWriter->writeAttribute("spid",$shapeId);
+					$objWriter->endElement();
+
+					$objWriter->endElement();
+
+					$objWriter->startElement("p:attrNameLst");
+
+					$objWriter->writeElement("p:attrName","style.visibility");
+
+					$objWriter->endElement();
+
+					$objWriter->endElement();
+
+					$objWriter->startElement("p:to");
+
+					$objWriter->startElement("p:strVal");
+					$objWriter->writeAttribute("val","visible");
+					$objWriter->endElement();
+
+					$objWriter->endElement();
+
+					$objWriter->endElement();	
+
+					$objWriter->endElement(); //end child tn lst
+
+					$objWriter->endElement(); //end ctn
+
+					$objWriter->endElement();
+
+					$firstShapeInAnimation = false;		
+				}
+
+
+				$objWriter->endElement(); //end child lst 
+
+				$objWriter->endElement(); //end ctn	
+
+				$objWriter->endElement(); //end par 
+
+
+				$objWriter->endElement(); //end childtnlist
+
+				$objWriter->endElement(); //end ctn
+
+				$objWriter->endElement(); //end par
+
+			}
+
+
+			$objWriter->endElement();
+
+			$objWriter->endElement();
+
+			///prevCondLst
+			$objWriter->startElement("p:prevCondLst");
+
+			$objWriter->startElement('p:cond');
+			$objWriter->writeAttribute('evt','onPrev');
+			$objWriter->writeAttribute('delay','0');
+
+			$objWriter->startElement('p:tgtEl');
+
+			$objWriter->writeElement('p:sldTgt', null);
+
+			$objWriter->endElement();
+
+			$objWriter->endElement();
+
+			$objWriter->endElement();
+
+			//nextCondLst
+			$objWriter->startElement("p:nextCondLst");
+
+			$objWriter->startElement('p:cond');
+			$objWriter->writeAttribute('evt','onNext');
+			$objWriter->writeAttribute('delay','0');
+
+			$objWriter->startElement('p:tgtEl');
+
+			$objWriter->writeElement('p:sldTgt', null);
+
+			$objWriter->endElement();
+
+			$objWriter->endElement();
+
+			$objWriter->endElement();
+
+			$objWriter->endElement(); //end p:seq
+
+			$objWriter->endElement(); //end p:childTnLst
+
+			$objWriter->endElement();  //end ctn
+
+			$objWriter->endElement(); //end par
+
+			$objWriter->endElement(); //	end tnLst
+
+			$objWriter->startElement('p:bldLst');
+
+			//add in ids of all shapes in this slides animations
+
+			foreach($animationIds as $id){
+				$objWriter->startElement('p:bldP');
+				$objWriter->writeAttribute("spid",$id);
+				$objWriter->writeAttribute('grpId',0);
+				$objWriter->endELement();	
+			}
+
+
+			$objWriter->endElement(); // end bldLst
+
+			$objWriter->endElement(); //end timing	
+
+			$objWriter->endElement();
+		}		
+		
 
         $objWriter->endElement();
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -1596,7 +1596,7 @@ class Slide extends AbstractPart
         // Check slide
         if (is_null($pNote)) {
             throw new \Exception("Invalid \PhpOffice\PhpPresentation\Slide\Note object passed.");
-        }   
+        }
         
         // Create XML writer
         $objWriter = $this->getXMLWriter();
@@ -1680,7 +1680,7 @@ class Slide extends AbstractPart
 
         //p:cNvPr
         $objWriter->startElement('p:cNvPr');
-        $objWriter->writeAttribute('id','2');
+        $objWriter->writeAttribute('id', '2');
         $objWriter->writeAttribute('name', 'Slide Image Placeholder 1');
         $objWriter->endElement();
 
@@ -1690,7 +1690,7 @@ class Slide extends AbstractPart
         //a:spLocks
         $objWriter->startElement('a:spLocks');
         $objWriter->writeAttribute('noGrp', '1');
-        $objWriter->writeAttribute('noRot', '1'); 
+        $objWriter->writeAttribute('noRot', '1');
         $objWriter->writeAttribute('noChangeAspect', '1');
         $objWriter->endElement();
 
@@ -1701,7 +1701,7 @@ class Slide extends AbstractPart
         $objWriter->startElement('p:nvPr');
 
         //p:ph
-        $objWriter->startElement('p:ph'); 
+        $objWriter->startElement('p:ph');
         $objWriter->writeAttribute('type', 'sldImg');
         $objWriter->endElement();
 
@@ -1736,7 +1736,7 @@ class Slide extends AbstractPart
 
         //a:prstGeom
         $objWriter->startElement('a:prstGeom');
-        $objWriter->writeAttribute('prst','rect');
+        $objWriter->writeAttribute('prst', 'rect');
 
         //a:avLst
         $objWriter->writeElement('a:avLst', null);
@@ -1749,21 +1749,21 @@ class Slide extends AbstractPart
 
         //a:ln
         $objWriter->startElement('a:ln');
-        $objWriter->writeAttribute('w','12700');
+        $objWriter->writeAttribute('w', '12700');
 
         //a:solidFill
         $objWriter->startElement('a:solidFill');
 
         //a:prstClr
         $objWriter->startElement('a:prstClr');
-        $objWriter->writeAttribute('val','black');
+        $objWriter->writeAttribute('val', 'black');
         $objWriter->endElement();
 
         //end a:solidFill
         $objWriter->endElement();
 
         //end a:ln
-        $objWriter->endElement(); 
+        $objWriter->endElement();
         
         //end p:spPr
         $objWriter->endElement();
@@ -1818,25 +1818,25 @@ class Slide extends AbstractPart
         
         //a:off
         $objWriter->startElement('a:off');
-        $objWriter->writeAttribute('x',CommonDrawing::pixelsToEmu($pNote->getOffsetX()));
-        $objWriter->writeAttribute('y',CommonDrawing::pixelsToEmu(ROUND($pNote->getExtentY()/2)));
-        $objWriter->endElement(); 
+        $objWriter->writeAttribute('x', CommonDrawing::pixelsToEmu($pNote->getOffsetX()));
+        $objWriter->writeAttribute('y', CommonDrawing::pixelsToEmu(ROUND($pNote->getExtentY()/2)));
+        $objWriter->endElement();
         
         //a:ext
         $objWriter->startElement('a:ext');
-        $objWriter->writeAttribute('cx','5486400');
-        $objWriter->writeAttribute('cy','3600450');
-        $objWriter->endElement(); 
+        $objWriter->writeAttribute('cx', '5486400');
+        $objWriter->writeAttribute('cy', '3600450');
+        $objWriter->endElement();
         
         //end a:xfrm
         $objWriter->endElement();
         
         //a:prstGeom
         $objWriter->startElement('a:prstGeom');
-        $objWriter->writeAttribute('prst','rect');
+        $objWriter->writeAttribute('prst', 'rect');
         
         //a:avLst
-        $objWriter->writeElement('a:avLst',null);
+        $objWriter->writeElement('a:avLst', null);
         
         //end a:prstGeom
         $objWriter->endElement();

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -217,276 +217,275 @@ class Slide extends AbstractPart
 
         if (!is_null($pSlide->getTransition())) {
             $this->writeTransition($objWriter, $pSlide->getTransition());
-		}
-		
-		//do animation writing 
-		$shapeId = 1;
+        }
+        
+        //do animation writing
+        $shapeId = 1;
         $shapes  = $pSlide->getShapeCollection();
-		
-		$animations = $pSlide->getAnimations();
+        
+        $animations = $pSlide->getAnimations();
 
-		if(count($animations) > 0){
-			
-			$hashToIdMap = ARRAY(); 
+        if (count($animations) > 0) {
+            
+            $hashToIdMap = array();
 
-			foreach($shapes as $shape){
-				$shapeId += 1; 
-				$hash = $shape->getHashCode();
-				$hashToIdMap[$hash] = $shapeId;
-			}
+            foreach ($shapes as $shape) {
+                $shapeId += 1;
+                $hash = $shape->getHashCode();
+                $hashToIdMap[$hash] = $shapeId;
+            }
 
-			$animationIds = ARRAY();
+            $animationIds = array();
 
-			foreach($animations as $animation){
-				$shapesInAnimation = $animation->getShapeCollection(); 
-				foreach($shapesInAnimation as $shape){
-					$hash = $shape->getHashCode();
-					$animationIds[] = $hashToIdMap[$hash];
-				}
-			}
+            foreach ($animations as $animation) {
+                $shapesInAnimation = $animation->getShapeCollection();
+                foreach ($shapesInAnimation as $shape) {
+                    $hash = $shape->getHashCode();
+                    $animationIds[] = $hashToIdMap[$hash];
+                }
+            }
 
+            $idCount = 1;
 
-			$idCount = 1;
+            $objWriter->startElement('p:timing');
 
-			$objWriter->startElement('p:timing');
+            $objWriter->startElement('p:tnLst');
 
-			$objWriter->startElement('p:tnLst');
+            $objWriter->startElement('p:par');
 
-			$objWriter->startElement('p:par');
+            $objWriter->startElement('p:cTn');
+            $objWriter->writeAttribute('id', $idCount);
+            $idCount += 1;
+            $objWriter->writeAttribute('dur', 'indefinite');
+            $objWriter->writeAttribute('restart', 'never');
+            $objWriter->writeAttribute('nodeType', 'tmRoot');
 
-			$objWriter->startElement('p:cTn');
-			$objWriter->writeAttribute('id',$idCount);
-			$idCount += 1;
-			$objWriter->writeAttribute('dur','indefinite');
-			$objWriter->writeAttribute('restart','never');
-			$objWriter->writeAttribute('nodeType','tmRoot');
+            $objWriter->startElement('p:childTnLst');
 
-			$objWriter->startElement('p:childTnLst');
+            $objWriter->startElement('p:seq');
+            $objWriter->writeAttribute('concurrent', '1');
+            $objWriter->writeAttribute('nextAc', 'seek');
 
-			$objWriter->startElement('p:seq');
-			$objWriter->writeAttribute('concurrent','1');
-			$objWriter->writeAttribute('nextAc','seek');
+            $objWriter->startElement('p:cTn'); 
+            $objWriter->writeAttribute('id', $idCount);
+            $idCount += 1;
+            $objWriter->writeAttribute('dur', 'indefinite');
+            $objWriter->writeAttribute('nodeType', 'mainSeq');
 
-			$objWriter->startElement('p:cTn'); 
-			$objWriter->writeAttribute('id',$idCount);
-			$idCount += 1;
-			$objWriter->writeAttribute('dur','indefinite');
-			$objWriter->writeAttribute('nodeType','mainSeq');
+            $objWriter->startElement("p:childTnLst");
 
-			$objWriter->startElement("p:childTnLst");
+            //each animation has multiple shapes
+            foreach($animations as $animation){
 
-			//each animation has multiple shapes
-			foreach($animations as $animation){
+                $objWriter->startElement("p:par");
 
-				$objWriter->startElement("p:par");
+                $objWriter->startElement("p:cTn");
+                $objWriter->writeAttribute("id", $idCount);
+                $idCount += 1;
+                $objWriter->writeAttribute("fill", "hold");
 
-				$objWriter->startElement("p:cTn");
-				$objWriter->writeAttribute("id",$idCount);
-				$idCount += 1;
-				$objWriter->writeAttribute("fill","hold");
+                $objWriter->startElement('p:stCondLst');
 
-				$objWriter->startElement('p:stCondLst');
+                $objWriter->startElement('p:cond');
+                $objWriter->writeAttribute("delay", "indefinite");
+                $objWriter->endElement();
 
-				$objWriter->startElement('p:cond');
-				$objWriter->writeAttribute("delay","indefinite");
-				$objWriter->endElement();
+                $objWriter->endElement();
 
-				$objWriter->endElement();
+                $objWriter->startElement("p:childTnLst");
 
-				$objWriter->startElement("p:childTnLst");
+                $objWriter->startElement("p:par");
 
-				$objWriter->startElement("p:par");
+                $objWriter->startElement("p:cTn");
+                $objWriter->writeAttribute("id", $idCount);
+                $idCount += 1;
+                $objWriter->writeAttribute("fill", "hold");
 
-				$objWriter->startElement("p:cTn");
-				$objWriter->writeAttribute("id",$idCount);
-				$idCount += 1;
-				$objWriter->writeAttribute("fill","hold");
+                $objWriter->startElement('p:stCondLst');
 
-				$objWriter->startElement('p:stCondLst');
+                $objWriter->startElement('p:cond');
+                $objWriter->writeAttribute("delay", "0");
+                $objWriter->endElement();
 
-				$objWriter->startElement('p:cond');
-				$objWriter->writeAttribute("delay","0");
-				$objWriter->endElement();
+                $objWriter->endElement();
 
-				$objWriter->endElement();
+                $objWriter->startElement("p:childTnLst");
 
-				$objWriter->startElement("p:childTnLst");
+                $shapesInAnimation = $animation->getShapeCollection();
 
-				$shapesInAnimation = $animation->getShapeCollection();
+                $firstShapeInAnimation = true;
 
-				$firstShapeInAnimation = true;		
-				
-				foreach($shapesInAnimation as $shape){
-					$hash = $shape->getHashCode();
-					$shapeId = $hashToIdMap[$hash]; 
+                foreach ($shapesInAnimation as $shape) {
+                    $hash = $shape->getHashCode();
+                    $shapeId = $hashToIdMap[$hash]; 
 
-					$objWriter->startElement("p:par");
+                    $objWriter->startElement("p:par");
 
-					$objWriter->startElement("p:cTn");
-					$objWriter->writeAttribute("id", $idCount); 
-					$idCount += 1;
-					$objWriter->writeAttribute("presetID", "1");			
-					$objWriter->writeAttribute("presetClass", "entr");
-					$objWriter->writeAttribute("fill", "hold");
-					$objWriter->writeAttribute("presetSubtype", "0");
-					$objWriter->writeAttribute("grpId", "0");
+                    $objWriter->startElement("p:cTn");
+                    $objWriter->writeAttribute("id", $idCount);
+                    $idCount += 1;
+                    $objWriter->writeAttribute("presetID", "1");
+                    $objWriter->writeAttribute("presetClass", "entr");
+                    $objWriter->writeAttribute("fill", "hold");
+                    $objWriter->writeAttribute("presetSubtype", "0");
+                    $objWriter->writeAttribute("grpId", "0");
 
-					$nodeType = $firstShapeInAnimation ? "clickEffect" : "withEffect";
+                    $nodeType = $firstShapeInAnimation ? "clickEffect" : "withEffect";
 
-					$objWriter->writeAttribute("nodeType",$nodeType);
+                    $objWriter->writeAttribute("nodeType", $nodeType);
 
-					$objWriter->startElement("p:stCondLst");
+                    $objWriter->startElement("p:stCondLst");
 
-					$objWriter->startElement("p:cond");
-					$objWriter->writeAttribute("delay","0");
-					$objWriter->endElement();
+                    $objWriter->startElement("p:cond");
+                    $objWriter->writeAttribute("delay", "0");
+                    $objWriter->endElement();
 
-					$objWriter->endElement(); 	
+                    $objWriter->endElement();
 
-					$objWriter->startElement("p:childTnLst");
+                    $objWriter->startElement("p:childTnLst");
 
-					$objWriter->startElement("p:set");
+                    $objWriter->startElement("p:set");
 
-					$objWriter->startElement("p:cBhvr");
+                    $objWriter->startElement("p:cBhvr");
 
-					$objWriter->startElement("p:cTn"); 
-					$objWriter->writeAttribute("id",$idCount);
-					$idCount +=  1;
-					$objWriter->writeAttribute("dur","1");
-					$objWriter->writeAttribute("fill","hold");
+                    $objWriter->startElement("p:cTn"); 
+                    $objWriter->writeAttribute("id", $idCount);
+                    $idCount +=  1;
+                    $objWriter->writeAttribute("dur", "1");
+                    $objWriter->writeAttribute("fill", "hold");
 
-					$objWriter->startElement("p:stCondLst");
-						
-					$objWriter->startElement("p:cond");
-					$objWriter->writeAttribute("delay","0");
-					$objWriter->endElement();
+                    $objWriter->startElement("p:stCondLst");
 
-					$objWriter->endElement(); 								
+                    $objWriter->startElement("p:cond");
+                    $objWriter->writeAttribute("delay", "0");
+                    $objWriter->endElement();
 
+                    $objWriter->endElement(); 
 
 
-					$objWriter->endElement();
 
-					$objWriter->startElement("p:tgtEl");
+                    $objWriter->endElement();
 
-					$objWriter->startElement("p:spTgt");
-					//shape id 
-					$objWriter->writeAttribute("spid",$shapeId);
-					$objWriter->endElement();
+                    $objWriter->startElement("p:tgtEl");
 
-					$objWriter->endElement();
+                    $objWriter->startElement("p:spTgt");
+                    //shape id 
+                    $objWriter->writeAttribute("spid", $shapeId);
+                    $objWriter->endElement();
 
-					$objWriter->startElement("p:attrNameLst");
+                    $objWriter->endElement();
 
-					$objWriter->writeElement("p:attrName","style.visibility");
+                    $objWriter->startElement("p:attrNameLst");
 
-					$objWriter->endElement();
+                    $objWriter->writeElement("p:attrName", "style.visibility");
 
-					$objWriter->endElement();
+                    $objWriter->endElement();
 
-					$objWriter->startElement("p:to");
+                    $objWriter->endElement();
 
-					$objWriter->startElement("p:strVal");
-					$objWriter->writeAttribute("val","visible");
-					$objWriter->endElement();
+                    $objWriter->startElement("p:to");
 
-					$objWriter->endElement();
+                    $objWriter->startElement("p:strVal");
+                    $objWriter->writeAttribute("val", "visible");
+                    $objWriter->endElement();
 
-					$objWriter->endElement();	
+                    $objWriter->endElement();
 
-					$objWriter->endElement(); //end child tn lst
+                    $objWriter->endElement();
 
-					$objWriter->endElement(); //end ctn
+                    $objWriter->endElement(); //end child tn lst
 
-					$objWriter->endElement();
+                    $objWriter->endElement(); //end ctn
 
-					$firstShapeInAnimation = false;		
-				}
+                    $objWriter->endElement();
 
+                    $firstShapeInAnimation = false;
+                }
 
-				$objWriter->endElement(); //end child lst 
 
-				$objWriter->endElement(); //end ctn	
+                $objWriter->endElement(); //end child lst 
 
-				$objWriter->endElement(); //end par 
+                $objWriter->endElement(); //end ctn	
 
+                $objWriter->endElement(); //end par 
 
-				$objWriter->endElement(); //end childtnlist
 
-				$objWriter->endElement(); //end ctn
+                $objWriter->endElement(); //end childtnlist
 
-				$objWriter->endElement(); //end par
+                $objWriter->endElement(); //end ctn
 
-			}
+                $objWriter->endElement(); //end par
 
+            }
 
-			$objWriter->endElement();
 
-			$objWriter->endElement();
+            $objWriter->endElement();
 
-			///prevCondLst
-			$objWriter->startElement("p:prevCondLst");
+            $objWriter->endElement();
 
-			$objWriter->startElement('p:cond');
-			$objWriter->writeAttribute('evt','onPrev');
-			$objWriter->writeAttribute('delay','0');
+           ///prevCondLst
+            $objWriter->startElement("p:prevCondLst");
 
-			$objWriter->startElement('p:tgtEl');
+            $objWriter->startElement('p:cond');
+            $objWriter->writeAttribute('evt', 'onPrev');
+            $objWriter->writeAttribute('delay', '0');
 
-			$objWriter->writeElement('p:sldTgt', null);
+            $objWriter->startElement('p:tgtEl');
 
-			$objWriter->endElement();
+            $objWriter->writeElement('p:sldTgt', null);
 
-			$objWriter->endElement();
+            $objWriter->endElement();
 
-			$objWriter->endElement();
+            $objWriter->endElement();
 
-			//nextCondLst
-			$objWriter->startElement("p:nextCondLst");
+            $objWriter->endElement();
 
-			$objWriter->startElement('p:cond');
-			$objWriter->writeAttribute('evt','onNext');
-			$objWriter->writeAttribute('delay','0');
+            //nextCondLst
+            $objWriter->startElement("p:nextCondLst");
 
-			$objWriter->startElement('p:tgtEl');
+            $objWriter->startElement('p:cond');
+            $objWriter->writeAttribute('evt', 'onNext');
+            $objWriter->writeAttribute('delay', '0');
 
-			$objWriter->writeElement('p:sldTgt', null);
+            $objWriter->startElement('p:tgtEl');
 
-			$objWriter->endElement();
+            $objWriter->writeElement('p:sldTgt', null);
 
-			$objWriter->endElement();
+            $objWriter->endElement();
 
-			$objWriter->endElement();
+            $objWriter->endElement();
 
-			$objWriter->endElement(); //end p:seq
+            $objWriter->endElement();
 
-			$objWriter->endElement(); //end p:childTnLst
+            $objWriter->endElement(); //end p:seq
 
-			$objWriter->endElement();  //end ctn
+            $objWriter->endElement(); //end p:childTnLst
 
-			$objWriter->endElement(); //end par
+            $objWriter->endElement();  //end ctn
 
-			$objWriter->endElement(); //	end tnLst
+            $objWriter->endElement(); //end par
 
-			$objWriter->startElement('p:bldLst');
+            $objWriter->endElement(); //end tnLst
 
-			//add in ids of all shapes in this slides animations
+            $objWriter->startElement('p:bldLst');
 
-			foreach($animationIds as $id){
-				$objWriter->startElement('p:bldP');
-				$objWriter->writeAttribute("spid",$id);
-				$objWriter->writeAttribute('grpId',0);
-				$objWriter->endELement();	
-			}
+            //add in ids of all shapes in this slides animations
 
+            foreach ($animationIds as $id) {
+                $objWriter->startElement('p:bldP');
+                $objWriter->writeAttribute("spid", $id);
+                $objWriter->writeAttribute('grpId', 0);
+                $objWriter->endELement();
+            }
 
-			$objWriter->endElement(); // end bldLst
 
-			$objWriter->endElement(); //end timing	
+            $objWriter->endElement(); // end bldLst
 
-			$objWriter->endElement();
-		}		
-		
+            $objWriter->endElement(); //end timing	
+
+            $objWriter->endElement();
+        }
+        
 
         $objWriter->endElement();
 


### PR DESCRIPTION
Added animation class, added animation tags to Powerpoint2007 Slide Writer, added animation objects to Slide.php

This only supports appear. Shapes can be grouped to appear together or sequentially by order they're added as animations. 

Use:

```
$animation = new Animation(); //create the animation
$currentSlide = $this->pp->getActiveSlide();  //get the current slide
$currentSlide->addAnimation($animation); //add the animation to the current slide
/*
* add n shapes to animation
* every shape in an animation will appear at the same time on click
*/
$animation->addShape($shape); 
$animation->addShape($shape2); 
```


