### PR TITLE
Defining width & height of a shape don't return any error if width & height were equal to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfix
 - PowerPoint2007 : Text is subscripted when set superscript to false - @qmachard GH-360
+- Core : Defining width & height of a shape don't return any error if width & height were equal to 0 - @surger GH-555
 
 ### Changes
 - Dropped support for HHVM - @sunspikes GH-556

--- a/src/PhpPresentation/Shape/AbstractGraphic.php
+++ b/src/PhpPresentation/Shape/AbstractGraphic.php
@@ -177,7 +177,7 @@ abstract class AbstractGraphic extends AbstractShape implements ComparableInterf
     public function setHeight($pValue = 0)
     {
         // Resize proportional?
-        if ($this->resizeProportional && $pValue != 0) {
+        if ($this->resizeProportional && $pValue != 0 && $this->height != 0) {
             $ratio        = $this->width / $this->height;
             $this->width = (int) round($ratio * $pValue);
         }

--- a/src/PhpPresentation/Shape/AbstractGraphic.php
+++ b/src/PhpPresentation/Shape/AbstractGraphic.php
@@ -157,7 +157,7 @@ abstract class AbstractGraphic extends AbstractShape implements ComparableInterf
     public function setWidth($pValue = 0)
     {
         // Resize proportional?
-        if ($this->resizeProportional && $pValue != 0) {
+        if ($this->resizeProportional && $pValue != 0 && $this->width != 0) {
             $ratio         = $this->height / $this->width;
             $this->height = (int) round($ratio * $pValue);
         }


### PR DESCRIPTION
Add zero check before divizion