### PR TITLE
Word2007 Writer: LineChart supports LabelPosition for Series

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -16,6 +16,7 @@
 - Word2007 Reader: Fixed cast of color by [@Progi1984](https://github.com/Progi1984) fixing [#826](https://github.com/PHPOffice/PHPPresentation/pull/826) in [#840](https://github.com/PHPOffice/PHPPresentation/pull/840)
 - Word2007 Reader: Fixed panose with 20 characters by [@Progi1984](https://github.com/Progi1984) fixing [#798](https://github.com/PHPOffice/PHPPresentation/pull/798) in [#842](https://github.com/PHPOffice/PHPPresentation/pull/842)
 - `Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false  by [@jaapdh](https://github.com/jaapdh) in [#843](https://github.com/PHPOffice/PHPPresentation/pull/843)
+- Word2007 Writer: LineChart supports LabelPosition for Series by [@pal-software](https://github.com/jaapdh) fixing [#606](https://github.com/PHPOffice/PHPPresentation/pull/606) in [#8434](https://github.com/PHPOffice/PHPPresentation/pull/844)
 
 ## Miscellaneous
 

--- a/samples/Sample_05_Chart_Line.php
+++ b/samples/Sample_05_Chart_Line.php
@@ -62,6 +62,7 @@ $lineChart = new Line();
 $series = new Series('Downloads', $seriesData);
 $series->setShowSeriesName(true);
 $series->setShowValue(true);
+$series->setLabelPosition(Series::LABEL_BOTTOM);
 $lineChart->addSeries($series);
 
 // Create a shape (chart)

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -1796,6 +1796,9 @@ class PptCharts extends AbstractDecoratorWriter
 
             $objWriter->endElement();
 
+            // c:dLblPos
+            $this->writeElementWithValAttribute($objWriter, 'c:dLblPos', $series->getLabelPosition());
+
             // c:showVal
             $this->writeElementWithValAttribute($objWriter, 'c:showVal', $series->hasShowValue() ? '1' : '0');
 

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -1243,6 +1243,35 @@ class PptChartsTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testTypeLineSeriesLabelPosition(): void
+    {
+        $expectedElement = '/c:chartSpace/c:chart/c:plotArea/c:lineChart/c:ser/c:dLbls/c:dLblPos';
+
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oShape = $oSlide->createChartShape();
+        $oShape->setResizeProportional(false)->setHeight(550)->setWidth(700)->setOffsetX(120)->setOffsetY(80);
+        $oLine = new Line();
+        $oSeries = new Series('Downloads', $this->seriesData);
+        $oLine->addSeries($oSeries);
+        $oShape->getPlotArea()->setType($oLine);
+
+        $this->assertZipFileExists('ppt/charts/' . $oShape->getIndexedFilename());
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $expectedElement);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $expectedElement, 'val', Series::LABEL_CENTER);
+
+        $this->assertIsSchemaECMA376Valid();
+
+        $oSeries->setLabelPosition(Series::LABEL_BOTTOM);
+        $oLine->setSeries([$oSeries]);
+        $this->resetPresentationFile();
+
+        $this->assertZipFileExists('ppt/charts/' . $oShape->getIndexedFilename());
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $expectedElement);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $expectedElement, 'val', Series::LABEL_BOTTOM);
+
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testTypeLineSeriesOutline(): void
     {
         $expectedWidth = mt_rand(1, 100);


### PR DESCRIPTION
### Description

Word2007 Writer: LineChart supports LabelPosition for Series

Fixes #606

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)