### PR TITLE
fix: expected int but got float error in reading Powerpoint presenation

### DIFF
--- a/src/PhpPresentation/Shape/RichText/Paragraph.php
+++ b/src/PhpPresentation/Shape/RichText/Paragraph.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHPPresentation - A pure PHP library for reading and writing
  * presentations documents.
@@ -355,9 +356,9 @@ class Paragraph implements ComparableInterface
     /**
      * Value in points.
      */
-    public function setSpacingBefore(int $spacingBefore): self
+    public function setSpacingBefore(float $spacingBefore): self
     {
-        $this->spacingBefore = $spacingBefore;
+        $this->spacingBefore = (int)$spacingBefore;
 
         return $this;
     }


### PR DESCRIPTION
fix of this error:
PhpOffice\PhpPresentation\Shape\RichText\Paragraph::setSpacingBefore(): Argu
ment #1 ($spacingBefore) must be of type int, float given, called in ...\vendor\phpoffice\phppresentation\src\PhpPresentation\Reader\Powe
rPoint2007.php on line 1129 and defined in ...vendor\phpoffice\phppresentation\src\PhpPresentation\Shape\RichText\Paragraph.php:367     
Stack trace:
#0 ...\vendor\phpoffice
\phppresentation\src\PhpPresentation\Reader\PowerPoint2007.php(1129): PhpOffice\PhpPresentation\Shape\RichText\Par
agraph->setSpacingBefore(7.48)