### PR TITLE
General : Fixed copying bug when presentation had multiple slides

### DIFF
--- a/docs/changes/1.1.0.md
+++ b/docs/changes/1.1.0.md
@@ -34,6 +34,7 @@
 - PowerPoint2007 Writer : Fixed broken animation for first shape - [@shannan1989](https://github.com/shannan1989) in [#783](https://github.com/PHPOffice/PHPPresentation/pull/783)
 - Samples : Allow to run without composer - [@pal-software](https://github.com/pal-software) in [#784](https://github.com/PHPOffice/PHPPresentation/pull/784)
 - PowerPoint2007 Writer: Extract relations from nested ShapeContainerInterface objects - [@DennisBirkholz](https://github.com/DennisBirkholz) in [#785](https://github.com/PHPOffice/PHPPresentation/pull/785)
+- General : Fixed copying bug when presentation had multiple slides [@dees040](https://github.com/dees040) in [#786](https://github.com/PHPOffice/PHPPresentation/pull/786)
 
 ## Miscellaneous
 

--- a/src/PhpPresentation/PhpPresentation.php
+++ b/src/PhpPresentation/PhpPresentation.php
@@ -312,10 +312,25 @@ class PhpPresentation
         $copied = clone $this;
 
         $slideCount = count($this->slideCollection);
+
+        // Because the rebindParent() method on AbstractSlide removes the slide
+        // from the parent (current $this which we're cloning) presentation, we
+        // save the collection. This way, after the copying has finished, we can
+        // return the slides to the original presentation.
+        $oldSlideCollection = $this->slideCollection;
+        $newSlideCollection = [];
+
         for ($i = 0; $i < $slideCount; ++$i) {
-            $this->slideCollection[$i] = $this->slideCollection[$i]->copy();
-            $this->slideCollection[$i]->rebindParent($this);
+            $newSlideCollection[$i] = $oldSlideCollection[$i]->copy();
+            $newSlideCollection[$i]->rebindParent($copied);
         }
+
+        // Give the copied presentation a copied slide collection which the
+        // copied slides have been rebind to the copied presentation.
+        $copied->slideCollection = $newSlideCollection;
+
+        // Return the original slides to the original presentation.
+        $this->slideCollection = $oldSlideCollection;
 
         return $copied;
     }

--- a/tests/PhpPresentation/Tests/PhpPresentationTest.php
+++ b/tests/PhpPresentation/Tests/PhpPresentationTest.php
@@ -86,7 +86,12 @@ class PhpPresentationTest extends TestCase
     public function testCopy(): void
     {
         $object = new PhpPresentation();
-        self::assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $object->copy());
+        $object->createSlide();
+
+        $copy = $object->copy();
+
+        self::assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $copy);
+        self::assertEquals(2, $copy->getSlideCount());
     }
 
     /**


### PR DESCRIPTION
If in the original code you would add a dump of the slide collection like the example below and try to copy a presentation with three slides you'll get an exception:

> Undefined array key 2

The code:

```php
public function copy(): self
{
    $copied = clone $this;

    $slideCount = count($this->slideCollection);
    for ($i = 0; $i < $slideCount; ++$i) {
        var_dump(array_keys($this->slideCollection));

        $this->slideCollection[$i] = $this->slideCollection[$i]->copy();
        $this->slideCollection[$i]->rebindParent($this);
    }

    return $copied;
}
```

The dump output:

```
array:3 [ // vendor/phpoffice/phppresentation/src/PhpPresentation/PhpPresentation.php:325
  0 => 0
  1 => 1
  2 => 2
]
array:2 [ // vendor/phpoffice/phppresentation/src/PhpPresentation/PhpPresentation.php:325
  0 => 0
  1 => 1
]
array:1 [ // vendor/phpoffice/phppresentation/src/PhpPresentation/PhpPresentation.php:325
  0 => 0
]
```

Because of the `rebindParent()` which is being called on the copied slide, the copied presentation's original `$slideCollection` is being edited. This causes the code to break. This PR fixes that problem by saving the original `$slideCollection` before starting the slide copying process. Afterwards we set the new slide collection to the new copied presentation and also revert the original contact of the old presentation which is being copied.

I've also updated the unit test so that a presentation with multiple slides is being copied. If you test the unit test without the changes in `PhpOffice\PhpPresentation\PhpPresentation` you can also see the exception being thrown: 

> There was 1 error:
>  
> 1) PhpOffice\PhpPresentation\Tests\PhpPresentationTest::testCopy
> Error: Call to a member function copy() on null
> 
> /PHPPresentation/src/PhpPresentation/PhpPresentation.php:316
> /PHPPresentation/tests/PhpPresentation/Tests/PhpPresentationTest.php:90
> 
> ERRORS!
> Tests: 1, Assertions: 0, Errors: 1, Warnings: 2, Deprecations: 1.