### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Branch Master : [![Build Status](https://travis-ci.org/PHPOffice/PHPPresentation.svg?branch=master)](https://travis-ci.org/PHPOffice/PHPPresentation) [![Documentation Status](https://readthedocs.org/projects/phppresentation/badge/?version=master)](http://phppresentation.readthedocs.io/en/latest/?badge=master)  
 Branch Develop : [![Build Status](https://travis-ci.org/PHPOffice/PHPPresentation.svg?branch=develop)](https://travis-ci.org/PHPOffice/PHPPresentation) [![Documentation Status](https://readthedocs.org/projects/phppresentation/badge/?version=develop)](http://phppresentation.readthedocs.io/en/latest/?badge=develop)
 
-PHPPresentation is a library written in pure PHP that provides a set of classes to write to different presentation file formats, i.e. Microsoft [Office Open XML](http://en.wikipedia.org/wiki/Office_Open_XML) (OOXML or OpenXML) or OASIS [Open Document Format for Office Applications](http://en.wikipedia.org/wiki/OpenDocument) (OpenDocument or ODF). 
+PHPPresentation is a library written in pure PHP that provides a set of classes to write to different presentation file formats, i.e. Microsoft [Office Open XML](http://en.wikipedia.org/wiki/Office_Open_XML) (OOXML or OpenXML) or OASIS [Open Document Format for Office Applications](http://en.wikipedia.org/wiki/OpenDocument) (OpenDocument or ODF).
 
 PHPPresentation is an open source project licensed under the terms of [LGPL version 3](https://github.com/PHPOffice/PHPPresentation/blob/develop/COPYING.LESSER). PHPPresentation is aimed to be a high quality software product by incorporating [continuous integration](https://travis-ci.org/PHPOffice/PHPPresentation) and [unit testing](http://phpoffice.github.io/PHPPresentation/coverage/develop/). You can learn more about PHPPresentation by reading the [Developers' Documentation](http://phppresentation.readthedocs.org/) and the [API Documentation](http://phpoffice.github.io/PHPPresentation/docs/develop/).
 
@@ -76,7 +76,7 @@ require_once 'path/to/PhpPresentation/src/PhpPresentation/Autoloader.php';
 ```
 
 You will also need to download the latest PHPOffice/Common release from its [releases page](https://github.com/PHPOffice/Common/releases).  
-And you will also have to register its autoloader, too. 
+And you will also have to register its autoloader, too.
 
 ```php
 require_once 'path/to/PhpOffice/Common/src/Common/Autoloader.php';
@@ -130,7 +130,7 @@ $textRun = $shape->createTextRun('Thank you for using PHPPresentation!');
 $textRun->getFont()->setBold(true)
                    ->setSize(60)
                    ->setColor( new Color( 'FFE06B20' ) );
-                   
+
 $oWriterPPTX = IOFactory::createWriter($objPHPPowerPoint, 'PowerPoint2007');
 $oWriterPPTX->save(__DIR__ . "/sample.pptx");
 $oWriterODP = IOFactory::createWriter($objPHPPowerPoint, 'ODPresentation');

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpoffice/common": "0.2.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "~4.8.36",
         "phpdocumentor/phpdocumentor":"2.*",
         "phpmd/phpmd": "2.*",
         "sebastian/phpcpd": "2.*",

--- a/tests/PhpPresentation/Tests/AbstractShapeTest.php
+++ b/tests/PhpPresentation/Tests/AbstractShapeTest.php
@@ -24,11 +24,12 @@ use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Style\Border;
 use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Shadow;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Autoloader
  */
-class AbstractShapeTest extends \PHPUnit_Framework_TestCase
+class AbstractShapeTest extends TestCase
 {
     /**
      * Register

--- a/tests/PhpPresentation/Tests/AutoloaderTest.php
+++ b/tests/PhpPresentation/Tests/AutoloaderTest.php
@@ -18,11 +18,12 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\Autoloader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Autoloader
  */
-class AutoloaderTest extends \PHPUnit_Framework_TestCase
+class AutoloaderTest extends TestCase
 {
     /**
      * Register

--- a/tests/PhpPresentation/Tests/DocumentLayoutTest.php
+++ b/tests/PhpPresentation/Tests/DocumentLayoutTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\DocumentLayout;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for DocumentLayout
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\DocumentLayout
  */
-class DocumentLayoutTest extends \PHPUnit_Framework_TestCase
+class DocumentLayoutTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/DocumentPropertiesTest.php
+++ b/tests/PhpPresentation/Tests/DocumentPropertiesTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\DocumentProperties;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for DocumentProperties
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\DocumentProperties
  */
-class DocumentPropertiesTest extends \PHPUnit_Framework_TestCase
+class DocumentPropertiesTest extends TestCase
 {
     /**
      * Test get set value

--- a/tests/PhpPresentation/Tests/HashTableTest.php
+++ b/tests/PhpPresentation/Tests/HashTableTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\HashTable;
 use PhpOffice\PhpPresentation\Slide;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for HashTable
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\HashTable
  */
-class HashTableTest extends \PHPUnit_Framework_TestCase
+class HashTableTest extends TestCase
 {
     /**
      */

--- a/tests/PhpPresentation/Tests/IOFactoryTest.php
+++ b/tests/PhpPresentation/Tests/IOFactoryTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\IOFactory;
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for IOFactory
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\IOFactory
  */
-class IOFactoryTest extends \PHPUnit_Framework_TestCase
+class IOFactoryTest extends TestCase
 {
     /**
      * Test create writer

--- a/tests/PhpPresentation/Tests/PhpPresentationTest.php
+++ b/tests/PhpPresentation/Tests/PhpPresentationTest.php
@@ -21,13 +21,14 @@ use PhpOffice\PhpPresentation\DocumentLayout;
 use PhpOffice\PhpPresentation\DocumentProperties;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\PresentationProperties;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class PhpPresentationTest extends \PHPUnit_Framework_TestCase
+class PhpPresentationTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/PresentationPropertiesTest.php
+++ b/tests/PhpPresentation/Tests/PresentationPropertiesTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\PresentationProperties;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for DocumentProperties
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PresentationProperties
  */
-class PresentationPropertiesTest extends \PHPUnit_Framework_TestCase
+class PresentationPropertiesTest extends TestCase
 {
     public function testCommentVisible()
     {

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -20,13 +20,14 @@ namespace PhpOffice\PhpPresentation\Tests\Reader;
 use PhpOffice\PhpPresentation\Reader\ODPresentation;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for ODPresentation reader
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Reader\ODPresentation
  */
-class ODPresentationTest extends \PHPUnit_Framework_TestCase
+class ODPresentationTest extends TestCase
 {
     /**
      * Test can read
@@ -34,20 +35,20 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
     public function testCanRead()
     {
         $object = new ODPresentation();
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_01.ppt';
         $this->assertFalse($object->canRead($file));
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/serialized.phppt';
         $this->assertFalse($object->canRead($file));
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_12.pptx';
         $this->assertFalse($object->canRead($file));
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_12.odp';
         $this->assertTrue($object->canRead($file));
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -57,7 +58,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $object = new ODPresentation();
         $object->load('');
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Invalid file format for PhpOffice\PhpPresentation\Reader\ODPresentation:
@@ -68,7 +69,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $object = new ODPresentation();
         $object->load($file);
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -78,7 +79,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $object = new ODPresentation();
         $object->fileSupportsUnserializePhpPresentation('');
     }
-    
+
     public function testLoadFile01()
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_12.odp';
@@ -94,7 +95,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('office 2007 openxml libreoffice odt php', $oPhpPresentation->getDocumentProperties()->getKeywords());
         //
         $this->assertCount(4, $oPhpPresentation->getAllSlides());
-        
+
         // Slide 1
         $oSlide1 = $oPhpPresentation->getSlide(0);
         $arrayShape = $oSlide1->getShapeCollection();
@@ -140,7 +141,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($oRichText->getFont()->isBold());
         $this->assertEquals(60, $oRichText->getFont()->getSize());
         $this->assertEquals('FF000000', $oRichText->getFont()->getColor()->getARGB());
-        
+
         // Slide 2
         $oSlide2 = $oPhpPresentation->getSlide(1);
         $arrayShape = $oSlide2->getShapeCollection();
@@ -237,7 +238,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Supports writing to different file formats', $oRichText->getText());
         $this->assertEquals(36, $oRichText->getFont()->getSize());
         $this->assertEquals('FF000000', $oRichText->getFont()->getColor()->getARGB());
-        
+
         // Slide 3
         $oSlide2 = $oPhpPresentation->getSlide(2);
         $arrayShape = $oSlide2->getShapeCollection();
@@ -394,7 +395,7 @@ class ODPresentationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('... (more to come) ...', $oRichText->getText());
         $this->assertEquals(36, $oRichText->getFont()->getSize());
         $this->assertEquals('FF000000', $oRichText->getFont()->getColor()->getARGB());
-        
+
         // Slide 4
         $oSlide3 = $oPhpPresentation->getSlide(3);
         $arrayShape = $oSlide3->getShapeCollection();

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -21,13 +21,14 @@ use PhpOffice\PhpPresentation\DocumentLayout;
 use PhpOffice\PhpPresentation\Reader\PowerPoint2007;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PowerPoint2007 reader
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Reader\PowerPoint2007
  */
-class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
+class PowerPoint2007Test extends TestCase
 {
     /**
      * Test can read
@@ -35,17 +36,17 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
     public function testCanRead()
     {
         $object = new PowerPoint2007();
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_01.ppt';
         $this->assertFalse($object->canRead($file));
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/serialized.phppt';
         $this->assertFalse($object->canRead($file));
-        
+
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_12.pptx';
         $this->assertTrue($object->canRead($file));
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -55,7 +56,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
         $object = new PowerPoint2007();
         $object->load('');
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Invalid file format for PhpOffice\PhpPresentation\Reader\PowerPoint2007:
@@ -66,7 +67,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
         $object = new PowerPoint2007();
         $object->load($file);
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -76,7 +77,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
         $object = new PowerPoint2007();
         $object->fileSupportsUnserializePhpPresentation('');
     }
-    
+
     public function testLoadFile01()
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_12.pptx';
@@ -98,7 +99,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
 
         // Slides
         $this->assertCount(4, $oPhpPresentation->getAllSlides());
-        
+
         // Slide 1
         $oSlide1 = $oPhpPresentation->getSlide(0);
         $arrayShape = $oSlide1->getShapeCollection();
@@ -144,7 +145,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
         $this->assertTrue($oRichText->getFont()->isBold());
         $this->assertEquals(60, $oRichText->getFont()->getSize());
         $this->assertEquals('FF000000', $oRichText->getFont()->getColor()->getARGB());
-        
+
         // Slide 2
         $oSlide2 = $oPhpPresentation->getSlide(1);
         $arrayShape = $oSlide2->getShapeCollection();
@@ -241,7 +242,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Supports writing to different file formats', $oRichText->getText());
         $this->assertEquals(36, $oRichText->getFont()->getSize());
         $this->assertEquals('FF000000', $oRichText->getFont()->getColor()->getARGB());
-        
+
         // Slide 3
         $oSlide2 = $oPhpPresentation->getSlide(2);
         $arrayShape = $oSlide2->getShapeCollection();
@@ -398,7 +399,7 @@ class PowerPoint2007Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals('... (more to come) ...', $oRichText->getText());
         $this->assertEquals(36, $oRichText->getFont()->getSize());
         $this->assertEquals('FF000000', $oRichText->getFont()->getColor()->getARGB());
-        
+
         // Slide 4
         $oSlide3 = $oPhpPresentation->getSlide(3);
         $arrayShape = $oSlide3->getShapeCollection();

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint97Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint97Test.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Reader;
 
 use PhpOffice\PhpPresentation\Reader\PowerPoint97;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PowerPoint97 reader
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Reader\PowerPoint97
  */
-class PowerPoint97Test extends \PHPUnit_Framework_TestCase
+class PowerPoint97Test extends TestCase
 {
     /**
      * Test can read
@@ -36,7 +37,7 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($object->canRead($file));
     }
-    
+
 
     /**
      * Test cant read
@@ -45,10 +46,10 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/serialized.phppt';
         $object = new PowerPoint97();
-    
+
         $this->assertFalse($object->canRead($file));
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -58,7 +59,7 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $object = new PowerPoint97();
         $object->load('');
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Invalid file format for PhpOffice\PhpPresentation\Reader\PowerPoint97:
@@ -69,7 +70,7 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $object = new PowerPoint97();
         $object->load($file);
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -79,7 +80,7 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $object = new PowerPoint97();
         $object->fileSupportsUnserializePhpPresentation('');
     }
-    
+
     public function testLoadFile01()
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_01.ppt';
@@ -87,11 +88,11 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $oPhpPresentation = $object->load($file);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
         $this->assertEquals(1, $oPhpPresentation->getSlideCount());
-        
+
         $oSlide = $oPhpPresentation->getSlide(0);
         $this->assertCount(2, $oSlide->getShapeCollection());
     }
-    
+
     public function testLoadFile02()
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_02.ppt';
@@ -99,20 +100,20 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $oPhpPresentation = $object->load($file);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
         $this->assertEquals(4, $oPhpPresentation->getSlideCount());
-        
+
         $oSlide = $oPhpPresentation->getSlide(0);
         $this->assertCount(2, $oSlide->getShapeCollection());
-        
+
         $oSlide = $oPhpPresentation->getSlide(1);
         $this->assertCount(3, $oSlide->getShapeCollection());
-        
+
         $oSlide = $oPhpPresentation->getSlide(2);
         $this->assertCount(3, $oSlide->getShapeCollection());
-        
+
         $oSlide = $oPhpPresentation->getSlide(3);
         $this->assertCount(3, $oSlide->getShapeCollection());
     }
-    
+
     public function testLoadFile03()
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_03.ppt';
@@ -120,11 +121,11 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $oPhpPresentation = $object->load($file);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
         $this->assertEquals(1, $oPhpPresentation->getSlideCount());
-        
+
         $oSlide = $oPhpPresentation->getSlide(0);
         $this->assertCount(1, $oSlide->getShapeCollection());
     }
-    
+
     public function testLoadFile04()
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_04.ppt';
@@ -132,7 +133,7 @@ class PowerPoint97Test extends \PHPUnit_Framework_TestCase
         $oPhpPresentation = $object->load($file);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
         $this->assertEquals(1, $oPhpPresentation->getSlideCount());
-        
+
         $oSlide = $oPhpPresentation->getSlide(0);
         $this->assertCount(4, $oSlide->getShapeCollection());
     }

--- a/tests/PhpPresentation/Tests/Reader/SerializedTest.php
+++ b/tests/PhpPresentation/Tests/Reader/SerializedTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Reader;
 
 use PhpOffice\PhpPresentation\Reader\Serialized;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for serialized reader
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Reader\Serialized
  */
-class SerializedTest extends \PHPUnit_Framework_TestCase
+class SerializedTest extends TestCase
 {
     /**
      * Test can read
@@ -36,7 +37,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($object->canRead($file));
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -46,7 +47,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $object = new Serialized();
         $object->load('');
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Invalid file format for PhpOffice\PhpPresentation\Reader\Serialized:
@@ -57,7 +58,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $object = new Serialized();
         $object->load($file);
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open  for reading! File does not exist.
@@ -67,7 +68,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $object = new Serialized();
         $object->fileSupportsUnserializePhpPresentation('');
     }
-    
+
     public function testLoadSerializedFileNotExists()
     {
         $file = tempnam(sys_get_temp_dir(), 'PhpPresentation_Serialized');
@@ -75,7 +76,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $oArchive->open($file, \ZipArchive::CREATE);
         $oArchive->addFromString('PhpPresentation.xml', '');
         $oArchive->close();
-        
+
         $object = new Serialized();
         $this->assertNull($object->load($file));
     }

--- a/tests/PhpPresentation/Tests/Shape/AbstractGraphicTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AbstractGraphicTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\AbstractGraphic;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Table element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\AbstractGraphic
  */
-class AbstractGraphicTest extends \PHPUnit_Framework_TestCase
+class AbstractGraphicTest extends TestCase
 {
     public function testWidthAndHeight()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/AxisTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/AxisTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Axis;
 use PhpOffice\PhpPresentation\Style\Font;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Axis element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Axis
  */
-class AxisTest extends \PHPUnit_Framework_TestCase
+class AxisTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/GridlinesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/GridlinesTest.php
@@ -3,8 +3,9 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Gridlines;
+use PHPUnit\Framework\TestCase;
 
-class GridlinesTest extends \PHPUnit_Framework_TestCase
+class GridlinesTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/LegendTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/LegendTest.php
@@ -22,13 +22,14 @@ use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Border;
 use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Font;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Legend element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Legend
  */
-class LegendTest extends \PHPUnit_Framework_TestCase
+class LegendTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/MarkerTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/MarkerTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Marker;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Legend element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Marker
  */
-class MarkerTest extends \PHPUnit_Framework_TestCase
+class MarkerTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/PlotAreaTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/PlotAreaTest.php
@@ -21,13 +21,14 @@ use PhpOffice\PhpPresentation\Shape\Chart;
 use PhpOffice\PhpPresentation\Shape\Chart\Axis;
 use PhpOffice\PhpPresentation\Shape\Chart\PlotArea;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar3D;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PlotArea element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\PlotArea
  */
-class PlotAreaTest extends \PHPUnit_Framework_TestCase
+class PlotAreaTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
@@ -22,13 +22,14 @@ use PhpOffice\PhpPresentation\Shape\Chart\Series;
 use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Style\Outline;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Series element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Series
  */
-class SeriesTest extends \PHPUnit_Framework_TestCase
+class SeriesTest extends TestCase
 {
     public function testConstruct()
     {
@@ -45,21 +46,21 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($object->getOutline());
         $this->assertFalse($object->hasShowLegendKey());
     }
-    
+
     public function testDataLabelNumFormat()
     {
         $object = new Series();
-        
+
         $this->assertEmpty($object->getDlblNumFormat());
         $this->assertFalse($object->hasDlblNumFormat());
-        
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\Series', $object->setDlblNumFormat('#%'));
-        
+
         $this->assertEquals('#%', $object->getDlblNumFormat());
         $this->assertTrue($object->hasDlblNumFormat());
-        
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\Series', $object->setDlblNumFormat());
-        
+
         $this->assertEmpty($object->getDlblNumFormat());
         $this->assertFalse($object->hasDlblNumFormat());
     }

--- a/tests/PhpPresentation/Tests/Shape/Chart/TitleTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/TitleTest.php
@@ -20,13 +20,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 use PhpOffice\PhpPresentation\Shape\Chart\Title;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Font;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Title element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Title
  */
-class TitleTest extends \PHPUnit_Framework_TestCase
+class TitleTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/AbstractTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/AbstractTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Scatter element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter
  */
-class AbstractTest extends \PHPUnit_Framework_TestCase
+class AbstractTest extends TestCase
 {
     public function testAxis()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/AreaTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/AreaTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Area;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Bar3D element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Bar3D
  */
-class AreaTest extends \PHPUnit_Framework_TestCase
+class AreaTest extends TestCase
 {
     public function testData()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/Bar3DTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/Bar3DTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar3D;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Bar3D element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Bar3D
  */
-class Bar3DTest extends \PHPUnit_Framework_TestCase
+class Bar3DTest extends TestCase
 {
     public function testData()
     {
@@ -52,7 +53,7 @@ class Bar3DTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\Type\\Bar3D', $object->addSeries(new Series()));
         $this->assertCount(1, $object->getSeries());
     }
-    
+
     public function testBarDirection()
     {
         $object = new Bar3D();

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/BarTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/BarTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Bar element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Bar
  */
-class BarTest extends \PHPUnit_Framework_TestCase
+class BarTest extends TestCase
 {
     public function testData()
     {
@@ -52,7 +53,7 @@ class BarTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\Type\\Bar', $object->addSeries(new Series()));
         $this->assertCount(1, $object->getSeries());
     }
-    
+
     public function testBarDirection()
     {
         $object = new Bar();

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/DoughnutTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/DoughnutTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Doughnut;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Doughnut element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Doughnut
  */
-class DoughnutTest extends \PHPUnit_Framework_TestCase
+class DoughnutTest extends TestCase
 {
     public function testData()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/LineTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/LineTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Line;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Line element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Line
  */
-class LineTest extends \PHPUnit_Framework_TestCase
+class LineTest extends TestCase
 {
     public function testData()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/Pie3DTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/Pie3DTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Pie3D;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Pie3D element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Pie3D
  */
-class Pie3DTest extends \PHPUnit_Framework_TestCase
+class Pie3DTest extends TestCase
 {
     public function testData()
     {
@@ -56,7 +57,7 @@ class Pie3DTest extends \PHPUnit_Framework_TestCase
     public function testExplosion()
     {
         $value = rand(0, 100);
-        
+
         $object = new Pie3D();
 
         $this->assertEquals(0, $object->getExplosion());

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/PieTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/PieTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Pie;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Pie element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Pie
  */
-class PieTest extends \PHPUnit_Framework_TestCase
+class PieTest extends TestCase
 {
     public function testData()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/ScatterTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/ScatterTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart\Type;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Scatter element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter
  */
-class ScatterTest extends \PHPUnit_Framework_TestCase
+class ScatterTest extends TestCase
 {
     public function testData()
     {

--- a/tests/PhpPresentation/Tests/Shape/Chart/View3DTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/View3DTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 
 use PhpOffice\PhpPresentation\Shape\Chart\View3D;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for View3D element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart\View3D
  */
-class View3DTest extends \PHPUnit_Framework_TestCase
+class View3DTest extends TestCase
 {
     public function testDepthPercent()
     {

--- a/tests/PhpPresentation/Tests/Shape/ChartTest.php
+++ b/tests/PhpPresentation/Tests/Shape/ChartTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Chart;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Chart element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Chart
  */
-class ChartTest extends \PHPUnit_Framework_TestCase
+class ChartTest extends TestCase
 {
     public function testConstruct()
     {
@@ -35,14 +36,14 @@ class ChartTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\PlotArea', $object->getPlotArea());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\View3D', $object->getView3D());
     }
-    
+
 
     public function testClone()
     {
         $object = new Chart();
-        
+
         $oClone = clone $object;
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart', $oClone);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\Title', $oClone->getTitle());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart\\Legend', $oClone->getLegend());

--- a/tests/PhpPresentation/Tests/Shape/Comment/AuthorTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Comment/AuthorTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Comment;
 
 use PhpOffice\PhpPresentation\Shape\Comment\Author;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Author element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Comment\Author
  */
-class AuthorTest extends \PHPUnit_Framework_TestCase
+class AuthorTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/CommentTest.php
+++ b/tests/PhpPresentation/Tests/Shape/CommentTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Comment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Chart element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Comment
  */
-class CommentTest extends \PHPUnit_Framework_TestCase
+class CommentTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Drawing/Base64Test.php
+++ b/tests/PhpPresentation/Tests/Shape/Drawing/Base64Test.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Drawing;
 
 use PhpOffice\PhpPresentation\Shape\Drawing\Base64;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Drawing element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Drawing
  */
-class Base64Test extends \PHPUnit_Framework_TestCase
+class Base64Test extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpPresentation/Tests/Shape/Drawing/FileTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Drawing/FileTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Drawing;
 
 use PhpOffice\PhpPresentation\Shape\Drawing\File;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Drawing element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Drawing
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/Drawing/ZipFileTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Drawing/ZipFileTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\Drawing;
 
 use PhpOffice\PhpPresentation\Shape\Drawing\ZipFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Drawing element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Drawing
  */
-class ZipFileTest extends \PHPUnit_Framework_TestCase
+class ZipFileTest extends TestCase
 {
     protected $fileOk;
     protected $fileKoZip;

--- a/tests/PhpPresentation/Tests/Shape/GroupTest.php
+++ b/tests/PhpPresentation/Tests/Shape/GroupTest.php
@@ -19,18 +19,19 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Group;
 use PhpOffice\PhpPresentation\Shape\Line;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Group element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Group
  */
-class GroupTest extends \PHPUnit_Framework_TestCase
+class GroupTest extends TestCase
 {
     public function testConstruct()
     {
         $object = new Group();
-        
+
         $this->assertEquals(0, $object->getOffsetX());
         $this->assertEquals(0, $object->getOffsetY());
         $this->assertEquals(0, $object->getExtentX());
@@ -39,11 +40,11 @@ class GroupTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Group', $object->setWidth(rand(1, 100)));
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Group', $object->setHeight(rand(1, 100)));
     }
-    
+
     public function testAdd()
     {
         $object = new Group();
-        
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Chart', $object->createChartShape());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Drawing\\File', $object->createDrawingShape());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Line', $object->createLineShape(10, 10, 10, 10));
@@ -51,7 +52,7 @@ class GroupTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Table', $object->createTableShape());
         $this->assertEquals(5, $object->getShapeCollection()->count());
     }
-    
+
     public function testExtentX()
     {
         $object = new Group();
@@ -60,7 +61,7 @@ class GroupTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(30, $object->getExtentX());
     }
-    
+
     public function testExtentY()
     {
         $object = new Group();
@@ -69,7 +70,7 @@ class GroupTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(40, $object->getExtentY());
     }
-    
+
     public function testOffsetX()
     {
         $object = new Group();
@@ -77,11 +78,11 @@ class GroupTest extends \PHPUnit_Framework_TestCase
         $object->addShape($line1);
 
         $this->assertEquals(10, $object->getOffsetX());
-        
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Group', $object->setOffsetX(rand(1, 100)));
         $this->assertEquals(10, $object->getOffsetX());
     }
-    
+
     public function testOffsetY()
     {
         $object = new Group();
@@ -89,11 +90,11 @@ class GroupTest extends \PHPUnit_Framework_TestCase
         $object->addShape($line1);
 
         $this->assertEquals(20, $object->getOffsetY());
-        
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Group', $object->setOffsetY(rand(1, 100)));
         $this->assertEquals(20, $object->getOffsetY());
     }
-    
+
     public function testExtentsAndOffsetsForOneShape()
     {
         // We record initial values here because
@@ -107,7 +108,7 @@ class GroupTest extends \PHPUnit_Framework_TestCase
         $object = new Group();
         $line1  = new Line($offsetX, $offsetY, $extentX, $extentY);
         $object->addShape($line1);
-        
+
         $this->assertEquals($offsetX, $object->getOffsetX());
         $this->assertEquals($offsetY, $object->getOffsetY());
         $this->assertEquals($extentX, $object->getExtentX());
@@ -135,10 +136,10 @@ class GroupTest extends \PHPUnit_Framework_TestCase
         );
 
         $object = new Group();
-        
+
         $object->addShape($line1);
         $object->addShape($line2);
-        
+
         $this->assertEquals($offsetX, $object->getOffsetX());
         $this->assertEquals($offsetY, $object->getOffsetY());
         $this->assertEquals($extentX+$increase, $object->getExtentX());

--- a/tests/PhpPresentation/Tests/Shape/HyperlinkTest.php
+++ b/tests/PhpPresentation/Tests/Shape/HyperlinkTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Hyperlink;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for hyperlink element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Hyperlink
  */
-class HyperlinkTest extends \PHPUnit_Framework_TestCase
+class HyperlinkTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/LineTest.php
+++ b/tests/PhpPresentation/Tests/Shape/LineTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Line;
 use PhpOffice\PhpPresentation\Style\Border;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for memory drawing element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Line
  */
-class LineTest extends \PHPUnit_Framework_TestCase
+class LineTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/MediaTest.php
+++ b/tests/PhpPresentation/Tests/Shape/MediaTest.php
@@ -3,8 +3,9 @@
 namespace PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Media;
+use PHPUnit\Framework\TestCase;
 
-class MediaTest extends \PHPUnit_Framework_TestCase
+class MediaTest extends TestCase
 {
     public function testInheritance()
     {

--- a/tests/PhpPresentation/Tests/Shape/PlaceholderTest.php
+++ b/tests/PhpPresentation/Tests/Shape/PlaceholderTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Placeholder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Table element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Table
  */
-class PlaceholderTest extends \PHPUnit_Framework_TestCase
+class PlaceholderTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Shape/RichText/BreakElementTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/BreakElementTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape\RichText;
 
 use PhpOffice\PhpPresentation\Shape\RichText\BreakElement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for BreakElement element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\RichText\BreakElement
  */
-class BreakElementTest extends \PHPUnit_Framework_TestCase
+class BreakElementTest extends TestCase
 {
     /**
      * Test can read
@@ -52,7 +53,7 @@ class BreakElementTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\BreakElement', $object->setLanguage('en-US'));
         $this->assertNull($object->getLanguage());
     }
-    
+
     /**
      * Test get/set hash index
      */

--- a/tests/PhpPresentation/Tests/Shape/RichText/ParagraphTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/ParagraphTest.php
@@ -22,13 +22,14 @@ use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
 use PhpOffice\PhpPresentation\Style\Font;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Paragraph element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\RichText\Paragraph
  */
-class ParagraphTest extends \PHPUnit_Framework_TestCase
+class ParagraphTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/RichText/RunTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/RunTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\RichText;
 
 use PhpOffice\PhpPresentation\Shape\RichText\Run;
 use PhpOffice\PhpPresentation\Style\Font;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Run element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\RichText\Run
  */
-class RunTest extends \PHPUnit_Framework_TestCase
+class RunTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/RichText/TextElementTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/TextElementTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\RichText;
 
 use PhpOffice\PhpPresentation\Shape\Hyperlink;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for TextElement element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\RichText\TextElement
  */
-class TextElementTest extends \PHPUnit_Framework_TestCase
+class TextElementTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/RichTextTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichTextTest.php
@@ -20,13 +20,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for RichText element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\RichText
  */
-class RichTextTest extends \PHPUnit_Framework_TestCase
+class RichTextTest extends TestCase
 {
     public function testConstruct()
     {
@@ -149,36 +150,36 @@ class RichTextTest extends \PHPUnit_Framework_TestCase
     public function testGetSetHAutoShrink()
     {
         $object = new RichText();
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkHorizontal());
         $this->assertNull($object->hasAutoShrinkHorizontal());
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkHorizontal(2));
         $this->assertNull($object->hasAutoShrinkHorizontal());
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkHorizontal(true));
         $this->assertTrue($object->hasAutoShrinkHorizontal());
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkHorizontal(false));
         $this->assertFalse($object->hasAutoShrinkHorizontal());
     }
     public function testGetSetVAutoShrink()
     {
         $object = new RichText();
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkVertical());
         $this->assertNull($object->hasAutoShrinkVertical());
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkVertical(2));
         $this->assertNull($object->hasAutoShrinkVertical());
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkVertical(true));
         $this->assertTrue($object->hasAutoShrinkVertical());
-    
+
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->setAutoShrinkVertical(false));
         $this->assertFalse($object->hasAutoShrinkVertical());
     }
-    
+
     public function testGetSetHOverflow()
     {
         $object = new RichText();

--- a/tests/PhpPresentation/Tests/Shape/Table/CellTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Table/CellTest.php
@@ -22,13 +22,14 @@ use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
 use PhpOffice\PhpPresentation\Style\Borders;
 use PhpOffice\PhpPresentation\Style\Fill;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Cell element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Cell
  */
-class CellTest extends \PHPUnit_Framework_TestCase
+class CellTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/Table/RowTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Table/RowTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Table;
 
 use PhpOffice\PhpPresentation\Shape\Table\Row;
 use PhpOffice\PhpPresentation\Style\Fill;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Row element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Row
  */
-class RowTest extends \PHPUnit_Framework_TestCase
+class RowTest extends TestCase
 {
     /**
      * Test can read

--- a/tests/PhpPresentation/Tests/Shape/TableTest.php
+++ b/tests/PhpPresentation/Tests/Shape/TableTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Table;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Table element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\Table
  */
-class TableTest extends \PHPUnit_Framework_TestCase
+class TableTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Slide/AbstractSlideTest.php
+++ b/tests/PhpPresentation/Tests/Slide/AbstractSlideTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Slide;
 
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Slide\AbstractSlide;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Table element
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Shape\AbstractGraphic
  */
-class AbstractSlideTest extends \PHPUnit_Framework_TestCase
+class AbstractSlideTest extends TestCase
 {
     public function testCollection()
     {

--- a/tests/PhpPresentation/Tests/Slide/AnimationTest.php
+++ b/tests/PhpPresentation/Tests/Slide/AnimationTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\Slide\Animation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Animation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Slide\Animation
  */
-class AnimationTest extends \PHPUnit_Framework_TestCase
+class AnimationTest extends TestCase
 {
     public function testShape()
     {

--- a/tests/PhpPresentation/Tests/Slide/Background/ColorTest.php
+++ b/tests/PhpPresentation/Tests/Slide/Background/ColorTest.php
@@ -4,8 +4,9 @@ namespace PhpOffice\PhpPresentation\Tests\Slide\Background;
 
 use PhpOffice\PhpPresentation\Slide\Background\Color;
 use PhpOffice\PhpPresentation\Style\Color as StyleColor;
+use PHPUnit\Framework\TestCase;
 
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
     public function testColor()
     {

--- a/tests/PhpPresentation/Tests/Slide/Background/ImageTest.php
+++ b/tests/PhpPresentation/Tests/Slide/Background/ImageTest.php
@@ -3,8 +3,9 @@
 namespace PhpOffice\PhpPresentation\Tests\Slide\Background;
 
 use PhpOffice\PhpPresentation\Slide\Background\Image;
+use PHPUnit\Framework\TestCase;
 
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends TestCase
 {
     public function testColor()
     {

--- a/tests/PhpPresentation/Tests/Slide/Background/SchemeColorTest.php
+++ b/tests/PhpPresentation/Tests/Slide/Background/SchemeColorTest.php
@@ -4,8 +4,9 @@ namespace PhpOffice\PhpPresentation\Tests\Slide\Background;
 
 use PhpOffice\PhpPresentation\Slide\Background\SchemeColor;
 use PhpOffice\PhpPresentation\Style\SchemeColor as StyleSchemeColor;
+use PHPUnit\Framework\TestCase;
 
-class SchemeColorTest extends \PHPUnit_Framework_TestCase
+class SchemeColorTest extends TestCase
 {
     public function testBasic()
     {

--- a/tests/PhpPresentation/Tests/Slide/IteratorTest.php
+++ b/tests/PhpPresentation/Tests/Slide/IteratorTest.php
@@ -20,13 +20,14 @@ namespace PhpOffice\PhpPresentation\Tests\Slide;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\Slide\Iterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for IOFactory
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\IOFactory
  */
-class IteratorTest extends \PHPUnit_Framework_TestCase
+class IteratorTest extends TestCase
 {
     /**
      */

--- a/tests/PhpPresentation/Tests/Slide/NoteTest.php
+++ b/tests/PhpPresentation/Tests/Slide/NoteTest.php
@@ -20,25 +20,26 @@ namespace PhpOffice\PhpPresentation\Tests;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Slide\Note;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class NoteTest extends \PHPUnit_Framework_TestCase
+class NoteTest extends TestCase
 {
     public function testParent()
     {
         $object = new Note();
         $this->assertNull($object->getParent());
-        
+
         $oPhpPresentation = new PhpPresentation();
         $oSlide = $oPhpPresentation->createSlide();
         $oSlide->setNote($object);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Slide', $object->getParent());
     }
-    
+
     public function testExtent()
     {
         $object = new Note();
@@ -47,13 +48,13 @@ class NoteTest extends \PHPUnit_Framework_TestCase
         $object = new Note();
         $this->assertNotNull($object->getExtentY());
     }
-    
+
     public function testHashCode()
     {
         $object = new Note();
         $this->assertInternalType('string', $object->getHashCode());
     }
-    
+
     public function testOffset()
     {
         $object = new Note();
@@ -62,14 +63,14 @@ class NoteTest extends \PHPUnit_Framework_TestCase
         $object = new Note();
         $this->assertNotNull($object->getOffsetY());
     }
-    
+
     public function testShape()
     {
         $object = new Note();
         $this->assertEquals(0, $object->getShapeCollection()->count());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->createRichTextShape());
         $this->assertEquals(1, $object->getShapeCollection()->count());
-        
+
         $oRichText = new RichText();
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText', $object->addShape($oRichText));
         $this->assertEquals(2, $object->getShapeCollection()->count());

--- a/tests/PhpPresentation/Tests/Slide/SlideLayoutTest.php
+++ b/tests/PhpPresentation/Tests/Slide/SlideLayoutTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\Slide\SlideLayout;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Slide\SlideLayout
  */
-class SlideLayoutTest extends \PHPUnit_Framework_TestCase
+class SlideLayoutTest extends TestCase
 {
     public function testBase()
     {
@@ -35,7 +36,7 @@ class SlideLayoutTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\\ArrayObject', $object->getShapeCollection());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->colorMap);
     }
-    
+
     public function testLayoutName()
     {
         // Mocks

--- a/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
+++ b/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Slide\SlideMaster
  */
-class SlideMasterTest extends \PHPUnit_Framework_TestCase
+class SlideMasterTest extends TestCase
 {
     public function testBase()
     {

--- a/tests/PhpPresentation/Tests/Slide/TransitionTest.php
+++ b/tests/PhpPresentation/Tests/Slide/TransitionTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\Slide\Transition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Slide\Transition
  */
-class TransitionTest extends \PHPUnit_Framework_TestCase
+class TransitionTest extends TestCase
 {
     public function testSpeed()
     {

--- a/tests/PhpPresentation/Tests/SlideTest.php
+++ b/tests/PhpPresentation/Tests/SlideTest.php
@@ -20,46 +20,47 @@ namespace PhpOffice\PhpPresentation\Tests;
 use PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\Slide\Transition;
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class SlideTest extends \PHPUnit_Framework_TestCase
+class SlideTest extends TestCase
 {
     public function testExtents()
     {
         $object = new Slide();
         $this->assertNotNull($object->getExtentX());
-        
+
         $object = new Slide();
         $this->assertNotNull($object->getExtentY());
     }
-    
+
     public function testOffset()
     {
         $object = new Slide();
         $this->assertNotNull($object->getOffsetX());
-        
+
         $object = new Slide();
         $this->assertNotNull($object->getOffsetY());
     }
-    
+
     public function testParent()
     {
         $object = new Slide();
         $this->assertNull($object->getParent());
-        
+
         $oPhpPresentation = new PhpPresentation();
         $object = new Slide($oPhpPresentation);
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $object->getParent());
     }
-    
+
     public function testSlideMasterId()
     {
         $value = rand(1, 100);
-        
+
         $object = new Slide();
         $this->assertEquals(1, $object->getSlideMasterId());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Slide', $object->setSlideMasterId());

--- a/tests/PhpPresentation/Tests/Style/AlignmentTest.php
+++ b/tests/PhpPresentation/Tests/Style/AlignmentTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Alignment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class AlignmentTest extends \PHPUnit_Framework_TestCase
+class AlignmentTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/BorderTest.php
+++ b/tests/PhpPresentation/Tests/Style/BorderTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Border;
 use PhpOffice\PhpPresentation\Style\Color;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class BorderTest extends \PHPUnit_Framework_TestCase
+class BorderTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/BordersTest.php
+++ b/tests/PhpPresentation/Tests/Style/BordersTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Border;
 use PhpOffice\PhpPresentation\Style\Borders;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class BordersTest extends \PHPUnit_Framework_TestCase
+class BordersTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/BulletTest.php
+++ b/tests/PhpPresentation/Tests/Style/BulletTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Bullet;
 use PhpOffice\PhpPresentation\Style\Color;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class BulletTest extends \PHPUnit_Framework_TestCase
+class BulletTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/ColorMapTest.php
+++ b/tests/PhpPresentation/Tests/Style/ColorMapTest.php
@@ -18,8 +18,9 @@
 namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\ColorMap;
+use PHPUnit\Framework\TestCase;
 
-class ColorMapTest extends \PHPUnit_Framework_TestCase
+class ColorMapTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/PhpPresentation/Tests/Style/ColorTest.php
+++ b/tests/PhpPresentation/Tests/Style/ColorTest.php
@@ -18,13 +18,14 @@
 namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Color;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/FillTest.php
+++ b/tests/PhpPresentation/Tests/Style/FillTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\Fill;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class FillTest extends \PHPUnit_Framework_TestCase
+class FillTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/FontTest.php
+++ b/tests/PhpPresentation/Tests/Style/FontTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\Font;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class FontTest extends \PHPUnit_Framework_TestCase
+class FontTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/OutlineTest.php
+++ b/tests/PhpPresentation/Tests/Style/OutlineTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Outline;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Style\Outline
  */
-class OutlineTest extends \PHPUnit_Framework_TestCase
+class OutlineTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/ShadowTest.php
+++ b/tests/PhpPresentation/Tests/Style/ShadowTest.php
@@ -19,13 +19,14 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 
 use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\Shadow;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpPresentation
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\PhpPresentation
  */
-class ShadowTest extends \PHPUnit_Framework_TestCase
+class ShadowTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Style/TextStyleTest.php
+++ b/tests/PhpPresentation/Tests/Style/TextStyleTest.php
@@ -20,8 +20,9 @@ namespace PhpOffice\PhpPresentation\Tests\Style;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\TextStyle;
+use PHPUnit\Framework\TestCase;
 
-class TextStyleTest extends \PHPUnit_Framework_TestCase
+class TextStyleTest extends TestCase
 {
     public function testConstructDefaultTrue()
     {

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
@@ -18,6 +18,7 @@
 namespace PhpOffice\PhpPresentation\Tests\Writer;
 
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PHPUnit\Framework\TestCase;
 
 require 'AbstractWriter.php';
 
@@ -26,7 +27,7 @@ require 'AbstractWriter.php';
  *
  * @coversDefaultClass AbstractWriter
  */
-class AbstractWriterTest extends \PHPUnit_Framework_TestCase
+class AbstractWriterTest extends TestCase
 {
     /**
      * Test create new instance

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/LayoutPack/TemplateBasedTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/LayoutPack/TemplateBasedTest.php
@@ -19,6 +19,7 @@ namespace PhpOffice\PhpPresentation\Tests\Writer\PowerPoint2007\LayoutPack;
 
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007\LayoutPack\PackDefault;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007\LayoutPack\TemplateBased;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for TemplateBased
@@ -26,7 +27,7 @@ use PhpOffice\PhpPresentation\Writer\PowerPoint2007\LayoutPack\TemplateBased;
  * @deprecated 0.7
  * @coversDefaultClass TemplateBased
  */
-class TemplateBasedTest extends \PHPUnit_Framework_TestCase
+class TemplateBasedTest extends TestCase
 {
     public function testFindLayout()
     {

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
@@ -5,13 +5,14 @@ namespace PhpPresentation\Tests\Writer\PowerPoint2007;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007\PptSlideMasters;
 use PhpOffice\PhpPresentation\Slide\SlideLayout;
 use PhpOffice\PhpPresentation\Shape\Drawing\File as ShapeDrawingFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PowerPoint2007
  *
  * @coversDefaultClass PowerPoint2007
  */
-class PptSlideMastersTest extends \PHPUnit_Framework_TestCase
+class PptSlideMastersTest extends TestCase
 {
     public function testWriteSlideMasterRelationships()
     {

--- a/tests/PhpPresentation/Tests/Writer/SerializedTest.php
+++ b/tests/PhpPresentation/Tests/Writer/SerializedTest.php
@@ -19,20 +19,21 @@ namespace PhpOffice\PhpPresentation\Tests\Writer;
 
 use PhpOffice\PhpPresentation\Writer\Serialized;
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for serialized reader
  *
  * @coversDefaultClass PhpOffice\PhpPresentation\Reader\Serialized
  */
-class SerializedTest extends \PHPUnit_Framework_TestCase
+class SerializedTest extends TestCase
 {
     public function testConstruct()
     {
         $object = new Serialized(new PhpPresentation());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $object->getPhpPresentation());
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage No PhpPresentation assigned.
@@ -42,7 +43,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $object = new Serialized();
         $object->getPhpPresentation();
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Filename is empty.
@@ -52,7 +53,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $object = new Serialized(new PhpPresentation());
         $object->save('');
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage No PhpPresentation assigned.
@@ -62,7 +63,7 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $object = new Serialized();
         $object->save('file.phpppt');
     }
-    
+
     public function testSave()
     {
         $oPhpPresentation = new PhpPresentation();
@@ -70,12 +71,12 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $oImage = $oSlide->createDrawingShape();
         $oImage->setPath(PHPPRESENTATION_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'images'.DIRECTORY_SEPARATOR.'PhpPresentationLogo.png');
         $object = new Serialized($oPhpPresentation);
-        
+
         $file = tempnam(sys_get_temp_dir(), 'PhpPresentation_Serialized');
-        
+
         $this->assertFileExists($file, $object->save($file));
     }
-    
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not open
@@ -87,12 +88,12 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $oImage = $oSlide->createDrawingShape();
         $oImage->setPath(PHPPRESENTATION_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'images'.DIRECTORY_SEPARATOR.'PhpPresentationLogo.png');
         $object = new Serialized($oPhpPresentation);
-        
+
         $file = tempnam(sys_get_temp_dir(), 'PhpPresentation_Serialized');
-        
+
         $this->assertFileExists($file, $object->save($file.DIRECTORY_SEPARATOR.'test'.DIRECTORY_SEPARATOR.'test'));
     }
-    
+
     public function testSaveOverwriting()
     {
         $oPhpPresentation = new PhpPresentation();
@@ -100,10 +101,10 @@ class SerializedTest extends \PHPUnit_Framework_TestCase
         $oImage = $oSlide->createDrawingShape();
         $oImage->setPath(PHPPRESENTATION_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'images'.DIRECTORY_SEPARATOR.'PhpPresentationLogo.png');
         $object = new Serialized($oPhpPresentation);
-        
+
         $file = tempnam(sys_get_temp_dir(), 'PhpPresentation_Serialized');
         file_put_contents($file, rand(1, 100));
-        
+
         $this->assertFileExists($file, $object->save($file));
     }
 }

--- a/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
+++ b/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
@@ -4,8 +4,9 @@ namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\IOFactory;
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PHPUnit\Framework\TestCase;
 
-class PhpPresentationTestCase extends \PHPUnit_Framework_TestCase
+class PhpPresentationTestCase extends TestCase
 {
     /**
      * @var PhpPresentation


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21) for compatibility with `namespaces`.