### PR TITLE
fix: Fixed missing images #829

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -10,6 +10,7 @@
 ## Bug fixes
 
 - Word2007 Reader: Fixed cast of spacing fixing [#729](https://github.com/PHPOffice/PHPPresentation/pull/729), [#796](https://github.com/PHPOffice/PHPPresentation/pull/796) in [#818](https://github.com/PHPOffice/PHPPresentation/pull/818)
+- Word2007 Writer: Fixed missing images [#829](https://github.com/PHPOffice/PHPPresentation/pull/829) by [@kw-pr](https://github.com/kw-pr)
 
 ## Miscellaneous
 

--- a/samples/Sample_05_Chart.php
+++ b/samples/Sample_05_Chart.php
@@ -132,7 +132,7 @@ function fnSlide_BarHorizontal(PhpPresentation $objPHPPresentation): void
 
     // Create a bar chart (that should be inserted in a shape)
     echo date('H:i:s') . ' Create a horizontal bar chart (that should be inserted in a chart shape) ' . EOL;
-    $barChartHorz = clone $objPHPPresentation->getSlide(1)->getShapeCollection()[1]->getPlotArea()->getType();
+    $barChartHorz = clone $objPHPPresentation->getSlide(1)->getShapeCollection()[2]->getPlotArea()->getType();
     $barChartHorz->setBarDirection(Bar3D::DIRECTION_HORIZONTAL);
 
     // Create templated slide
@@ -363,7 +363,7 @@ function fnSlide_Bar3DHorizontal(PhpPresentation $objPHPPresentation): void
 
     // Create a bar chart (that should be inserted in a shape)
     echo date('H:i:s') . ' Create a horizontal bar chart (that should be inserted in a chart shape) ' . EOL;
-    $bar3DChartHorz = clone $objPHPPresentation->getSlide(5)->getShapeCollection()[1]->getPlotArea()->getType();
+    $bar3DChartHorz = clone $objPHPPresentation->getSlide(5)->getShapeCollection()[2]->getPlotArea()->getType();
     $bar3DChartHorz->setBarDirection(Bar3D::DIRECTION_HORIZONTAL);
 
     // Create templated slide

--- a/src/PhpPresentation/Slide/AbstractSlide.php
+++ b/src/PhpPresentation/Slide/AbstractSlide.php
@@ -242,6 +242,7 @@ abstract class AbstractSlide implements ComparableInterface, ShapeContainerInter
     {
         $shape = new File();
         $this->addShape($shape);
+        $shape->setContainer($this);
 
         return $shape;
     }


### PR DESCRIPTION
### Description

Added setContainer in Slide/AbstractSlide::createDrawingShape().

Fixes #820 createDrawingShape stopped working in 1.1.0

See https://github.com/PHPOffice/PHPPresentation/issues/820#issuecomment-2500864459 for details.

### Checklist:

- [x] My CI is mostly :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)

I think extra tests and documentation is not needed for a bugfix.