### PR TITLE
SetImageResource receives unsupported output

### DIFF
--- a/src/PhpPresentation/Shape/Drawing/Gd.php
+++ b/src/PhpPresentation/Shape/Drawing/Gd.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Shape\Drawing;
 
+use GdImage;
+
 class Gd extends AbstractDrawingAdapter
 {
     // Rendering functions
@@ -83,7 +85,7 @@ class Gd extends AbstractDrawingAdapter
     /**
      * Set image resource.
      *
-     * @param resource|false|\GdImage|null $value
+     * @param resource|false|GdImage|null $value
      *
      * @return $this
      */

--- a/src/PhpPresentation/Shape/Drawing/Gd.php
+++ b/src/PhpPresentation/Shape/Drawing/Gd.php
@@ -83,7 +83,7 @@ class Gd extends AbstractDrawingAdapter
     /**
      * Set image resource.
      *
-     * @param resource $value
+     * @param resource|false|\GdImage|null $value
      *
      * @return $this
      */
@@ -91,7 +91,7 @@ class Gd extends AbstractDrawingAdapter
     {
         $this->imageResource = $value;
 
-        if (null !== $this->imageResource) {
+        if (null !== $this->imageResource && false !== $value) {
             // Get width/height
             $this->width = imagesx($this->imageResource);
             $this->height = imagesy($this->imageResource);


### PR DESCRIPTION
SetImageResource receives the output from imagecreatetruecolor which can also be false or GdImage.

This solves the PHPStan failing on the current config.