### PR TITLE
PowerPoint2077 Writer : Fixed error when defining min/max bounds to 0

### DIFF
--- a/docs/changes/1.1.0.md
+++ b/docs/changes/1.1.0.md
@@ -14,4 +14,5 @@
 ## Bugfixes
 
 - Fixed CI - [@Progi1984](https://github.com/Progi1984) in [#766](https://github.com/PHPOffice/PHPPresentation/pull/766)
-- Fixed broken PPT Presentations due to MS Office update 2309 - [@WFarmerEthisphere](https://github.com/WFarmerEthisphere) in [#770](https://github.com/PHPOffice/PHPPresentation/pull/770)
+- PowerPoint2077 Writer : Fixed broken PPT Presentations due to MS Office update 2309 - [@WFarmerEthisphere](https://github.com/WFarmerEthisphere) in [#770](https://github.com/PHPOffice/PHPPresentation/pull/770)
+- PowerPoint2077 Writer : Fixed error when defining min/max bounds to 0 - [@LilyEssence](https://github.com/LilyEssence) in [#771](https://github.com/PHPOffice/PHPPresentation/pull/771)

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -2284,13 +2284,13 @@ class PptCharts extends AbstractDecoratorWriter
         $objWriter->writeAttribute('val', $orientation);
         $objWriter->endElement();
 
-        if (null != $oAxis->getMaxBounds()) {
+        if (null !== $oAxis->getMaxBounds()) {
             $objWriter->startElement('c:max');
             $objWriter->writeAttribute('val', $oAxis->getMaxBounds());
             $objWriter->endElement();
         }
 
-        if (null != $oAxis->getMinBounds()) {
+        if (null !== $oAxis->getMinBounds()) {
             $objWriter->startElement('c:min');
             $objWriter->writeAttribute('val', $oAxis->getMinBounds());
             $objWriter->endElement();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -275,6 +275,56 @@ class PptChartsTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testAxisBoundsIfZero(): void
+    {
+        $value = 0;
+
+        $oSeries = new Series('Downloads', $this->seriesData);
+        $oSeries->getFill()->setStartColor(new Color('FFAABBCC'));
+        $oLine = new Line();
+        $oLine->addSeries($oSeries);
+        $oShape = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oShape->getPlotArea()->setType($oLine);
+
+        $elementMax = '/c:chartSpace/c:chart/c:plotArea/c:catAx/c:scaling/c:max';
+        $elementMin = '/c:chartSpace/c:chart/c:plotArea/c:catAx/c:scaling/c:min';
+
+        $this->assertZipXmlElementNotExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMax);
+        $this->assertZipXmlElementNotExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMin);
+
+        $this->assertIsSchemaECMA376Valid();
+
+        $oShape->getPlotArea()->getAxisX()->setMinBounds($value);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementNotExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMax);
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMin);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $elementMin, 'val', $value);
+
+        $this->assertIsSchemaECMA376Valid();
+
+        $oShape->getPlotArea()->getAxisX()->setMinBounds(null);
+        $oShape->getPlotArea()->getAxisX()->setMaxBounds($value);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementNotExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMin);
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMax);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $elementMax, 'val', $value);
+
+        $this->assertIsSchemaECMA376Valid();
+
+        $oShape->getPlotArea()->getAxisX()->setMinBounds($value);
+        $oShape->getPlotArea()->getAxisX()->setMaxBounds($value);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMin);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $elementMin, 'val', $value);
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $elementMax);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $elementMax, 'val', $value);
+
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testAxisCrosses(): void
     {
         $oSeries = new Series('Downloads', $this->seriesData);


### PR DESCRIPTION
Superseeds #754 by @LilyEssence 