### PR TITLE
Fix: Hyperlink text color for PowerPoint2007 writer

### DIFF
--- a/docs/changes/1.0.0.md
+++ b/docs/changes/1.0.0.md
@@ -1,9 +1,9 @@
-# 1.0.0 - WIP
+# 1.0.0
 
 ## Bugfix
-- PowerPoint2007 Writer : Text is subscripted when set superscript to false - [[@qmachard]](https://github.com/qmachard])(https://github.com/qmachard) GH-360
-- Core : Defining width & height of a shape don't return any error if width & height were equal to 0 - [[@surger]](https://github.com/surger])(https://github.com/surger) GH-555
-- ODPresentation Writer : Display axis title depending the visibility - [[@Progi1984]](https://github.com/Progi1984])(https://github.com/Progi1984) GH-410
+- PowerPoint2007 Writer : Text is subscripted when set superscript to false - [@qmachard](https://github.com/qmachard) GH-360
+- Core : Defining width & height of a shape don't return any error if width & height were equal to 0 - [@surger](https://github.com/surger) GH-555
+- ODPresentation Writer : Display axis title depending the visibility - [@Progi1984](https://github.com/Progi1984) GH-410
 
 ## Changes
 - Dropped support for HHVM - [@sunspikes](https://github.com/sunspikes) GH-556

--- a/docs/changes/1.1.0.md
+++ b/docs/changes/1.1.0.md
@@ -1,0 +1,7 @@
+# 1.0.0 - WIP
+
+## Features
+
+- Support for Hyperlink Text Color - [@MartynasJanu](https://github.com/MartynasJanu) & [@Progi1984](https://github.com/Progi1984) GH-682
+    - PowerPoint2007 Reader
+    - PowerPoint2007 Writer

--- a/docs/usage/shapes/richtext.md
+++ b/docs/usage/shapes/richtext.md
@@ -50,6 +50,42 @@ $richText->setColumnSpacing(200);
 $columnSpacing = $richText->getColumnSpacing();
 ```
 
+## Hyperlink
+
+For a rich text, you can define the hyperlink.
+
+Example:
+
+```php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\RichText;
+
+$richText = new RichText();
+$richText->getHyperlink()->setUrl('https://phpoffice.github.io/PHPPresentation/');
+
+```
+
+### Use of Text Color
+
+!!! warning
+    Available only on the PowerPoint2007 Reader/Writer
+
+Hyperlinks can be set to use the text color instead of the default theme color.
+
+Example:
+
+```php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\RichText;
+
+$richText = new RichText();
+$richText->getHyperlink()->setUrl('https://phpoffice.github.io/PHPPresentation/');
+$richText->getHyperlink()->setIsTextColorUsed(true);
+
+```
+
 ## Paragraph
 ### Bullet
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,8 @@ nav:
   - FAQ: 'faq.md'
   - Credits: 'credits.md'
   - Releases:
-      - '1.0.0 (WIP)': 'changes/1.0.0.md'
+      - '1.1.0 (WIP)': 'changes/1.1.0.md'
+      - '1.0.0': 'changes/1.0.0.md'
       - '0.9.0': 'changes/0.9.0.md'
       - '0.8.0': 'changes/0.8.0.md'
       - '0.7.0': 'changes/0.7.0.md'

--- a/src/PhpPresentation/Shape/Hyperlink.php
+++ b/src/PhpPresentation/Shape/Hyperlink.php
@@ -61,6 +61,13 @@ class Hyperlink
     private $hashIndex;
 
     /**
+     * If true, uses the text color, instead of theme color
+     *
+     * @var bool
+     */
+    private $useTextColor = false;
+
+    /**
      * Create a new \PhpOffice\PhpPresentation\Shape\Hyperlink.
      *
      * @param string $pUrl Url to link the shape to
@@ -192,6 +199,34 @@ class Hyperlink
     public function setHashIndex(int $value)
     {
         $this->hashIndex = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get whether or not to use text color for a hyperlink, instead of theme color.
+     *
+     * @see https://docs.microsoft.com/en-us/openspecs/office_standards/ms-odrawxml/014fbc20-3705-4812-b8cd-93f5af05b504
+     *
+     * @return bool Whether or not to use text color for a hyperlink, instead of theme color.
+     */
+    public function getUseTextColor(): bool
+    {
+        return $this->useTextColor;
+    }
+
+    /**
+     * Set whether or not to use text color for a hyperlink, instead of theme color.
+     *
+     * @see https://docs.microsoft.com/en-us/openspecs/office_standards/ms-odrawxml/014fbc20-3705-4812-b8cd-93f5af05b504
+     *
+     * @param bool $useTextColor
+     *
+     * @return self
+     */
+    public function setUseTextColor(bool $useTextColor): self
+    {
+        $this->useTextColor = $useTextColor;
 
         return $this;
     }

--- a/src/PhpPresentation/Shape/Hyperlink.php
+++ b/src/PhpPresentation/Shape/Hyperlink.php
@@ -207,7 +207,7 @@ class Hyperlink
      *
      * @see https://docs.microsoft.com/en-us/openspecs/office_standards/ms-odrawxml/014fbc20-3705-4812-b8cd-93f5af05b504
      *
-     * @return bool Whether or not to use text color for a hyperlink, instead of theme color.
+     * @return bool whether or not to use text color for a hyperlink, instead of theme color
      */
     public function isTextColorUsed(): bool
     {

--- a/src/PhpPresentation/Shape/Hyperlink.php
+++ b/src/PhpPresentation/Shape/Hyperlink.php
@@ -65,7 +65,7 @@ class Hyperlink
      *
      * @var bool
      */
-    private $useTextColor = false;
+    private $isTextColorUsed = false;
 
     /**
      * Create a new \PhpOffice\PhpPresentation\Shape\Hyperlink.
@@ -75,7 +75,6 @@ class Hyperlink
      */
     public function __construct(string $pUrl = '', string $pTooltip = '')
     {
-        // Initialise member variables
         $this->setUrl($pUrl);
         $this->setTooltip($pTooltip);
     }
@@ -210,9 +209,9 @@ class Hyperlink
      *
      * @return bool Whether or not to use text color for a hyperlink, instead of theme color.
      */
-    public function getUseTextColor(): bool
+    public function isTextColorUsed(): bool
     {
-        return $this->useTextColor;
+        return $this->isTextColorUsed;
     }
 
     /**
@@ -220,13 +219,13 @@ class Hyperlink
      *
      * @see https://docs.microsoft.com/en-us/openspecs/office_standards/ms-odrawxml/014fbc20-3705-4812-b8cd-93f5af05b504
      *
-     * @param bool $useTextColor
+     * @param bool $isTextColorUsed
      *
      * @return self
      */
-    public function setUseTextColor(bool $useTextColor): self
+    public function setIsTextColorUsed(bool $isTextColorUsed): self
     {
-        $this->useTextColor = $useTextColor;
+        $this->isTextColorUsed = $isTextColorUsed;
 
         return $this;
     }

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -788,6 +788,19 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         if ($shape->getHyperlink()->isInternal()) {
             $objWriter->writeAttribute('action', $shape->getHyperlink()->getUrl());
         }
+
+        if ($shape->getHyperlink()->getUseTextColor()) {
+            $objWriter->startElement('a:extLst');
+            $objWriter->startElement('a:ext');
+            $objWriter->writeAttribute('uri', '{A12FA001-AC4F-418D-AE19-62706E023703}');
+            $objWriter->startElement('ahyp:hlinkClr');
+            $objWriter->writeAttribute('xmlns:ahyp', 'http://schemas.microsoft.com/office/drawing/2018/hyperlinkcolor');
+            $objWriter->writeAttribute('val', 'tx');
+            $objWriter->endElement();
+            $objWriter->endElement();
+            $objWriter->endElement();
+        }
+
         $objWriter->endElement();
     }
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -789,7 +789,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
             $objWriter->writeAttribute('action', $shape->getHyperlink()->getUrl());
         }
 
-        if ($shape->getHyperlink()->getUseTextColor()) {
+        if ($shape->getHyperlink()->isTextColorUsed()) {
             $objWriter->startElement('a:extLst');
             $objWriter->startElement('a:ext');
             $objWriter->writeAttribute('uri', '{A12FA001-AC4F-418D-AE19-62706E023703}');

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -568,6 +568,7 @@ class PowerPoint2007Test extends TestCase
         $this->assertTrue($oRichText->hasHyperlink());
         $this->assertEquals('https://github.com/PHPOffice/PHPPresentation/', $oRichText->getHyperlink()->getUrl());
         $this->assertEquals('PHPPresentation', $oRichText->getHyperlink()->getTooltip());
+        $this->assertFalse($oRichText->getHyperlink()->isTextColorUsed());
         $this->assertEquals('Calibri', $oRichText->getFont()->getName());
         $this->assertEquals(Font::FORMAT_LATIN, $oRichText->getFont()->getFormat());
     }

--- a/tests/PhpPresentation/Tests/Shape/HyperlinkTest.php
+++ b/tests/PhpPresentation/Tests/Shape/HyperlinkTest.php
@@ -121,4 +121,16 @@ class HyperlinkTest extends TestCase
         $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Hyperlink', $object->setUrl('http://www.github.com'));
         $this->assertFalse($object->isInternal());
     }
+
+    public function testIsTextColorUsed(): void
+    {
+        $object = new Hyperlink();
+        $this->assertFalse($object->isTextColorUsed());
+
+        $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Hyperlink', $object->setIsTextColorUsed(true));
+        $this->assertTrue($object->isTextColorUsed());
+
+        $this->assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Hyperlink', $object->setIsTextColorUsed(false));
+        $this->assertFalse($object->isTextColorUsed());
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -452,6 +452,36 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testHyperlinkTextColorUsed(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oRichText = $oSlide->createRichTextShape();
+        $oRun = $oRichText->createTextRun('Delta');
+        $oRun->getHyperlink()->setIsTextColorUsed(true);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:hlinkClick';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:hlinkClick/a:extLst';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:hlinkClick/a:extLst/a:ext';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'uri', '{A12FA001-AC4F-418D-AE19-62706E023703}');
+
+        $this->assertIsSchemaECMA376Valid();
+
+        $this->resetPresentationFile();
+
+        $oRun->getHyperlink()->setIsTextColorUsed(false);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:hlinkClick';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:hlinkClick/a:extLst';
+        $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $element);
+    }
+
     public function testListBullet(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();


### PR DESCRIPTION
Hyperlinks can now be set to use the text color instead of the default theme color. This way it becomes possible to actually set the hyperlink color when using PowerPoint2007 writer.

Fixes #541
```
$textRun->getHyperlink()->setUrl($url);
$textRun->getHyperlink()->setUseTextColor(true);
```