### PR TITLE
Fix issue when first element in series is null

### DIFF
--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -338,7 +338,16 @@ class PptCharts extends AbstractDecoratorWriter
         // c:strLit / c:numLit
         // c:strRef / c:numRef
         $referenceType = ($isReference ? 'Ref' : 'Lit');
-        $dataType = is_numeric($values[0]) ? 'num' : 'str';
+        
+        // get data type from first non-null value
+        $dataType = null;
+        foreach($values as $value){
+            if ( !isset($value) ){
+                continue;
+            }
+            $dataType = is_numeric($value) ? 'num' : 'str';
+        }
+        
         $objWriter->startElement('c:' . $dataType . $referenceType);
 
         $numValues = count($values);

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -340,7 +340,7 @@ class PptCharts extends AbstractDecoratorWriter
         $referenceType = ($isReference ? 'Ref' : 'Lit');
         
         // get data type from first non-null value
-        $dataType = null;
+        $dataType = 'num';
         foreach($values as $value){
             if ( !isset($value) ){
                 continue;


### PR DESCRIPTION
Creating charts fail when the first element of a series is null. This fix will check the data type of a series based on the first non-null element of the list rather than the first element.