### PR TITLE
BUGFIX #820 createDrawingShape stopped working in 1.1.0

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -10,6 +10,7 @@
 ## Bug fixes
 
 - Word2007 Reader: Fixed cast of spacing fixing [#729](https://github.com/PHPOffice/PHPPresentation/pull/729), [#796](https://github.com/PHPOffice/PHPPresentation/pull/796) in [#818](https://github.com/PHPOffice/PHPPresentation/pull/818)
+- Word2007 Writer: Fixed missing images [#829](https://github.com/PHPOffice/PHPPresentation/pull/829) by [@kw-pr](https://github.com/kw-pr)
 
 ## Miscellaneous
 

--- a/src/PhpPresentation/Traits/ShapeCollection.php
+++ b/src/PhpPresentation/Traits/ShapeCollection.php
@@ -81,6 +81,10 @@ trait ShapeCollection
     {
         $this->shapeCollection[] = $shape;
 
+        if (method_exists($shape, 'setContainer') && $shape->getContainer() === null) {
+            $shape->setContainer($this);
+        }
+
         return $this;
     }
 

--- a/src/PhpPresentation/Traits/ShapeCollection.php
+++ b/src/PhpPresentation/Traits/ShapeCollection.php
@@ -77,7 +77,7 @@ trait ShapeCollection
 
     /**
      * @return static
-     * @throws ShapeContainerAlreadyAssignedException&Throwable
+     * @throws ShapeContainerAlreadyAssignedException&\Throwable
      */
     public function addShape(AbstractShape $shape)
     {

--- a/src/PhpPresentation/Traits/ShapeCollection.php
+++ b/src/PhpPresentation/Traits/ShapeCollection.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpPresentation\Traits;
 
 use PhpOffice\PhpPresentation\AbstractShape;
+use PhpOffice\PhpPresentation\ShapeContainerInterface;
 
 trait ShapeCollection
 {
@@ -76,12 +77,13 @@ trait ShapeCollection
 
     /**
      * @return static
+     * @throws ShapeContainerAlreadyAssignedException
      */
     public function addShape(AbstractShape $shape)
     {
         $this->shapeCollection[] = $shape;
 
-        if (method_exists($shape, 'setContainer') && $shape->getContainer() === null) {
+        if ($this instanceof ShapeContainerInterface && $shape->getContainer() === null) {
             $shape->setContainer($this);
         }
 

--- a/src/PhpPresentation/Traits/ShapeCollection.php
+++ b/src/PhpPresentation/Traits/ShapeCollection.php
@@ -77,7 +77,7 @@ trait ShapeCollection
 
     /**
      * @return static
-     * @throws ShapeContainerAlreadyAssignedException
+     * @throws ShapeContainerAlreadyAssignedException&Throwable
      */
     public function addShape(AbstractShape $shape)
     {


### PR DESCRIPTION
Added setContainer in ShapeCollection::addShape().

### Description

Fixes #820 createDrawingShape stopped working in 1.1.0

See https://github.com/PHPOffice/PHPPresentation/issues/820#issuecomment-2500864459 for details.

### Checklist:

- [x] My CI is (almost) :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)

I think tests and documentation is not needed for this.