### PR TITLE
Fixed fonts in the generated file after usiong a reader

### DIFF
--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -485,6 +485,8 @@ class PowerPoint2007 implements ReaderInterface
                         // Background
                         $oBackground = new Slide\Background\Image();
                         $oBackground->setPath($tmpBkgImg);
+                        $extension = pathinfo( $pathImage, PATHINFO_EXTENSION );
+                        $oBackground->setExtension($extension);
                         // Slide Background
                         $oSlide = $this->oPhpPresentation->getActiveSlide();
                         $oSlide->setBackground($oBackground);

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1312,6 +1312,13 @@ class PowerPoint2007 implements ReaderInterface
                             $this->loadHyperlink($document, $oElementHlinkClick, $oText->getHyperlink())
                         );
                     }
+
+                    $oElementFontFormatEastAsian = $document->getElement('a:ea', $oElementrPr);
+                    if (is_object($oElementFontFormatEastAsian)) {
+                        $oText->getFont()->setFormat(Font::FORMAT_EAST_ASIAN);
+                        $oElementFontFormat = $oElementFontFormatEastAsian;
+                    }
+
                     // Font
                     $oElementFontFormat = null;
                     $oElementFontFormatLatin = $document->getElement('a:latin', $oElementrPr);
@@ -1319,11 +1326,7 @@ class PowerPoint2007 implements ReaderInterface
                         $oText->getFont()->setFormat(Font::FORMAT_LATIN);
                         $oElementFontFormat = $oElementFontFormatLatin;
                     }
-                    $oElementFontFormatEastAsian = $document->getElement('a:ea', $oElementrPr);
-                    if (is_object($oElementFontFormatEastAsian)) {
-                        $oText->getFont()->setFormat(Font::FORMAT_EAST_ASIAN);
-                        $oElementFontFormat = $oElementFontFormatEastAsian;
-                    }
+
                     $oElementFontFormatComplexScript = $document->getElement('a:cs', $oElementrPr);
                     if (is_object($oElementFontFormatComplexScript)) {
                         $oText->getFont()->setFormat(Font::FORMAT_COMPLEX_SCRIPT);

--- a/src/PhpPresentation/Slide/Background/Image.php
+++ b/src/PhpPresentation/Slide/Background/Image.php
@@ -47,6 +47,11 @@ class Image extends AbstractBackground
     protected $width;
 
     /**
+     * @var string
+     */
+    protected $extension;
+
+    /**
      * Get Path.
      */
     public function getPath(): ?string
@@ -80,6 +85,19 @@ class Image extends AbstractBackground
     }
 
     /**
+     * Set Extension.
+     *
+     * @param string $pValue File Extension
+     *
+     * @return self
+     */
+    public function setExtension(string $pValue)
+    {
+        $this->extension = $pValue;
+        return $this;
+    }
+
+    /**
      * Get Filename.
      */
     public function getFilename(): string
@@ -92,9 +110,12 @@ class Image extends AbstractBackground
      */
     public function getExtension(): string
     {
+        if($this->extension){
+            return $this->extension;
+        }
         $exploded = explode('.', $this->getFilename());
-
         return $exploded[count($exploded) - 1];
+
     }
 
     /**

--- a/src/PhpPresentation/Style/Font.php
+++ b/src/PhpPresentation/Style/Font.php
@@ -214,10 +214,6 @@ class Font implements ComparableInterface
      */
     public function setPanose(string $pValue): self
     {
-        if (mb_strlen($pValue) !== 10) {
-            throw new InvalidParameterException('pValue', $pValue, 'The length is not equals to 10');
-        }
-
         $allowedChars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
         foreach (mb_str_split($pValue) as $char) {
             if (!in_array($char, $allowedChars)) {

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -677,21 +677,18 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->startElement('a:' . $element->getFont()->getFormat());
         $objWriter->writeAttribute('typeface', $element->getFont()->getName());
         if ($element->getFont()->getPanose() !== '') {
-            $panose = array_map(function (string $value) {
-                return '0' . $value;
-            }, str_split($element->getFont()->getPanose()));
-
-            $objWriter->writeAttribute('panose', implode('', $panose));
+            $objWriter->writeAttribute('panose', $element->getFont()->getPanose());
         }
         $objWriter->writeAttributeIf(
             $element->getFont()->getPitchFamily() !== 0,
             'pitchFamily',
             $element->getFont()->getPitchFamily()
         );
+        $charset = $element->getFont()->getCharset();
         $objWriter->writeAttributeIf(
             $element->getFont()->getCharset() !== Font::CHARSET_DEFAULT,
             'charset',
-            dechex($element->getFont()->getCharset())
+            $charset
         );
         $objWriter->endElement();
 

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -885,7 +885,7 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $latinElement, 'typeface');
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'typeface', 'Calibri');
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $latinElement, 'charset');
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'charset', '12');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'charset', '18');
         $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $eastAsianElement);
         $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $complexScriptElement);
         $this->assertIsSchemaECMA376Valid();
@@ -898,7 +898,7 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $eastAsianElement, 'typeface');
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $eastAsianElement, 'typeface', 'Calibri');
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $eastAsianElement, 'charset');
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $eastAsianElement, 'charset', '12');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $eastAsianElement, 'charset', '18');
         $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $complexScriptElement);
         $this->assertIsSchemaECMA376Valid();
 
@@ -911,7 +911,7 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $complexScriptElement, 'typeface');
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $complexScriptElement, 'typeface', 'Calibri');
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $complexScriptElement, 'charset');
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $complexScriptElement, 'charset', '12');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $complexScriptElement, 'charset', '18');
         $this->assertIsSchemaECMA376Valid();
     }
 


### PR DESCRIPTION
Discovered a font issue in the scenario of importing and then exporting, not sure about other scenarios. Unclear about the handling of Panose length and adding zeros, as Panose can easily exceed 10, and not very familiar with using dechex. After fixing, the font displays correctly, placing a:latin in a:ea results in the font displaying correctly after modification.