### PR TITLE
Word2007 Reader: Fixed cast of spacing

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes
 
+- Word2007 Reader: Fixed cast of spacing fixing [#729](https://github.com/PHPOffice/PHPPresentation/pull/729), [#796](https://github.com/PHPOffice/PHPPresentation/pull/796) in [#818](https://github.com/PHPOffice/PHPPresentation/pull/818)
+
 ## Miscellaneous
 
 ## BC Breaks

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1205,20 +1205,20 @@ class PowerPoint2007 implements ReaderInterface
             $oElementLineSpacingPoints = $document->getElement('a:lnSpc/a:spcPts', $oSubElement);
             if ($oElementLineSpacingPoints instanceof DOMElement) {
                 $oParagraph->setLineSpacingMode(Paragraph::LINE_SPACING_MODE_POINT);
-                $oParagraph->setLineSpacing((int) $oElementLineSpacingPoints->getAttribute('val') / 100);
+                $oParagraph->setLineSpacing((int) ((int) $oElementLineSpacingPoints->getAttribute('val') / 100));
             }
             $oElementLineSpacingPercent = $document->getElement('a:lnSpc/a:spcPct', $oSubElement);
             if ($oElementLineSpacingPercent instanceof DOMElement) {
                 $oParagraph->setLineSpacingMode(Paragraph::LINE_SPACING_MODE_PERCENT);
-                $oParagraph->setLineSpacing((int) $oElementLineSpacingPercent->getAttribute('val') / 1000);
+                $oParagraph->setLineSpacing((int) ((int) $oElementLineSpacingPercent->getAttribute('val') / 1000));
             }
             $oElementSpacingBefore = $document->getElement('a:spcBef/a:spcPts', $oSubElement);
             if ($oElementSpacingBefore instanceof DOMElement) {
-                $oParagraph->setSpacingBefore((int) $oElementSpacingBefore->getAttribute('val') / 100);
+                $oParagraph->setSpacingBefore((int) ((int) $oElementSpacingBefore->getAttribute('val') / 100));
             }
             $oElementSpacingAfter = $document->getElement('a:spcAft/a:spcPts', $oSubElement);
             if ($oElementSpacingAfter instanceof DOMElement) {
-                $oParagraph->setSpacingAfter((int) $oElementSpacingAfter->getAttribute('val') / 100);
+                $oParagraph->setSpacingAfter((int) ((int) $oElementSpacingAfter->getAttribute('val') / 100));
             }
 
             $oParagraph->getBulletStyle()->setBulletType(Bullet::TYPE_NONE);

--- a/src/PhpPresentation/Shape/RichText/Paragraph.php
+++ b/src/PhpPresentation/Shape/RichText/Paragraph.php
@@ -317,10 +317,8 @@ class Paragraph implements ComparableInterface
 
     /**
      * Value in points.
-     *
-     * @param int $lineSpacing
      */
-    public function setLineSpacing($lineSpacing): self
+    public function setLineSpacing(int $lineSpacing): self
     {
         $this->lineSpacing = $lineSpacing;
 


### PR DESCRIPTION
### Description

Word2007 Reader: Fixed cast of spacing

Fixes #729 & Fixes #796

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)