### PR TITLE
Added Sample_02_Serialized to composer samples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "samples": [
             "php samples/Sample_01_Complex.php",
             "php samples/Sample_01_Simple.php",
+            "php samples/Sample_02_Serialized.php",
             "php samples/Sample_03_Image.php",
             "php samples/Sample_03_Video.php",
             "php samples/Sample_04_Table.php",


### PR DESCRIPTION
The sample is missing but it works.

There are also 3 Sample_12 files missing. But they do not work mainly because PhpPptTree does not exists.

### Description

If this is missing on purpose, just close this.

Fixes no issue.

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)

None of the above, sorry.