### PR TITLE
Update DocumentLayout.php

### DIFF
--- a/src/PhpPresentation/DocumentLayout.php
+++ b/src/PhpPresentation/DocumentLayout.php
@@ -129,6 +129,7 @@ class DocumentLayout
                 $this->dimensionY = $this->dimension[$this->layout]['cy'];
                 break;
             case self::LAYOUT_CUSTOM:
+                break;
             default:
                 $this->layout = self::LAYOUT_CUSTOM;
                 $this->dimensionX = $pValue['cx'];


### PR DESCRIPTION
自定义幻灯片宽高的时候设定会报错，添加跳出机制后就会避免掉

Translate : 
> Setting the custom slide width and height will report an error, adding a pop-up mechanism will avoid it.