### PR TITLE
Use proper name for `ext-gd`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "codeclimate/php-test-reporter": "dev-master"
     },
     "suggest": {
-        "ext-gd2": "Required to add images"
+        "ext-gd": "Required to add images"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`ext-gd2` is  not recognized by composer and should instead be `ext-gd`.