### PR TITLE
`createDrawingShape` has no container defined

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -16,7 +16,8 @@
 - Word2007 Reader: Fixed cast of color by [@Progi1984](https://github.com/Progi1984) fixing [#826](https://github.com/PHPOffice/PHPPresentation/pull/826) in [#840](https://github.com/PHPOffice/PHPPresentation/pull/840)
 - Word2007 Reader: Fixed panose with 20 characters by [@Progi1984](https://github.com/Progi1984) fixing [#798](https://github.com/PHPOffice/PHPPresentation/pull/798) in [#842](https://github.com/PHPOffice/PHPPresentation/pull/842)
 - `Gd::setImageResource()` : Fixed when imagecreatetruecolor returns false  by [@jaapdh](https://github.com/jaapdh) in [#843](https://github.com/PHPOffice/PHPPresentation/pull/843)
-- Word2007 Writer: LineChart supports LabelPosition for Series by [@pal-software](https://github.com/jaapdh) fixing [#606](https://github.com/PHPOffice/PHPPresentation/pull/606) in [#8434](https://github.com/PHPOffice/PHPPresentation/pull/844)
+- Word2007 Writer: LineChart supports LabelPosition for Series by [@pal-software](https://github.com/pal-software) fixing [#606](https://github.com/PHPOffice/PHPPresentation/pull/606) in [#8434](https://github.com/PHPOffice/PHPPresentation/pull/844)
+- `createDrawingShape` has no container defined by [@Progi1984](https://github.com/Progi1984) fixing [#820](https://github.com/PHPOffice/PHPPresentation/pull/820) in [#845](https://github.com/PHPOffice/PHPPresentation/pull/845)
 
 ## Miscellaneous
 

--- a/src/PhpPresentation/Traits/ShapeCollection.php
+++ b/src/PhpPresentation/Traits/ShapeCollection.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpPresentation\Traits;
 
 use PhpOffice\PhpPresentation\AbstractShape;
+use PhpOffice\PhpPresentation\ShapeContainerInterface;
 
 trait ShapeCollection
 {
@@ -80,7 +81,11 @@ trait ShapeCollection
      */
     public function addShape(AbstractShape $shape)
     {
-        $this->shapeCollection[] = $shape;
+        if (!$shape->getContainer() && $this instanceof ShapeContainerInterface) {
+            $shape->setContainer($this);
+        } else {
+            $this->shapeCollection[] = $shape;
+        }
 
         return $this;
     }

--- a/tests/PhpPresentation/Tests/Slide/AbstractSlideTest.php
+++ b/tests/PhpPresentation/Tests/Slide/AbstractSlideTest.php
@@ -36,10 +36,10 @@ class AbstractSlideTest extends TestCase
     public function testCollection(): void
     {
         /** @var AbstractSlide $stub */
-        $stub = $this->getMockForAbstractClass('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide');
+        $stub = $this->getMockForAbstractClass(AbstractSlide::class);
 
         $array = [];
-        self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $stub->setShapeCollection($array));
+        self::assertInstanceOf(AbstractSlide::class, $stub->setShapeCollection($array));
         self::assertIsArray($stub->getShapeCollection());
         self::assertCount(count($array), $stub->getShapeCollection());
 
@@ -48,22 +48,22 @@ class AbstractSlideTest extends TestCase
             new RichText(),
             new RichText(),
         ];
-        self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $stub->setShapeCollection($array));
+        self::assertInstanceOf(AbstractSlide::class, $stub->setShapeCollection($array));
         self::assertIsArray($stub->getShapeCollection());
         self::assertCount(count($array), $stub->getShapeCollection());
     }
 
-    public function testsearchShapes(): void
+    public function testSearchShapes(): void
     {
         /** @var AbstractSlide $stub */
-        $stub = $this->getMockForAbstractClass('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide');
+        $stub = $this->getMockForAbstractClass(AbstractSlide::class);
 
         $array = [
             (new RichText())->setName('AAA'),
             (new Table())->setName('BBB'),
             (new Chart())->setName('AAA'),
         ];
-        self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $stub->setShapeCollection($array));
+        self::assertInstanceOf(AbstractSlide::class, $stub->setShapeCollection($array));
 
         // Search by Name
         $result = $stub->searchShapes('AAA', null);

--- a/tests/PhpPresentation/Tests/SlideTest.php
+++ b/tests/PhpPresentation/Tests/SlideTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Shape\Drawing\File;
+use PhpOffice\PhpPresentation\ShapeContainerInterface;
 use PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\Slide\AbstractBackground;
 use PhpOffice\PhpPresentation\Slide\Animation;
@@ -142,5 +144,41 @@ class SlideTest extends TestCase
         self::assertFalse($object->isVisible());
         self::assertInstanceOf(Slide::class, $object->setIsVisible());
         self::assertTrue($object->isVisible());
+    }
+
+    public function testAddShape(): void
+    {
+        $slide = new Slide();
+        self::assertInstanceOf(ShapeContainerInterface::class, $slide);
+        $shape = new File();
+
+        self::assertIsArray($slide->getShapeCollection());
+        self::assertCount(0, $slide->getShapeCollection());
+
+        $slide->addShape($shape);
+        self::assertInstanceOf(File::class, $shape);
+        self::assertEquals($slide, $shape->getContainer());
+        self::assertInstanceOf(Slide::class, $shape->getContainer());
+
+        self::assertIsArray($slide->getShapeCollection());
+        self::assertCount(1, $slide->getShapeCollection());
+        self::assertEquals([$shape], $slide->getShapeCollection());
+    }
+
+    public function testCreateDrawingShape(): void
+    {
+        $slide = new Slide();
+
+        self::assertIsArray($slide->getShapeCollection());
+        self::assertCount(0, $slide->getShapeCollection());
+
+        $shape = $slide->createDrawingShape();
+        self::assertInstanceOf(File::class, $shape);
+        self::assertEquals($slide, $shape->getContainer());
+        self::assertInstanceOf(Slide::class, $shape->getContainer());
+
+        self::assertIsArray($slide->getShapeCollection());
+        self::assertCount(1, $slide->getShapeCollection());
+        self::assertEquals([$shape], $slide->getShapeCollection());
     }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -711,7 +711,7 @@ class PptChartsTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeNotExists($pathShape, $element, 'rot');
 
         $this->resetPresentationFile();
-        $value = mt_rand(0, 360);
+        $value = mt_rand(1, 360);
         $oShape->getPlotArea()->getAxisX()->setTitleRotation($value);
 
         $pathShape = 'ppt/charts/' . $oShape->getIndexedFilename();


### PR DESCRIPTION
### Description

`createDrawingShape` has no container defined

Fixes #820

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)