### PR TITLE
Refactoring tests

### DIFF
--- a/tests/PhpPresentation/Tests/PhpPresentationTest.php
+++ b/tests/PhpPresentation/Tests/PhpPresentationTest.php
@@ -41,7 +41,7 @@ class PhpPresentationTest extends TestCase
         $this->assertEquals(new DocumentProperties(), $object->getDocumentProperties());
         $this->assertEquals(new DocumentLayout(), $object->getLayout());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Slide', $object->getSlide());
-        $this->assertEquals(1, count($object->getAllSlides()));
+        $this->assertCount(1, $object->getAllSlides());
         $this->assertEquals(0, $object->getIndex($slide));
         $this->assertEquals(1, $object->getSlideCount());
         $this->assertEquals(0, $object->getActiveSlideIndex());

--- a/tests/PhpPresentation/Tests/Shape/RichText/ParagraphTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/ParagraphTest.php
@@ -147,17 +147,17 @@ class ParagraphTest extends TestCase
     {
         $object = new Paragraph();
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\Paragraph', $object->addText(new TextElement()));
-        $this->assertcount(1, $object->getRichTextElements());
+        $this->assertCount(1, $object->getRichTextElements());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\TextElement', $object->createText());
-        $this->assertcount(2, $object->getRichTextElements());
+        $this->assertCount(2, $object->getRichTextElements());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\TextElement', $object->createText('AAA'));
-        $this->assertcount(3, $object->getRichTextElements());
+        $this->assertCount(3, $object->getRichTextElements());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\BreakElement', $object->createBreak());
-        $this->assertcount(4, $object->getRichTextElements());
+        $this->assertCount(4, $object->getRichTextElements());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\Run', $object->createTextRun());
-        $this->assertcount(5, $object->getRichTextElements());
+        $this->assertCount(5, $object->getRichTextElements());
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\Run', $object->createTextRun('BBB'));
-        $this->assertcount(6, $object->getRichTextElements());
+        $this->assertCount(6, $object->getRichTextElements());
         $this->assertEquals('AAA'."\r\n".'BBB', $object->getPlainText());
         $this->assertEquals('AAA'."\r\n".'BBB', (string) $object);
     }

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
@@ -60,6 +60,6 @@ class AbstractWriterTest extends TestCase
         $writer->setPhpPresentation($presentation);
 
         $drawings = $writer->allDrawings();
-        $this->assertEquals(2, count($drawings), 'Number of drawings should equal two: one from normal slide and one from master slide');
+        $this->assertCount(2, $drawings, 'Number of drawings should equal two: one from normal slide and one from master slide');
     }
 }

--- a/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
+++ b/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
@@ -175,7 +175,7 @@ class PhpPresentationTestCase extends TestCase
     public function assertZipFileExists($filePath)
     {
         $this->writePresentationFile($this->oPresentation, $this->writerName);
-        self::assertThat(is_file($this->workDirectory . $filePath), self::isTrue());
+        self::assertTrue(is_file($this->workDirectory . $filePath));
     }
 
     /**
@@ -184,7 +184,7 @@ class PhpPresentationTestCase extends TestCase
     public function assertZipFileNotExists($filePath)
     {
         $this->writePresentationFile($this->oPresentation, $this->writerName);
-        self::assertThat(is_file($this->workDirectory . $filePath), self::isFalse());
+        self::assertFalse(is_file($this->workDirectory . $filePath));
     }
 
     /**
@@ -195,7 +195,7 @@ class PhpPresentationTestCase extends TestCase
     {
         $this->writePresentationFile($this->oPresentation, $this->writerName);
         $nodeList = $this->getXmlNodeList($filePath, $xPath);
-        self::assertThat(!($nodeList->length == 0), self::isTrue());
+        self::assertNotEquals(0, $nodeList->length);
     }
 
     /**
@@ -206,7 +206,7 @@ class PhpPresentationTestCase extends TestCase
     {
         $this->writePresentationFile($this->oPresentation, $this->writerName);
         $nodeList = $this->getXmlNodeList($filePath, $xPath);
-        self::assertThat(!($nodeList->length == 0), self::isFalse());
+        self::assertEquals(0, $nodeList->length);
     }
 
     /**


### PR DESCRIPTION
I've refactored some tests using `PHPUnit` assertion methods, instead of `PHP`'s. This will give us better error messages in case of failure.