### PR TITLE
Core : DocumentLayout : Fixed error when using DocumentLayout::LAYOUT_CUSTOM

### DIFF
--- a/docs/changes/1.1.0.md
+++ b/docs/changes/1.1.0.md
@@ -51,7 +51,8 @@
 - PowerPoint2007 Writer : Fixed broken animation for first shape - [@shannan1989](https://github.com/shannan1989) in [#783](https://github.com/PHPOffice/PHPPresentation/pull/783)
 - Samples : Allow to run without composer - [@pal-software](https://github.com/pal-software) in [#784](https://github.com/PHPOffice/PHPPresentation/pull/784)
 - PowerPoint2007 Writer: Extract relations from nested ShapeContainerInterface objects - [@DennisBirkholz](https://github.com/DennisBirkholz) in [#785](https://github.com/PHPOffice/PHPPresentation/pull/785)
-- General : Fixed copying bug when presentation had multiple slides [@dees040](https://github.com/dees040) in [#786](https://github.com/PHPOffice/PHPPresentation/pull/786)
+- Core : Fixed copying bug when presentation had multiple slides [@dees040](https://github.com/dees040) in [#786](https://github.com/PHPOffice/PHPPresentation/pull/786)
+- Core : DocumentLayout : Fixed error when using DocumentLayout::LAYOUT_CUSTOM by [@jiangzhangchan](https://github.com/dees040) fixing [#722](https://github.com/PHPOffice/PHPPresentation/pull/722) in [#811](https://github.com/PHPOffice/PHPPresentation/pull/811)
 
 ## Miscellaneous
 

--- a/src/PhpPresentation/DocumentLayout.php
+++ b/src/PhpPresentation/DocumentLayout.php
@@ -133,6 +133,9 @@ class DocumentLayout
 
                 break;
             case self::LAYOUT_CUSTOM:
+                $this->layout = self::LAYOUT_CUSTOM;
+
+                break;
             default:
                 $this->layout = self::LAYOUT_CUSTOM;
                 $this->dimensionX = $pValue['cx'];

--- a/tests/PhpPresentation/Tests/DocumentLayoutTest.php
+++ b/tests/PhpPresentation/Tests/DocumentLayoutTest.php
@@ -57,6 +57,24 @@ class DocumentLayoutTest extends TestCase
         self::assertEquals(9144000, $object->getCY());
     }
 
+    /**
+     * Test set custom layout.
+     */
+    public function testSetCustomLayoutWithString(): void
+    {
+        $object = new DocumentLayout();
+        $object->setDocumentLayout(DocumentLayout::LAYOUT_CUSTOM);
+        self::assertEquals(DocumentLayout::LAYOUT_CUSTOM, $object->getDocumentLayout());
+        // Default value
+        self::assertEquals(9144000, $object->getCX());
+        self::assertEquals(6858000, $object->getCY());
+
+        $object->setCX(13.333, DocumentLayout::UNIT_CENTIMETER);
+        $object->setCY(7.5, DocumentLayout::UNIT_CENTIMETER);
+        self::assertEquals(4799880, $object->getCX());
+        self::assertEquals(2700000, $object->getCY());
+    }
+
     public function testCX(): void
     {
         $value = mt_rand(1, 100000);


### PR DESCRIPTION
### Description

Fixes #722

Superseeds #611 by @jiangzhangchan

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)