### PR TITLE
Allow setting top and bottom margins, write table margins in PPTX writer

### DIFF
--- a/src/PhpPresentation/Style/Alignment.php
+++ b/src/PhpPresentation/Style/Alignment.php
@@ -88,6 +88,20 @@ class Alignment implements ComparableInterface
     private $marginRight = 0;
 
     /**
+     * Margin top
+     *
+     * @var int
+     */
+    private $marginTop = 0;
+
+    /**
+     * Margin bottom
+     *
+     * @var int
+     */
+    private $marginBottom = 0;
+
+    /**
      * Hash index
      *
      * @var string
@@ -260,6 +274,52 @@ class Alignment implements ComparableInterface
         }
 
         $this->marginRight = $pValue;
+
+        return $this;
+    }
+
+    /**
+     * Get margin top
+     *
+     * @return int
+     */
+    public function getMarginTop()
+    {
+        return $this->marginTop;
+    }
+
+    /**
+     * Set margin top
+     *
+     * @param  int                           $pValue
+     * @return \PhpOffice\PhpPresentation\Style\Alignment
+     */
+    public function setMarginTop($pValue = 0)
+    {
+        $this->marginTop = $pValue;
+
+        return $this;
+    }
+
+    /**
+     * Get margin bottom
+     *
+     * @return int
+     */
+    public function getMarginBottom()
+    {
+        return $this->marginBottom;
+    }
+
+    /**
+     * Set margin bottom
+     *
+     * @param  int                           $pValue
+     * @return \PhpOffice\PhpPresentation\Style\Alignment
+     */
+    public function setMarginBottom($pValue = 0)
+    {
+        $this->marginBottom = $pValue;
 
         return $this;
     }

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
@@ -1352,6 +1352,13 @@ class PptSlides extends AbstractSlide
                     $objWriter->writeAttribute('anchor', $verticalAlign);
                 }
 
+                // Margins
+                $alignment = $firstParagraph->getAlignment();
+                $objWriter->writeAttribute('marL', $alignment->getMarginLeft());
+                $objWriter->writeAttribute('marR', $alignment->getMarginRight());
+                $objWriter->writeAttribute('marT', $alignment->getMarginTop());
+                $objWriter->writeAttribute('marB', $alignment->getMarginBottom());
+
                 // Determine borders
                 $borderLeft         = $currentCell->getBorders()->getLeft();
                 $borderRight        = $currentCell->getBorders()->getRight();
@@ -1485,7 +1492,7 @@ class PptSlides extends AbstractSlide
 
                         // Size
                         $objWriter->writeAttribute('sz', ($element->getFont()->getSize() * 100));
-                        
+
                         // Character spacing
                         $objWriter->writeAttribute('spc', $element->getFont()->getCharacterSpacing());
 


### PR DESCRIPTION
This PR allows setting bottom and top margins, and propagates those margins (as well as left and right) when serializing table objects.

I think this would cover what is requested in #273.