### PR TITLE
Set rels index for slide layouts

### DIFF
--- a/src/PhpPresentation/Writer/PowerPoint2007/ContentTypes.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/ContentTypes.php
@@ -73,6 +73,7 @@ class ContentTypes extends AbstractDecoratorWriter
             $this->writeOverrideContentType($objWriter, '/ppt/theme/theme' . $oSlideMaster->getRelsIndex() . '.xml', 'application/vnd.openxmlformats-officedocument.theme+xml');
             foreach ($oSlideMaster->getAllSlideLayouts() as $oSlideLayout) {
                 $oSlideLayout->layoutNr = ++$sldLayoutNr;
+                $oSlideLayout->setRelsIndex((string) $oSlideLayout->layoutNr);
                 $oSlideLayout->layoutId = ++$sldLayoutId;
                 $this->writeOverrideContentType($objWriter, '/ppt/slideLayouts/slideLayout' . $oSlideLayout->layoutNr . '.xml', 'application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml');
             }


### PR DESCRIPTION
Due to the change https://github.com/PHPOffice/PHPPresentation/pull/637 we get an error with SlideLayouts:

`PhpOffice\PhpPresentation\Slide\AbstractSlide::getRelsIndex(): Return value must be of type string, null returned.`

It seems that `relsIndex` is not set for SlideLayouts and remains null. By adjusting the return type it does not work now. The method is used in:

`PhpOffice\PhpPresentation\Writer\PowerPoint2007\PptSlideLayouts::67`

It can be fixed by setting `relsIndex` in 

`PhpOffice\PhpPresentation\Writer\PowerPoint2007\ContentTypes::75`