### PR TITLE
Added language property to TextElement

### DIFF
--- a/src/PhpPresentation/Shape/RichText/BreakElement.php
+++ b/src/PhpPresentation/Shape/RichText/BreakElement.php
@@ -69,4 +69,25 @@ class BreakElement implements TextElementInterface
     {
         return md5(__CLASS__);
     }
+
+    /**
+     * Set language
+     *
+     * @param $lang
+     * @return \PhpOffice\PhpPresentation\Shape\RichText\TextElementInterface
+     */
+    public function setLanguage($lang)
+    {
+        return $this;
+    }
+
+    /**
+     * Get language
+     *
+     * @return string Language
+     */
+    public function getLanguage()
+    {
+        return null;
+    }
 }

--- a/src/PhpPresentation/Shape/RichText/TextElement.php
+++ b/src/PhpPresentation/Shape/RichText/TextElement.php
@@ -32,6 +32,11 @@ class TextElement implements TextElementInterface
     private $text;
 
     /**
+     * @var string
+     */
+    private $language;
+
+    /**
      * Hyperlink
      *
      * @var \PhpOffice\PhpPresentation\Shape\Hyperlink
@@ -128,5 +133,28 @@ class TextElement implements TextElementInterface
     public function getHashCode()
     {
         return md5($this->text . (is_null($this->hyperlink) ? '' : $this->hyperlink->getHashCode()) . __CLASS__);
+    }
+
+    /**
+     * Set language
+     *
+     * @param $lang
+     * @return \PhpOffice\PhpPresentation\Shape\RichText\TextElementInterface
+     */
+    public function setLanguage($lang)
+    {
+        $this->language = $lang;
+
+        return $this;
+    }
+
+    /**
+     * Get language
+     *
+     * @return string Language
+     */
+    public function getLanguage()
+    {
+        return $this->language;
     }
 }

--- a/src/PhpPresentation/Shape/RichText/TextElementInterface.php
+++ b/src/PhpPresentation/Shape/RichText/TextElementInterface.php
@@ -38,6 +38,21 @@ interface TextElementInterface
     public function setText($pText = '');
 
     /**
+     * Set language
+     *
+     * @param $lang
+     * @return \PhpOffice\PhpPresentation\Shape\RichText\TextElementInterface
+     */
+    public function setLanguage($lang);
+
+    /**
+     * Get language
+     *
+     * @return string Language
+     */
+    public function getLanguage();
+
+    /**
      * Get font
      *
      * @return \PhpOffice\PhpPresentation\Style\Font

--- a/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Slide.php
@@ -906,6 +906,9 @@ class Slide extends AbstractPart
                         // a:rPr
                         $objWriter->startElement('a:rPr');
 
+                        // Lang
+                        $objWriter->writeAttribute('lang', ($element->getLanguage() ?: 'en-US'));
+
                         // Bold
                         $objWriter->writeAttribute('b', ($element->getFont()->isBold() ? '1' : '0'));
 

--- a/tests/PhpPresentation/Tests/Shape/RichText/BreakElementTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/BreakElementTest.php
@@ -57,6 +57,7 @@ class BreakElementTest extends \PHPUnit_Framework_TestCase
     public function testLanguage()
     {
         $object = new BreakElement();
+        $this->assertNull($object->getLanguage());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\BreakElement', $object->setLanguage('en-US'));
         $this->assertNull($object->getLanguage());
     }

--- a/tests/PhpPresentation/Tests/Shape/RichText/BreakElementTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/BreakElementTest.php
@@ -53,4 +53,11 @@ class BreakElementTest extends \PHPUnit_Framework_TestCase
         $object = new BreakElement();
         $this->assertEquals(md5(get_class($object)), $object->getHashCode());
     }
+
+    public function testLanguage()
+    {
+        $object = new BreakElement();
+        $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\BreakElement', $object->setLanguage('en-US'));
+        $this->assertNull($object->getLanguage());
+    }
 }

--- a/tests/PhpPresentation/Tests/Shape/RichText/RunTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/RunTest.php
@@ -69,4 +69,11 @@ class RunTest extends \PHPUnit_Framework_TestCase
         $object = new Run();
         $this->assertEquals(md5($object->getFont()->getHashCode().get_class($object)), $object->getHashCode());
     }
+
+    public function testLanguage()
+    {
+        $object = new Run();
+        $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\Run', $object->setLanguage('en-US'));
+        $this->assertEquals('en-US', $object->getLanguage());
+    }
 }

--- a/tests/PhpPresentation/Tests/Shape/RichText/RunTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/RunTest.php
@@ -73,6 +73,7 @@ class RunTest extends \PHPUnit_Framework_TestCase
     public function testLanguage()
     {
         $object = new Run();
+        $this->assertNull($object->getLanguage());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\Run', $object->setLanguage('en-US'));
         $this->assertEquals('en-US', $object->getLanguage());
     }

--- a/tests/PhpPresentation/Tests/Shape/RichText/TextElementTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/TextElementTest.php
@@ -19,6 +19,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\RichText;
 
 use PhpOffice\PhpPresentation\Shape\Hyperlink;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
+use SebastianBergmann\PHPLOC\Log\Text;
 
 /**
  * Test class for TextElement element
@@ -75,5 +76,12 @@ class TextElementTest extends \PHPUnit_Framework_TestCase
     {
         $object = new TextElement();
         $this->assertEquals(md5(get_class($object)), $object->getHashCode());
+    }
+
+    public function testLanguage()
+    {
+        $object = new TextElement();
+        $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\TextElement', $object->setLanguage('en-US'));
+        $this->assertEquals('en-US', $object->getLanguage());
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/RichText/TextElementTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/TextElementTest.php
@@ -19,7 +19,6 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\RichText;
 
 use PhpOffice\PhpPresentation\Shape\Hyperlink;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
-use SebastianBergmann\PHPLOC\Log\Text;
 
 /**
  * Test class for TextElement element
@@ -81,6 +80,7 @@ class TextElementTest extends \PHPUnit_Framework_TestCase
     public function testLanguage()
     {
         $object = new TextElement();
+        $this->assertNull($object->getLanguage());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\TextElement', $object->setLanguage('en-US'));
         $this->assertEquals('en-US', $object->getLanguage());
     }


### PR DESCRIPTION
This pull request provides a language property to `TextElement`. It allows you to set the correct language of text and spell-checking will work properly. Language should be provided as *Language Culture Name* https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx

e.g.

```php
$line = "Tekst w języku polskim.";
$lineText = $paragraph->createTextRun($line)->setLanguage('pl-PL');
```

Kind Regards,
Szymon