### PR TITLE
Remove % signs from PptCharts to fix chart generation. Fixes #452

### DIFF
--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -105,7 +105,7 @@ class PptCharts extends AbstractDecoratorWriter
 
         // c:hPercent
         $hPercent = $chart->getView3D()->getHeightPercent();
-        $objWriter->writeElementIf($hPercent != null, 'c:hPercent', 'val', $hPercent . '%');
+        $objWriter->writeElementIf($hPercent != null, 'c:hPercent', 'val', $hPercent);
 
         // c:rotY
         $objWriter->startElement('c:rotY');
@@ -2322,7 +2322,7 @@ class PptCharts extends AbstractDecoratorWriter
 
             // c:lblOffset
             $objWriter->startElement('c:lblOffset');
-            $objWriter->writeAttribute('val', '100%');
+            $objWriter->writeAttribute('val', '100');
             $objWriter->endElement();
         }
 

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -988,7 +988,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:view3D/c:hPercent';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'val', '100%');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'val', '100');
 
         $oShape->getView3D()->setHeightPercent(null);
         $this->resetPresentationFile();

--- a/tests/resources/schema/ooxml/dml-chart.xsd
+++ b/tests/resources/schema/ooxml/dml-chart.xsd
@@ -194,7 +194,7 @@
     <xsd:attribute name="val" type="ST_RotX" default="0"/>
   </xsd:complexType>
   <xsd:simpleType name="ST_HPercent">
-    <xsd:union memberTypes="ST_HPercentWithSymbol"/>
+    <xsd:union memberTypes="ST_HPercentWithSymbol xsd:unsignedShort"/>
   </xsd:simpleType>
   <xsd:simpleType name="ST_HPercentWithSymbol">
     <xsd:restriction base="xsd:string">
@@ -202,7 +202,7 @@
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:complexType name="CT_HPercent">
-    <xsd:attribute name="val" type="ST_HPercent" default="100%"/>
+    <xsd:attribute name="val" type="ST_HPercent" default="100"/>
   </xsd:complexType>
   <xsd:simpleType name="ST_RotY">
     <xsd:restriction base="xsd:unsignedShort">
@@ -1164,7 +1164,7 @@
     </xsd:sequence>
   </xsd:complexType>
   <xsd:simpleType name="ST_LblOffset">
-    <xsd:union memberTypes="ST_LblOffsetPercent"/>
+    <xsd:union memberTypes="ST_LblOffsetPercent xsd:unsignedShort"/>
   </xsd:simpleType>
   <xsd:simpleType name="ST_LblOffsetPercent">
     <xsd:restriction base="xsd:string">
@@ -1172,7 +1172,7 @@
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:complexType name="CT_LblOffset">
-    <xsd:attribute name="val" type="ST_LblOffset" default="100%"/>
+    <xsd:attribute name="val" type="ST_LblOffset" default="100"/>
   </xsd:complexType>
   <xsd:group name="EG_AxShared">
     <xsd:sequence>


### PR DESCRIPTION
I have removed two instances of % signs in PptCharts which cause presentations with charts to be corrupted on newer versions of Powerpoint. I have also updated the test suite to match. 

However I am unsure if the changes I've made to the test schema are acceptable. Please let me know and I can updated.

Fixes issue #452 and possibly a couple others.