### PR TITLE
Change group shape extents to reflect content width/height.

### DIFF
--- a/src/PhpPresentation/Shape/Group.php
+++ b/src/PhpPresentation/Shape/Group.php
@@ -145,8 +145,8 @@ class Group extends AbstractShape implements ShapeContainerInterface
     {
         if ($this->extentX === null) {
             $extents = GeometryCalculator::calculateExtents($this);
-            $this->extentX = $extents[GeometryCalculator::X];
-            $this->extentY = $extents[GeometryCalculator::Y];
+            $this->extentX = $extents[GeometryCalculator::X] - $this->getOffsetX();
+            $this->extentY = $extents[GeometryCalculator::Y] - $this->getOffsetY();
         }
 
         return $this->extentX;
@@ -161,8 +161,8 @@ class Group extends AbstractShape implements ShapeContainerInterface
     {
         if ($this->extentY === null) {
             $extents = GeometryCalculator::calculateExtents($this);
-            $this->extentX = $extents[GeometryCalculator::X];
-            $this->extentY = $extents[GeometryCalculator::Y];
+            $this->extentX = $extents[GeometryCalculator::X] - $this->getOffsetX();
+            $this->extentY = $extents[GeometryCalculator::Y] - $this->getOffsetY();
         }
 
         return $this->extentY;

--- a/tests/PhpPresentation/Tests/Shape/GroupTest.php
+++ b/tests/PhpPresentation/Tests/Shape/GroupTest.php
@@ -56,25 +56,25 @@ class GroupTest extends TestCase
     public function testExtentX()
     {
         $object = new Group();
-        $line1  = new Line(10, 20, 30, 40);
+        $line1  = new Line(10, 20, 30, 50);
         $object->addShape($line1);
 
-        $this->assertEquals(30, $object->getExtentX());
+        $this->assertEquals(20, $object->getExtentX());
     }
 
     public function testExtentY()
     {
         $object = new Group();
-        $line1  = new Line(10, 20, 30, 40);
+        $line1  = new Line(10, 20, 30, 50);
         $object->addShape($line1);
 
-        $this->assertEquals(40, $object->getExtentY());
+        $this->assertEquals(30, $object->getExtentY());
     }
 
     public function testOffsetX()
     {
         $object = new Group();
-        $line1  = new Line(10, 20, 30, 40);
+        $line1  = new Line(10, 20, 30, 50);
         $object->addShape($line1);
 
         $this->assertEquals(10, $object->getOffsetX());
@@ -86,7 +86,7 @@ class GroupTest extends TestCase
     public function testOffsetY()
     {
         $object = new Group();
-        $line1  = new Line(10, 20, 30, 40);
+        $line1  = new Line(10, 20, 30, 50);
         $object->addShape($line1);
 
         $this->assertEquals(20, $object->getOffsetY());
@@ -102,11 +102,13 @@ class GroupTest extends TestCase
         // from the extents to produce a raw width and height.
         $offsetX = 100;
         $offsetY = 100;
-        $extentX = 1000;
-        $extentY = 450;
+        $endX = 1000;
+        $endY = 450;
+        $extentX = $endX - $offsetX;
+        $extentY = $endY - $offsetY;
 
         $object = new Group();
-        $line1  = new Line($offsetX, $offsetY, $extentX, $extentY);
+        $line1  = new Line($offsetX, $offsetY, $endX, $endY);
         $object->addShape($line1);
 
         $this->assertEquals($offsetX, $object->getOffsetX());
@@ -123,16 +125,18 @@ class GroupTest extends TestCase
         // combined with the above.
         $offsetX = 100;
         $offsetY = 100;
-        $extentX = 1000;
-        $extentY = 450;
+        $endX = 1000;
+        $endY = 450;
         $increase = 50;
+        $extentX = ($endX - $offsetX) + $increase;
+        $extentY = ($endY - $offsetY) + $increase;
 
-        $line1  = new Line($offsetX, $offsetY, $extentX, $extentY);
+        $line1  = new Line($offsetX, $offsetY, $endX, $endY);
         $line2 = new Line(
             $offsetX+$increase,
             $offsetY+$increase,
-            $extentX+$increase,
-            $extentY+$increase
+            $endX+$increase,
+            $endY+$increase
         );
 
         $object = new Group();
@@ -142,7 +146,7 @@ class GroupTest extends TestCase
 
         $this->assertEquals($offsetX, $object->getOffsetX());
         $this->assertEquals($offsetY, $object->getOffsetY());
-        $this->assertEquals($extentX+$increase, $object->getExtentX());
-        $this->assertEquals($extentY+$increase, $object->getExtentY());
+        $this->assertEquals($extentX, $object->getExtentX());
+        $this->assertEquals($extentY, $object->getExtentY());
     }
 }


### PR DESCRIPTION
Previously the group extents where calculated based on the extents of the containing shapes, which uses  the slide/container of the group as the point of reference. This would result in the group being larger than
needed; especially noticeable for a large X or Y offset.

Example selected group in PowerPoint 2016 before these changes:

<img width="806" alt="2018-02-05 14_04_46-group_test_pre pptx - powerpoint" src="https://user-images.githubusercontent.com/2559256/35784675-27a70fea-0a7f-11e8-9211-dcef28a8b8b3.png">

The same example and selection after the code changes:

<img width="806" alt="2018-02-05 14_03_33-group_test_post pptx - powerpoint" src="https://user-images.githubusercontent.com/2559256/35784685-479e40de-0a7f-11e8-8256-4ba51a0e6f3d.png">

The code that generated the above two files was a slight modification of `samples/Sample_08_Group.php` to move the first image further away from the left and top so as to more clearly show the effect:

```php
<?php

include_once 'Sample_Header.php';

use PhpOffice\PhpPresentation\PhpPresentation;
use PhpOffice\PhpPresentation\Style\Alignment;
use PhpOffice\PhpPresentation\Style\Color;

// Create new PHPPresentation object
echo date('H:i:s') . ' Create new PHPPresentation object' . EOL;
$objPHPPresentation = new PhpPresentation();

// Set properties
echo date('H:i:s') . ' Set properties'.EOL;
$objPHPPresentation->getDocumentProperties()->setCreator('PHPOffice')
                                  ->setLastModifiedBy('PHPPresentation Team')
                                  ->setTitle('Sample 01 Title')
                                  ->setSubject('Sample 01 Subject')
                                  ->setDescription('Sample 01 Description')
                                  ->setKeywords('office 2007 openxml libreoffice odt php')
                                  ->setCategory('Sample Category');

// Create slide
echo date('H:i:s') . ' Create slide'.EOL;
$currentGroup = $objPHPPresentation->getActiveSlide()->createGroup();

// Create a shape (drawing)
echo date('H:i:s') . ' Create a shape (drawing)'.EOL;
$shape = $currentGroup->createDrawingShape();
$shape->setName('PHPPresentation logo')
      ->setDescription('PHPPresentation logo')
      ->setPath('./resources/phppowerpoint_logo.gif')
      ->setHeight(36)
      ->setOffsetX(200)
      ->setOffsetY(100);
$shape->getShadow()->setVisible(true)
                   ->setDirection(45)
                   ->setDistance(10);

// Create a shape (drawing #2)
echo date('H:i:s') . ' Create a shape (drawing #2)'.EOL;
$shape = $currentGroup->createDrawingShape();
$shape->setName('PHPPresentation logo 2')
      ->setDescription('PHPPresentation logo 2')
      ->setPath('./resources/phppowerpoint_logo.gif')
      ->setHeight(36)
      ->setOffsetX(600)
      ->setOffsetY(200);
$shape->getShadow()->setVisible(true)
                   ->setDirection(45)
                   ->setDistance(10);

// Save file
echo write($objPHPPresentation, basename(__FILE__, '.php'), $writers);
if (!CLI) {
	include_once 'Sample_Footer.php';
}
```