### PR TITLE
Data type is num unless one of the values is non-numeric

### DIFF
--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -348,14 +348,13 @@ class PptCharts extends AbstractDecoratorWriter
         // c:strRef / c:numRef
         $referenceType = ($isReference ? 'Ref' : 'Lit');
 
-        // Get data type from first non-null value
-        $dataType = array_reduce($values, function ($carry, $item) {
-            if (!isset($item)) {
-                return $carry;
+        // Data type is num unless one of the values is non-numeric
+        $dataType = 'num';
+        foreach ($values as $value){
+            if (!is_numeric($value)){
+                $dataType = 'str';
             }
-
-            return is_numeric($item) ? 'num' : 'str';
-        }, 'num');
+        }
 
         $objWriter->startElement('c:' . $dataType . $referenceType);
 


### PR DESCRIPTION
What:
- only set datatype to 'str' if one of the values is non-numeric

Why:
- if the first value is numeric, but the later values are not, for example ['1', 'FOO'], the entry will be set to numlit, but since the second entry is not a numeric, the ppt fails to open and requires repair.
- The value should be set to 'strlit' if any of the values are non-numeric.