### PR TITLE
fix for loadMasterSlide

### DIFF
--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -557,7 +557,7 @@ class PowerPoint2007 implements ReaderInterface
                     $oElementLvlDefRPR = $xmlReader->getElement('a:defRPr', $oElementLvl);
                     if ($oElementLvlDefRPR instanceof DOMElement) {
                         if ($oElementLvlDefRPR->hasAttribute('sz')) {
-                            $oRTParagraph->getFont()->setSize($oElementLvlDefRPR->getAttribute('sz') / 100);
+                            $oRTParagraph->getFont()->setSize((int) ($oElementLvlDefRPR->getAttribute('sz') / 100));
                         }
                         if ($oElementLvlDefRPR->hasAttribute('b') && 1 == $oElementLvlDefRPR->getAttribute('b')) {
                             $oRTParagraph->getFont()->setBold(true);


### PR DESCRIPTION
in the method loadMasterSlide was a call to Font::setSize which expects an integer
while the call passed a float which resulted in an TypeError