### PR TITLE
Bugfixes for masterslide issues: issue #330, problems with broken powerpoints needing repair, missing images in shapes

### DIFF
--- a/src/PhpPresentation/Writer/AbstractWriter.php
+++ b/src/PhpPresentation/Writer/AbstractWriter.php
@@ -96,11 +96,12 @@ abstract class AbstractWriter
         // Get an array of all drawings
         $aDrawings  = array();
 
-        // Loop trough PhpPresentation
-        foreach ($this->getPhpPresentation()->getAllSlides() as $oSlide) {
+        // Loop through PhpPresentation
+        foreach (array_merge($this->getPhpPresentation()->getAllSlides(), $this->getPhpPresentation()->getAllMasterSlides()) as $oSlide) {
             $arrayReturn = $this->iterateCollection($oSlide->getShapeCollection()->getIterator());
             $aDrawings = array_merge($aDrawings, $arrayReturn);
         }
+
         return $aDrawings;
     }
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -108,6 +108,8 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
                 $iterator->next();
             }
         }
+
+        return $relId;
     }
 
     /**

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
@@ -70,12 +70,14 @@ class PptSlideMasters extends AbstractSlide
         if ($oBackground instanceof Image) {
             $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', '../media/' . $oBackground->getIndexedFilename($oMasterSlide->getRelsIndex()));
             $oBackground->relationId = 'rId' . $relId;
+
+            $relId++;
         }
 
         // TODO: Write hyperlink relationships?
         // TODO: Write comment relationships
         // Relationship theme/theme1.xml
-        $this->writeRelationship($objWriter, ++$relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', '../theme/theme' . $oMasterSlide->getRelsIndex() . '.xml');
+        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', '../theme/theme' . $oMasterSlide->getRelsIndex() . '.xml');
         $objWriter->endElement();
         // Return
         return $objWriter->getData();

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
@@ -54,12 +54,14 @@ class PptSlideMasters extends AbstractSlide
             // Save the used relationId
             $slideLayout->relationId = 'rId' . $relId;
         }
+
         // Write drawing relationships?
-        $this->writeDrawingRelations($oMasterSlide, $objWriter, ++$relId);
+        $relId = $this->writeDrawingRelations($oMasterSlide, $objWriter, ++$relId);
+
         // TODO: Write hyperlink relationships?
         // TODO: Write comment relationships
         // Relationship theme/theme1.xml
-        $this->writeRelationship($objWriter, ++$relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', '../theme/theme' . $oMasterSlide->getRelsIndex() . '.xml');
+        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', '../theme/theme' . $oMasterSlide->getRelsIndex() . '.xml');
         $objWriter->endElement();
         // Return
         return $objWriter->getData();

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
@@ -11,7 +11,6 @@ use PhpOffice\PhpPresentation\Shape\Table as ShapeTable;
 use PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
-use PhpOffice\PhpPresentation\Slide\Background\Image;
 
 class PptSlideMasters extends AbstractSlide
 {
@@ -25,13 +24,6 @@ class PptSlideMasters extends AbstractSlide
             $this->oZip->addFromString('ppt/slideMasters/_rels/slideMaster' . $oMasterSlide->getRelsIndex() . '.xml.rels', $this->writeSlideMasterRelationships($oMasterSlide));
             // Add the information from the masterSlide to the ZIP file
             $this->oZip->addFromString('ppt/slideMasters/slideMaster' . $oMasterSlide->getRelsIndex() . '.xml', $this->writeSlideMaster($oMasterSlide));
-
-            // Add background image slide
-            $oBkgImage = $oMasterSlide->getBackground();
-            if ($oBkgImage instanceof Image) {
-                $this->oZip->addFromString('ppt/media/' . $oBkgImage->getIndexedFilename($oMasterSlide->getRelsIndex()), file_get_contents($oBkgImage->getPath()));
-            }
-
         }
 
         return $this->oZip;
@@ -65,13 +57,6 @@ class PptSlideMasters extends AbstractSlide
 
         // Write drawing relationships?
         $relId = $this->writeDrawingRelations($oMasterSlide, $objWriter, ++$relId);
-
-        // Write background relationships?
-        $oBackground = $oMasterSlide->getBackground();
-        if ($oBackground instanceof Image) {
-            $this->writeRelationship($objWriter, ++$relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', '../media/' . $oBackground->getIndexedFilename($oMasterSlide->getRelsIndex()));
-            $oBackground->relationId = 'rId' . $relId;
-        }
 
         // TODO: Write hyperlink relationships?
         // TODO: Write comment relationships

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpPresentation\Shape\Table as ShapeTable;
 use PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
+use PhpOffice\PhpPresentation\Slide\Background\Image;
 
 class PptSlideMasters extends AbstractSlide
 {
@@ -24,6 +25,13 @@ class PptSlideMasters extends AbstractSlide
             $this->oZip->addFromString('ppt/slideMasters/_rels/slideMaster' . $oMasterSlide->getRelsIndex() . '.xml.rels', $this->writeSlideMasterRelationships($oMasterSlide));
             // Add the information from the masterSlide to the ZIP file
             $this->oZip->addFromString('ppt/slideMasters/slideMaster' . $oMasterSlide->getRelsIndex() . '.xml', $this->writeSlideMaster($oMasterSlide));
+
+            // Add background image slide
+            $oBkgImage = $oMasterSlide->getBackground();
+            if ($oBkgImage instanceof Image) {
+                $this->oZip->addFromString('ppt/media/' . $oBkgImage->getIndexedFilename($oMasterSlide->getRelsIndex()), file_get_contents($oBkgImage->getPath()));
+            }
+
         }
 
         return $this->oZip;
@@ -57,6 +65,13 @@ class PptSlideMasters extends AbstractSlide
 
         // Write drawing relationships?
         $relId = $this->writeDrawingRelations($oMasterSlide, $objWriter, ++$relId);
+
+        // Write background relationships?
+        $oBackground = $oMasterSlide->getBackground();
+        if ($oBackground instanceof Image) {
+            $this->writeRelationship($objWriter, ++$relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', '../media/' . $oBackground->getIndexedFilename($oMasterSlide->getRelsIndex()));
+            $oBackground->relationId = 'rId' . $relId;
+        }
 
         // TODO: Write hyperlink relationships?
         // TODO: Write comment relationships

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
@@ -55,7 +55,7 @@ class PptSlideMasters extends AbstractSlide
             $slideLayout->relationId = 'rId' . $relId;
         }
         // Write drawing relationships?
-        $this->writeDrawingRelations($oMasterSlide, $objWriter, $relId);
+        $this->writeDrawingRelations($oMasterSlide, $objWriter, ++$relId);
         // TODO: Write hyperlink relationships?
         // TODO: Write comment relationships
         // Relationship theme/theme1.xml

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlideMasters.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpPresentation\Shape\Table as ShapeTable;
 use PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
+use PhpOffice\PhpPresentation\Slide\Background\Image;
 
 class PptSlideMasters extends AbstractSlide
 {
@@ -24,6 +25,12 @@ class PptSlideMasters extends AbstractSlide
             $this->oZip->addFromString('ppt/slideMasters/_rels/slideMaster' . $oMasterSlide->getRelsIndex() . '.xml.rels', $this->writeSlideMasterRelationships($oMasterSlide));
             // Add the information from the masterSlide to the ZIP file
             $this->oZip->addFromString('ppt/slideMasters/slideMaster' . $oMasterSlide->getRelsIndex() . '.xml', $this->writeSlideMaster($oMasterSlide));
+
+            // Add background image slide
+            $oBkgImage = $oMasterSlide->getBackground();
+            if ($oBkgImage instanceof Image) {
+                $this->oZip->addFromString('ppt/media/' . $oBkgImage->getIndexedFilename($oMasterSlide->getRelsIndex()), file_get_contents($oBkgImage->getPath()));
+            }
         }
 
         return $this->oZip;
@@ -58,10 +65,17 @@ class PptSlideMasters extends AbstractSlide
         // Write drawing relationships?
         $relId = $this->writeDrawingRelations($oMasterSlide, $objWriter, ++$relId);
 
+        // Write background relationships?
+        $oBackground = $oMasterSlide->getBackground();
+        if ($oBackground instanceof Image) {
+            $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', '../media/' . $oBackground->getIndexedFilename($oMasterSlide->getRelsIndex()));
+            $oBackground->relationId = 'rId' . $relId;
+        }
+
         // TODO: Write hyperlink relationships?
         // TODO: Write comment relationships
         // Relationship theme/theme1.xml
-        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', '../theme/theme' . $oMasterSlide->getRelsIndex() . '.xml');
+        $this->writeRelationship($objWriter, ++$relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme', '../theme/theme' . $oMasterSlide->getRelsIndex() . '.xml');
         $objWriter->endElement();
         // Return
         return $objWriter->getData();

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriter.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriter.php
@@ -16,6 +16,7 @@
  */
 
 namespace PhpOffice\PhpPresentation\Tests\Writer;
+
 use PhpOffice\PhpPresentation\Writer;
 
 /**

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriter.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriter.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @copyright   2009-2017 PHPPresentation contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ * @link        https://github.com/PHPOffice/PHPPresentation
+ */
+
+namespace PhpOffice\PhpPresentation\Tests\Writer;
+use PhpOffice\PhpPresentation\Writer;
+
+/**
+ * Mock class for AbstractWriter
+ *
+ */
+class AbstractWriter extends Writer\AbstractWriter
+{
+    /**
+     * public wrapper for protected method
+     *
+     * @return \PhpOffice\PhpPresentation\Shape\AbstractDrawing[] All drawings in PhpPresentation
+     * @throws \Exception
+     */
+    public function allDrawings()
+    {
+        return parent::allDrawings();
+    }
+}

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
@@ -51,7 +51,8 @@ class AbstractWriterTest extends \PHPUnit_Framework_TestCase
         $activeSlide = $presentation->getActiveSlide();
         $activeSlide->createDrawingShape();
 
-        $masterSlide = $presentation->getAllMasterSlides()[0];
+        $masterSlides = $presentation->getAllMasterSlides();
+        $masterSlide = $masterSlides[0];
         $masterSlide->createDrawingShape();
 
         $writer = $this->getMockForAbstractClass('PhpOffice\\PhpPresentation\\Tests\\Writer\\AbstractWriter');

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
@@ -16,6 +16,7 @@
  */
 
 namespace PhpOffice\PhpPresentation\Tests\Writer;
+
 use PhpOffice\PhpPresentation\PhpPresentation;
 
 require 'AbstractWriter.php';
@@ -43,7 +44,7 @@ class AbstractWriterTest extends \PHPUnit_Framework_TestCase
     /**
      * Test all drawings method
      */
-    public function testAllDrawings_includesMasterSlides()
+    public function testAllDrawingsIncludesMasterSlides()
     {
         $presentation = new PhpPresentation();
 

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
@@ -16,6 +16,9 @@
  */
 
 namespace PhpOffice\PhpPresentation\Tests\Writer;
+use PhpOffice\PhpPresentation\PhpPresentation;
+
+require 'AbstractWriter.php';
 
 /**
  * Test class for AbstractWriter
@@ -35,5 +38,25 @@ class AbstractWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($oStubWriter->getZipAdapter());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Writer\\AbstractWriter', $oStubWriter->setZipAdapter($oStubZip));
         $this->assertInstanceOf('PhpOffice\\Common\\Adapter\\Zip\\ZipInterface', $oStubWriter->getZipAdapter());
+    }
+
+    /**
+     * Test all drawings method
+     */
+    public function testAllDrawings_includesMasterSlides()
+    {
+        $presentation = new PhpPresentation();
+
+        $activeSlide = $presentation->getActiveSlide();
+        $activeSlide->createDrawingShape();
+
+        $masterSlide = $presentation->getAllMasterSlides()[0];
+        $masterSlide->createDrawingShape();
+
+        $writer = $this->getMockForAbstractClass('PhpOffice\\PhpPresentation\\Tests\\Writer\\AbstractWriter');
+        $writer->setPhpPresentation($presentation);
+
+        $drawings = $writer->allDrawings();
+        $this->assertEquals(2, count($drawings), 'Number of drawings should equal two: one from normal slide and one from master slide');
     }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
@@ -4,6 +4,7 @@ namespace PhpPresentation\Tests\Writer\PowerPoint2007;
 
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007\PptSlideMasters;
 use PhpOffice\PhpPresentation\Slide\SlideLayout;
+use PhpOffice\PhpPresentation\Shape\Drawing\File as ShapeDrawingFile;
 
 /**
  * Test class for PowerPoint2007
@@ -25,10 +26,30 @@ class PptSlideMastersTest extends \PHPUnit_Framework_TestCase
             ->method('getAllSlideLayouts')
             ->will($this->returnValue($layouts));
 
+        $collection = new \ArrayObject();
+        $collection[] = new ShapeDrawingFile();
+        $collection[] = new ShapeDrawingFile();
+        $collection[] = new ShapeDrawingFile();
+
         $slideMaster->expects($this->exactly(2))
             ->method('getShapeCollection')
-            ->will($this->returnValue(new \ArrayObject()));
+            ->will($this->returnValue($collection));
 
         $data = $writer->writeSlideMasterRelationships($slideMaster);
+
+        $dom = new \DomDocument();
+        $dom->loadXml($data);
+
+        $xpath = new \DomXpath($dom);
+        $xpath->registerNamespace('r', 'http://schemas.openxmlformats.org/package/2006/relationships');
+        $list = $xpath->query('//r:Relationship');
+
+        $this->assertEquals(5, $list->length);
+
+        $this->assertEquals('rId1', $list->item(0)->getAttribute('Id'));
+        $this->assertEquals('rId2', $list->item(1)->getAttribute('Id'));
+        $this->assertEquals('rId3', $list->item(2)->getAttribute('Id'));
+        $this->assertEquals('rId4', $list->item(3)->getAttribute('Id'));
+        $this->assertEquals('rId5', $list->item(4)->getAttribute('Id'));
     }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpPresentation\Tests\Writer\PowerPoint2007;
+
+use PhpOffice\PhpPresentation\Writer\PowerPoint2007\PptSlideMasters;
+use PhpOffice\PhpPresentation\Slide\SlideLayout;
+
+/**
+ * Test class for PowerPoint2007
+ *
+ * @coversDefaultClass PowerPoint2007
+ */
+class PptSlideMastersTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWriteSlideMasterRelationships()
+    {
+        $writer = new PptSlideMasters();
+        $slideMaster = $this->getMockBuilder('PhpOffice\\PhpPresentation\\Slide\\SlideMaster')
+            ->setMethods(['getAllSlideLayouts', 'getRelsIndex', 'getShapeCollection'])
+            ->getMock();
+
+        $layouts = [new SlideLayout($slideMaster)];
+
+        $slideMaster->expects($this->once())
+            ->method('getAllSlideLayouts')
+            ->will($this->returnValue($layouts));
+
+        $slideMaster->expects($this->exactly(2))
+            ->method('getShapeCollection')
+            ->will($this->returnValue(new \ArrayObject()));
+
+        $data = $writer->writeSlideMasterRelationships($slideMaster);
+    }
+}

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
@@ -17,10 +17,10 @@ class PptSlideMastersTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new PptSlideMasters();
         $slideMaster = $this->getMockBuilder('PhpOffice\\PhpPresentation\\Slide\\SlideMaster')
-            ->setMethods(['getAllSlideLayouts', 'getRelsIndex', 'getShapeCollection'])
+            ->setMethods(array('getAllSlideLayouts', 'getRelsIndex', 'getShapeCollection'))
             ->getMock();
 
-        $layouts = [new SlideLayout($slideMaster)];
+        $layouts = array(new SlideLayout($slideMaster));
 
         $slideMaster->expects($this->once())
             ->method('getAllSlideLayouts')


### PR DESCRIPTION
Fixes bugs in saving master slides:
- draw shapes are not included in data written, because only shapes from regular slides are iterated over
- IDs used in relationship files linking powerpoint master slides to media are doubles - which leads to "broken" images when opening powerpoint files and PowerPoint 2010+ trying to repair the files
- background images in masterslides are neither written nor linked