### PR TITLE
Allow PowerPoint Line and Scatter types to set lines smooth

### DIFF
--- a/src/PhpPresentation/Shape/Chart/Type/AbstractTypeLine.php
+++ b/src/PhpPresentation/Shape/Chart/Type/AbstractTypeLine.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPPresentation
+ * @copyright   2009-2015 PHPPresentation contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpPresentation\Shape\Chart\Type;
+
+use PhpOffice\PhpPresentation\ComparableInterface;
+
+/**
+ * \PhpOffice\PhpPresentation\Shape\Chart\Type\Line
+ */
+abstract class AbstractTypeLine extends AbstractType implements ComparableInterface
+{
+	/**
+	* Is Line Smooth?
+	* @var boolean 
+	*/
+   protected $isSmooth = false;
+   
+	/**
+	* Is Line Smooth?
+	*
+	* @return boolean
+	*/
+   public function getIsSmooth(){
+	   return $this->isSmooth;
+   }
+   
+    /**
+    * Set Line Smoothness
+    *
+    * @param  boolean $value
+    * @return $this
+    */
+    public function setIsSmooth($value = true)
+    {
+        $this->isSmooth = $value;
+        return $this;
+    }
+   
+   
+}

--- a/src/PhpPresentation/Shape/Chart/Type/Line.php
+++ b/src/PhpPresentation/Shape/Chart/Type/Line.php
@@ -22,7 +22,7 @@ use PhpOffice\PhpPresentation\ComparableInterface;
 /**
  * \PhpOffice\PhpPresentation\Shape\Chart\Type\Line
  */
-class Line extends AbstractType implements ComparableInterface
+class Line extends AbstractTypeLine implements ComparableInterface
 {
     /**
      * Get hash code

--- a/src/PhpPresentation/Shape/Chart/Type/Scatter.php
+++ b/src/PhpPresentation/Shape/Chart/Type/Scatter.php
@@ -22,8 +22,9 @@ use PhpOffice\PhpPresentation\ComparableInterface;
 /**
  * \PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter
  */
-class Scatter extends AbstractType implements ComparableInterface
+class Scatter extends AbstractTypeLine implements ComparableInterface
 {
+	
     /**
      * Get hash code
      *

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -980,7 +980,7 @@ class PptCharts extends AbstractDecoratorWriter
         if ($barGrouping === Bar::GROUPING_CLUSTERED) {
             $objWriter->writeAttribute('val', '0');
         } elseif ($barGrouping === Bar::GROUPING_STACKED || $barGrouping === Bar::GROUPING_PERCENTSTACKED) {
-            $objWriter->writeAttribute('val', '100000');
+            $objWriter->writeAttribute('val', '100');
         }
         $objWriter->endElement();
 
@@ -1820,6 +1820,11 @@ class PptCharts extends AbstractDecoratorWriter
             $coords = ($includeSheet ? 'Sheet1!$' . \PHPExcel_Cell::stringFromColumnIndex($seriesIndex + 1) . '$2:$' . \PHPExcel_Cell::stringFromColumnIndex($seriesIndex + 1) . '$' . (1 + count($axisYData)) : '');
             $this->writeMultipleValuesOrReference($objWriter, $includeSheet, $axisYData, $coords);
             $objWriter->endElement();
+			
+			// c:smooth
+			$objWriter->startElement('c:smooth');
+			$objWriter->writeAttribute('val', $subject->getIsSmooth() ? '1' : '0');
+			$objWriter->endElement();
 
             $objWriter->endElement();
 
@@ -1830,12 +1835,7 @@ class PptCharts extends AbstractDecoratorWriter
         $objWriter->startElement('c:marker');
         $objWriter->writeAttribute('val', '1');
         $objWriter->endElement();
-
-        // c:smooth
-        $objWriter->startElement('c:smooth');
-        $objWriter->writeAttribute('val', '0');
-        $objWriter->endElement();
-
+		
         // c:axId
         $objWriter->startElement('c:axId');
         $objWriter->writeAttribute('val', '52743552');
@@ -1845,7 +1845,8 @@ class PptCharts extends AbstractDecoratorWriter
         $objWriter->startElement('c:axId');
         $objWriter->writeAttribute('val', '52749440');
         $objWriter->endElement();
-
+		
+		
         $objWriter->endElement();
     }
 
@@ -2007,7 +2008,7 @@ class PptCharts extends AbstractDecoratorWriter
 
             // c:smooth
             $objWriter->startElement('c:smooth');
-            $objWriter->writeAttribute('val', '0');
+            $objWriter->writeAttribute('val', $subject->getIsSmooth() ? '1' : '0');
             $objWriter->endElement();
 
             $objWriter->endElement();


### PR DESCRIPTION
The option is set on all series within the Line or Scatter Type.