### PR TITLE
Fix travis composer install memory exhaustion issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 before_script:
   ## Composer
   - composer self-update
-  - composer install --prefer-source
+  - COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-source
   ## PHPDocumentor
   - mkdir -p build/docs
   - mkdir -p build/coverage


### PR DESCRIPTION
fix all PHP5 travis builds erroring while composer install memory exhaustion