### PR TITLE
Change samples to run without composer installation (with your own installation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,4 @@ vendor
 /samples/Sample_00_Test.php
 /samples/#*
 /samples/Github_*.*
-/samples/results
 /composer.lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# This is forked repo from PHPOffice/PHPPresentation
-<br>
-
 # ![PHPPresentation](https://raw.githubusercontent.com/mvargasmoran/PHPPresentation/develop/docs/images/PHPPresentationLogo.png "PHPPresentation")
 
 [![Latest Stable Version](https://poser.pugx.org/phpoffice/phppresentation/v/stable.png)](https://packagist.org/packages/phpoffice/phppresentation)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# This is forked repo from PHPOffice/PHPPresentation
+<br>
+
 # ![PHPPresentation](https://raw.githubusercontent.com/mvargasmoran/PHPPresentation/develop/docs/images/PHPPresentationLogo.png "PHPPresentation")
 
 [![Latest Stable Version](https://poser.pugx.org/phpoffice/phppresentation/v/stable.png)](https://packagist.org/packages/phpoffice/phppresentation)

--- a/samples/Sample_Header.php
+++ b/samples/Sample_Header.php
@@ -29,7 +29,12 @@ Autoloader::register();
 if (is_file(__DIR__. '/../../../../vendor/autoload.php')) {
     require_once __DIR__ . '/../../../../vendor/autoload.php';
 } else {
-    throw new Exception ('Can not find the vendor folder!');
+    if (is_file(__DIR__. '/../../Common/src/Common/Autoloader.php')) {
+        include_once __DIR__ . '/../../Common/src/Common/Autoloader.php';
+        \PhpOffice\Common\Autoloader::register();
+    } else {
+        throw new Exception ('Can not find the vendor or the common folder!');
+    }
 }
 // do some checks to make sure the outputs are set correctly.
 if (is_dir(__DIR__.DIRECTORY_SEPARATOR.'results') === FALSE) {

--- a/samples/results/readme.md
+++ b/samples/results/readme.md
@@ -1,0 +1,1 @@
+results folder for samples


### PR DESCRIPTION
1. Now samples run only if PHPPresentation was installed with composer. So its look if vendor directory is exists.
Change the samples to run when PHPPresentation was installed without composer (with your own installation).

Then was downloaded PHPOffice/Common release from its releases page and unpack to PHPOffice directory. So directory structure must be:
<pre>
PHPOffice
    Common   <-- PHPOffice/Common release
        src
            Common
    PHPPresentation    <-- PHPOffice/PHPPresentation release
        samples
        src
</pre>

2. Added results folder to samples folder such as samples don't running without results folder.