### PR TITLE
Improve Group shape to allow moving all contained shapes at once.

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -5,6 +5,7 @@
 ## Enhancements
 
 - `phpoffice/phpspreadsheet`: Allow version 1.9 or 2.0 by [@Progi1984](https://github.com/Progi1984) fixing [#790](https://github.com/PHPOffice/PHPPresentation/pull/790), [#812](https://github.com/PHPOffice/PHPPresentation/pull/812) in [#816](https://github.com/PHPOffice/PHPPresentation/pull/816)
+- Group Shape: moving the shape now moves all contained shapes. Offsets and size are calculated based on the contained shapes by [@DennisBirkholz](https://github.com/DennisBirkholz) in [#690](https://github.com/PHPOffice/PHPPresentation/pull/690)
 
 ## Bug fixes
 

--- a/tests/PhpPresentation/Tests/Shape/GroupTest.php
+++ b/tests/PhpPresentation/Tests/Shape/GroupTest.php
@@ -79,10 +79,10 @@ class GroupTest extends TestCase
         $line1 = new Line(10, 20, 30, 50);
         $object->addShape($line1);
 
-        self::assertEquals(10, $object->getOffsetX());
+        self::assertEquals($line1->getOffsetX(), $object->getOffsetX());
 
-        self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Group', $object->setOffsetX(mt_rand(1, 100)));
-        self::assertEquals(10, $object->getOffsetX());
+        self::assertInstanceOf(Group::class, $object->setOffsetX(mt_rand(1, 100)));
+        self::assertEquals($line1->getOffsetX(), $object->getOffsetX());
     }
 
     public function testOffsetY(): void
@@ -91,10 +91,10 @@ class GroupTest extends TestCase
         $line1 = new Line(10, 20, 30, 50);
         $object->addShape($line1);
 
-        self::assertEquals(20, $object->getOffsetY());
+        self::assertEquals($line1->getOffsetY(), $object->getOffsetY());
 
-        self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\Group', $object->setOffsetY(mt_rand(1, 100)));
-        self::assertEquals(20, $object->getOffsetY());
+        self::assertInstanceOf(Group::class, $object->setOffsetY(mt_rand(1, 100)));
+        self::assertEquals($line1->getOffsetY(), $object->getOffsetY());
     }
 
     public function testExtentsAndOffsetsForOneShape(): void


### PR DESCRIPTION
This pull requests modifies the Group container shape so moving it around moves all contained shapes with it.
To make this work reliably all offsets, extents and dimensions are calculated based on the contained shapes and not cached anymore.
I also fixed the Group writing part in the PowerPoint2007 writer which used the extentX/Y methods to get the width and height. (The XML nodes/attributes are named really misleading here)

Thank you for considering this contribution and thank you for your work!