### PR TITLE
`Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -15,8 +15,8 @@
 - CI : Fixed PHPCSFixer by [@kw-pr](https://github.com/kw-pr) in [#835](https://github.com/PHPOffice/PHPPresentation/pull/835)
 - Word2007 Reader: Fixed cast of color by [@Progi1984](https://github.com/Progi1984) fixing [#826](https://github.com/PHPOffice/PHPPresentation/pull/826) in [#840](https://github.com/PHPOffice/PHPPresentation/pull/840)
 - Word2007 Reader: Fixed panose with 20 characters by [@Progi1984](https://github.com/Progi1984) fixing [#798](https://github.com/PHPOffice/PHPPresentation/pull/798) in [#842](https://github.com/PHPOffice/PHPPresentation/pull/842)
+- `Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false  by [@jaapdh](https://github.com/jaapdh) in [#843](https://github.com/PHPOffice/PHPPresentation/pull/843)
 
 ## Miscellaneous
-- `Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false  by [@jaapdh](https://github.com/jaapdh) in [#843](https://github.com/PHPOffice/PHPPresentation/pull/843)
 
 ## BC Breaks

--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -17,5 +17,6 @@
 - Word2007 Reader: Fixed panose with 20 characters by [@Progi1984](https://github.com/Progi1984) fixing [#798](https://github.com/PHPOffice/PHPPresentation/pull/798) in [#842](https://github.com/PHPOffice/PHPPresentation/pull/842)
 
 ## Miscellaneous
+- `Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false  by [@jaapdh](https://github.com/jaapdh) in [#843](https://github.com/PHPOffice/PHPPresentation/pull/843)
 
 ## BC Breaks

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,7 @@ parameters:
     - '#^Parameter \#1 \$pValue of static method PhpOffice\\Common\\Drawing\:\:pixelsToCentimeters\(\) expects int, float given\.#'
     - '#^Parameter \#1 \$pValue of static method PhpOffice\\Common\\Drawing\:\:pixelsToEmu\(\) expects int, float given\.#'
     ## PHP 8.0 & GdImage
+    - '#^Parameter \$value of method PhpOffice\\PhpPresentation\\Shape\\Drawing\\Gd::setImageResource\(\) has invalid type GdImage.#'
     - '#^Parameter \#1 \$value of method PhpOffice\\PhpPresentation\\Shape\\Drawing\\Gd::setImageResource\(\) expects resource\|null, GdImage\ given\.#'
     - '#^Parameter \#1 \$value of method PhpOffice\\PhpPresentation\\Shape\\Drawing\\Gd::setImageResource\(\) expects resource\|null, GdImage\|false given\.#'
     - '#^Parameter \#1 \$value of method PhpOffice\\PhpPresentation\\Shape\\Drawing\\Gd::setImageResource\(\) expects resource\|null, \(GdImage\|false\) given\.#'

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -829,6 +829,9 @@ class PowerPoint2007 implements ReaderInterface
                 if (!empty($imageFile)) {
                     if ($oShape instanceof Gd) {
                         $info = getimagesizefromstring($imageFile);
+                        if (!$info) {
+                            return;
+                        }
                         $oShape->setMimeType($info['mime']);
                         $oShape->setRenderingFunction(str_replace('/', '', $info['mime']));
                         $image = @imagecreatefromstring($imageFile);

--- a/src/PhpPresentation/Shape/Drawing/Gd.php
+++ b/src/PhpPresentation/Shape/Drawing/Gd.php
@@ -84,7 +84,7 @@ class Gd extends AbstractDrawingAdapter
     /**
      * Set image resource.
      *
-     * @param resource $value
+     * @param resource|false|\GdImage|null $value
      *
      * @return $this
      */
@@ -92,7 +92,7 @@ class Gd extends AbstractDrawingAdapter
     {
         $this->imageResource = $value;
 
-        if (null !== $this->imageResource) {
+        if (null !== $this->imageResource && false !== $value) {
             // Get width/height
             $this->width = imagesx($this->imageResource);
             $this->height = imagesy($this->imageResource);

--- a/src/PhpPresentation/Shape/Drawing/Gd.php
+++ b/src/PhpPresentation/Shape/Drawing/Gd.php
@@ -94,7 +94,7 @@ class Gd extends AbstractDrawingAdapter
     {
         $this->imageResource = $value;
 
-        if (null !== $this->imageResource && false !== $value) {
+        if (null !== $this->imageResource && false !== $this->imageResource) {
             // Get width/height
             $this->width = imagesx($this->imageResource);
             $this->height = imagesy($this->imageResource);

--- a/src/PhpPresentation/Shape/Drawing/Gd.php
+++ b/src/PhpPresentation/Shape/Drawing/Gd.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Shape\Drawing;
 
+use GdImage;
+
 class Gd extends AbstractDrawingAdapter
 {
     // Rendering functions
@@ -84,7 +86,7 @@ class Gd extends AbstractDrawingAdapter
     /**
      * Set image resource.
      *
-     * @param resource|false|\GdImage|null $value
+     * @param resource|false|GdImage|null $value
      *
      * @return $this
      */

--- a/src/PhpPresentation/Shape/Drawing/Gd.php
+++ b/src/PhpPresentation/Shape/Drawing/Gd.php
@@ -86,7 +86,7 @@ class Gd extends AbstractDrawingAdapter
     /**
      * Set image resource.
      *
-     * @param resource|false|GdImage|null $value
+     * @param null|false|GdImage|resource $value
      *
      * @return $this
      */


### PR DESCRIPTION
### Description

`Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)