### PR TITLE
Change Bar Chart overlap attribute when group stacking

### DIFF
--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -980,7 +980,7 @@ class PptCharts extends AbstractDecoratorWriter
         if ($barGrouping === Bar::GROUPING_CLUSTERED) {
             $objWriter->writeAttribute('val', '0');
         } elseif ($barGrouping === Bar::GROUPING_STACKED || $barGrouping === Bar::GROUPING_PERCENTSTACKED) {
-            $objWriter->writeAttribute('val', '100000');
+            $objWriter->writeAttribute('val', '100');
         }
         $objWriter->endElement();
 


### PR DESCRIPTION
Changing the overlap attribute to 100 fixes issue where PowerPoint requires a repair when trying to do group stacking.