### PR TITLE
PowerPoint2007 Writer : Fixed broken video file relationship

### DIFF
--- a/docs/changes/1.1.0.md
+++ b/docs/changes/1.1.0.md
@@ -20,6 +20,7 @@
 - PowerPoint2007 Writer : Outline : Fixed the base unit - [@Pakku](https://github.com/Pakku) in [#772](https://github.com/PHPOffice/PHPPresentation/pull/772)
 - PowerPoint2007 Writer : Fixed column indices for embedded spreadsheets - [@michael-roth](https://github.com/michael-roth) in [#773](https://github.com/PHPOffice/PHPPresentation/pull/773)
 - PowerPoint2007 Reader : Load images from file only if valid - [@aelliott1485](https://github.com/aelliott1485) in [#775](https://github.com/PHPOffice/PHPPresentation/pull/775)
+- PowerPoint2007 Writer : Fixed broken video file relationship - [@potofcoffee](https://github.com/potofcoffee) in [#776](https://github.com/PHPOffice/PHPPresentation/pull/776)
 
 ## BC Breaks
 - `PhpOffice\PhpPresentation\Style\Outline` : the width is now based on pixels (before in points)

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -1304,7 +1304,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
             $objWriter->writeAttribute('uri', '{DAA4B4D4-6D71-4841-9C94-3DE7FCFB9230}');
             // p:nvPr > p:extLst > p:ext > p14:media
             $objWriter->startElement('p14:media');
-            $objWriter->writeAttribute('r:embed', ((int) $shape->relationId + 1));
+            $objWriter->writeAttribute('r:embed', 'rId' . ((int) substr($shape->relationId, strlen('rId')) + 1));
             $objWriter->writeAttribute('xmlns:p14', 'http://schemas.microsoft.com/office/powerpoint/2010/main');
             // p:nvPr > p:extLst > p:ext > ##p14:media
             $objWriter->endElement();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -589,9 +589,14 @@ class PptSlidesTest extends PhpPresentationTestCase
 
         $element = '/p:sld/p:cSld/p:spTree/p:pic/p:nvPicPr/p:nvPr/a:videoFile';
         $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'r:link', 'rId2');
         $element = '/p:sld/p:cSld/p:spTree/p:pic/p:nvPicPr/p:nvPr/p:extLst/p:ext';
         $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'uri', '{DAA4B4D4-6D71-4841-9C94-3DE7FCFB9230}');
+        $element = '/p:sld/p:cSld/p:spTree/p:pic/p:nvPicPr/p:nvPr/p:extLst/p:ext/p14:media';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'r:embed', 'rId3');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'xmlns:p14', 'http://schemas.microsoft.com/office/powerpoint/2010/main');
 
         $this->assertIsSchemaECMA376Valid();
     }

--- a/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
+++ b/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
@@ -190,6 +190,7 @@ class PhpPresentationTestCase extends TestCase
 
         if (null === $this->xmlXPath) {
             $this->xmlXPath = new DOMXPath($this->xmlDom);
+            $this->xmlXPath->registerNamespace('p14', 'http://schemas.microsoft.com/office/powerpoint/2010/main');
         }
 
         return $this->xmlXPath->query($xpath);


### PR DESCRIPTION
This fixes the broken relationship reference for video files as described in #681. Videos will work with this patch, but no thumbnail is displayed when the videos is stopped. (This would require thumbnail creation and another relationship for the thumbnail image.)

Superseeds #697 by @potofcoffee
Fixes #681