### PR TITLE
PowerPoint2007 Reader : Load images in their initial format (and not by default in PNG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PhpOffice\PhpPresentation\Style\Color : Define only the transparency - @Progi1984 GH-370
 - PowerPoint2007 Reader : Background Color based on SchemeColor - @Progi1984 GH-397
 - PowerPoint2007 Reader : Support for hyperlinks under pictures - @ulziibuyan
+- PowerPoint2007 Reader : Load images in their initial format (and not by default in PNG) - @polidog GH-553
 
 ### Features
 - ODPresentation Writer : Support for the position of Legend - @Progi1984 GH-355

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -761,6 +761,9 @@ class PowerPoint2007 implements ReaderInterface
                 $pathImage = implode('/', $pathImage);
                 $imageFile = $this->oZip->getFromName($pathImage);
                 if (!empty($imageFile)) {
+                    $info = getimagesizefromstring($imageFile);
+                    $oShape->setMimeType($info['mime']);
+                    $oShape->setRenderingFunction(str_replace('/', '', $info['mime']));
                     $oShape->setImageResource(imagecreatefromstring($imageFile));
                 }
             }


### PR DESCRIPTION
Load PowerPoint 2007 images converted all files to png.
It's only default used.
I'm changed mimeType and renderingFunction.
