### PR TITLE
Added support for PHP 8.4 & `phpoffice/phpspreadsheet`: Allow version 3.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "phpoffice/common": "^1",
-        "phpoffice/phpspreadsheet": "^1.9 || ^2.0"
+        "phpoffice/phpspreadsheet": "^1.9 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=7.0",

--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -6,6 +6,7 @@
 
 - `phpoffice/phpspreadsheet`: Allow version 1.9 or 2.0 by [@Progi1984](https://github.com/Progi1984) fixing [#790](https://github.com/PHPOffice/PHPPresentation/pull/790), [#812](https://github.com/PHPOffice/PHPPresentation/pull/812) in [#816](https://github.com/PHPOffice/PHPPresentation/pull/816)
 - Group Shape: moving the shape now moves all contained shapes. Offsets and size are calculated based on the contained shapes by [@DennisBirkholz](https://github.com/DennisBirkholz) in [#690](https://github.com/PHPOffice/PHPPresentation/pull/690)
+- Added support for PHP 8.4 - [@Progi1984](https://github.com/Progi1984) in [#](https://github.com/PHPOffice/PHPPresentation/pull/)
 
 ## Bug fixes
 

--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -7,6 +7,7 @@
 - `phpoffice/phpspreadsheet`: Allow version 1.9 or 2.0 by [@Progi1984](https://github.com/Progi1984) fixing [#790](https://github.com/PHPOffice/PHPPresentation/pull/790), [#812](https://github.com/PHPOffice/PHPPresentation/pull/812) in [#816](https://github.com/PHPOffice/PHPPresentation/pull/816)
 - Group Shape: moving the shape now moves all contained shapes. Offsets and size are calculated based on the contained shapes by [@DennisBirkholz](https://github.com/DennisBirkholz) in [#690](https://github.com/PHPOffice/PHPPresentation/pull/690)
 - Added support for PHP 8.4 - [@Progi1984](https://github.com/Progi1984) in [#](https://github.com/PHPOffice/PHPPresentation/pull/)
+- `phpoffice/phpspreadsheet`: Allow version 3.0 by [@Progi1984](https://github.com/Progi1984) fixing [#836](https://github.com/PHPOffice/PHPPresentation/pull/836) in [#](https://github.com/PHPOffice/PHPPresentation/pull/)
 
 ## Bug fixes
 


### PR DESCRIPTION
### Description

Added support for PHP 8.4 & `phpoffice/phpspreadsheet`: Allow version 3.0

Fixes #836

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)