### PR TITLE
Powerpoint 2007 & ODPresentation Readers: Added support for loading embedded media

### DIFF
--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -31,6 +31,7 @@ use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\PresentationProperties;
 use PhpOffice\PhpPresentation\Shape\Drawing\Base64;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
+use PhpOffice\PhpPresentation\Shape\Media;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
@@ -542,6 +543,11 @@ class ODPresentation implements ReaderInterface
 
                     continue;
                 }
+                if ($this->oXMLReader->getElement('draw:plugin', $oNodeFrame)) {
+                    $this->loadShapeMedia($oNodeFrame);
+
+                    continue;
+                }
             }
         }
 
@@ -634,6 +640,56 @@ class ODPresentation implements ReaderInterface
         if (count($oShape->getParagraphs()) > 0) {
             $oShape->setActiveParagraph(0);
         }
+    }
+
+    /**
+     * Read Shape Media.
+     */
+    protected function loadShapeMedia(DOMElement $oNodeFrame): void
+    {
+        $oNodePlugin = $this->oXMLReader->getElement('draw:plugin', $oNodeFrame);
+        if (!($oNodePlugin instanceof DOMElement)) {
+            return;
+        }
+
+        $mediaFile = null;
+        if ($oNodePlugin->hasAttribute('xlink:href')) {
+            $filePath = $oNodePlugin->getAttribute('xlink:href');
+            $filePathParts = explode('/', $filePath);
+            if (!$filePathParts || $filePathParts[0] !== 'Media') {
+                return;
+            }
+
+            $mediaFile = $this->oZip->getFromName($filePath);
+        }
+
+        $tmpEmbed = tempnam(sys_get_temp_dir(), 'PhpPresentationReaderODPEmbed');
+        file_put_contents($tmpEmbed, $mediaFile);
+
+        $shape = new Media();
+        $shape
+            ->setFileName(basename($filePath))
+            ->setPath($tmpEmbed, false);
+
+        $shape->getShadow()->setVisible(false);
+        $shape->setName($oNodeFrame->hasAttribute('draw:name') ? $oNodeFrame->getAttribute('draw:name') : '');
+        $shape->setDescription($oNodeFrame->hasAttribute('draw:name') ? $oNodeFrame->getAttribute('draw:name') : '');
+        $shape->setResizeProportional(false);
+        $shape->setWidth($oNodeFrame->hasAttribute('svg:width') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:width'), 0, -2)) : 0);
+        $shape->setHeight($oNodeFrame->hasAttribute('svg:height') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:height'), 0, -2)) : 0);
+        $shape->setResizeProportional(true);
+        $shape->setOffsetX($oNodeFrame->hasAttribute('svg:x') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:x'), 0, -2)) : 0);
+        $shape->setOffsetY($oNodeFrame->hasAttribute('svg:y') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:y'), 0, -2)) : 0);
+
+        if ($oNodeFrame->hasAttribute('draw:style-name')) {
+            $keyStyle = $oNodeFrame->getAttribute('draw:style-name');
+            if (isset($this->arrayStyles[$keyStyle])) {
+                $shape->setShadow($this->arrayStyles[$keyStyle]['shadow']);
+                $shape->setFill($this->arrayStyles[$keyStyle]['fill']);
+            }
+        }
+
+        $this->oPhpPresentation->getActiveSlide()->addShape($shape);
     }
 
     /**

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -888,14 +888,18 @@ class PowerPoint2007 implements ReaderInterface
             }
         }
         $pathEmbed = implode('/', $pathEmbed);
+        $contentEmbed = $this->oZip->getFromName($pathEmbed);
 
         $tmpEmbed = tempnam(sys_get_temp_dir(), 'PhpPresentationReaderPPT2007Embed');
 
-        $contentEmbed = $this->oZip->getFromName($pathEmbed);
         file_put_contents($tmpEmbed, $contentEmbed);
 
-        $oShape->setName(basename($embedPath));
-        $oShape->setPath($tmpEmbed, false);
+        $fileName = basename($embedPath);
+
+        $oShape
+            ->setName($fileName)
+            ->setFileName($fileName)
+            ->setPath($tmpEmbed, false);
         return $oShape;
     }
 

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -823,7 +823,7 @@ class PowerPoint2007 implements ReaderInterface
         if ($oShape instanceof Media) {
             $oShape = $this->loadShapeDrawingEmbed($embedNode, $fileRels, $oShape);
         } else {
-            $oShape = $this->loadShapeDrawingImage($document, $oElement, $fileRels, $oShape);
+            $oShape = $this->loadShapeDrawingImage($document, $node, $fileRels, $oShape);
         }
 
         $oElement = $document->getElement('p:spPr', $node);
@@ -877,7 +877,9 @@ class PowerPoint2007 implements ReaderInterface
             return $oShape;
         }
 
-        $pathEmbed = 'ppt/slides/' . $this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'];
+        $embedPath = $this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'];
+
+        $pathEmbed = "ppt/slides/{$embedPath}";
 
         $pathEmbed = explode('/', $pathEmbed);
         foreach ($pathEmbed as $key => $partPath) {
@@ -892,6 +894,7 @@ class PowerPoint2007 implements ReaderInterface
         $contentEmbed = $this->oZip->getFromName($pathEmbed);
         file_put_contents($tmpEmbed, $contentEmbed);
 
+        $oShape->setName(basename($embedPath));
         $oShape->setPath($tmpEmbed, false);
         return $oShape;
     }

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -33,9 +33,11 @@ use PhpOffice\PhpPresentation\Exception\FileNotFoundException;
 use PhpOffice\PhpPresentation\Exception\InvalidFileFormatException;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\PresentationProperties;
+use PhpOffice\PhpPresentation\Shape\Drawing\AbstractDrawingAdapter;
 use PhpOffice\PhpPresentation\Shape\Drawing\Base64;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
 use PhpOffice\PhpPresentation\Shape\Hyperlink;
+use PhpOffice\PhpPresentation\Shape\Media;
 use PhpOffice\PhpPresentation\Shape\Placeholder;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
@@ -791,7 +793,11 @@ class PowerPoint2007 implements ReaderInterface
     {
         // Core
         $document->registerNamespace('asvg', 'http://schemas.microsoft.com/office/drawing/2016/SVG/main');
-        if ($document->getElement('p:blipFill/a:blip/a:extLst/a:ext/asvg:svgBlip', $node)) {
+        $embedNode = $document->getElements("p:nvPicPr/p:nvPr//*[local-name()='media']", $node);
+        $embedNode = $embedNode ? $embedNode->item(0) : false;
+        if ($embedNode) {
+            $oShape = new Media();
+        } elseif ($document->getElement('p:blipFill/a:blip/a:extLst/a:ext/asvg:svgBlip', $node)) {
             $oShape = new Base64();
         } else {
             $oShape = new Gd();
@@ -814,36 +820,10 @@ class PowerPoint2007 implements ReaderInterface
             }
         }
 
-        $oElement = $document->getElement('p:blipFill/a:blip', $node);
-        if ($oElement instanceof DOMElement) {
-            if ($oElement->hasAttribute('r:embed') && isset($this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'])) {
-                $pathImage = 'ppt/slides/' . $this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'];
-                $pathImage = explode('/', $pathImage);
-                foreach ($pathImage as $key => $partPath) {
-                    if ('..' == $partPath) {
-                        unset($pathImage[$key - 1], $pathImage[$key]);
-                    }
-                }
-                $pathImage = implode('/', $pathImage);
-                $imageFile = $this->oZip->getFromName($pathImage);
-                if (!empty($imageFile)) {
-                    if ($oShape instanceof Gd) {
-                        $info = getimagesizefromstring($imageFile);
-                        if (!$info) {
-                            return;
-                        }
-                        $oShape->setMimeType($info['mime']);
-                        $oShape->setRenderingFunction(str_replace('/', '', $info['mime']));
-                        $image = @imagecreatefromstring($imageFile);
-                        if (!$image) {
-                            return;
-                        }
-                        $oShape->setImageResource($image);
-                    } elseif ($oShape instanceof Base64) {
-                        $oShape->setData('data:image/svg+xml;base64,' . base64_encode($imageFile));
-                    }
-                }
-            }
+        if ($oShape instanceof Media) {
+            $oShape = $this->loadShapeDrawingEmbed($embedNode, $fileRels, $oShape);
+        } else {
+            $oShape = $this->loadShapeDrawingImage($document, $oElement, $fileRels, $oShape);
         }
 
         $oElement = $document->getElement('p:spPr', $node);
@@ -886,6 +866,79 @@ class PowerPoint2007 implements ReaderInterface
             );
         }
         $oSlide->addShape($oShape);
+    }
+
+    protected function loadShapeDrawingEmbed(DOMElement $oElement, string $fileRels, AbstractDrawingAdapter $oShape): AbstractDrawingAdapter
+    {
+        if (!$oElement->hasAttribute('r:embed')) {
+            return $oShape;
+        }
+        if (!isset($this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'])) {
+            return $oShape;
+        }
+
+        $pathEmbed = 'ppt/slides/' . $this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'];
+
+        $pathEmbed = explode('/', $pathEmbed);
+        foreach ($pathEmbed as $key => $partPath) {
+            if ('..' == $partPath) {
+                unset($pathEmbed[$key - 1], $pathEmbed[$key]);
+            }
+        }
+        $pathEmbed = implode('/', $pathEmbed);
+
+        $tmpEmbed = tempnam(sys_get_temp_dir(), 'PhpPresentationReaderPPT2007Embed');
+
+        $contentEmbed = $this->oZip->getFromName($pathEmbed);
+        file_put_contents($tmpEmbed, $contentEmbed);
+
+        $oShape->setPath($tmpEmbed, false);
+        return $oShape;
+    }
+
+    protected function loadShapeDrawingImage(XMLReader $document, DOMElement $node, string $fileRels, AbstractDrawingAdapter $oShape)
+    {
+        $oElement = $document->getElement('p:blipFill/a:blip', $node);
+        if (!($oElement instanceof DOMElement)) {
+            return $oShape;
+        }
+        if (!$oElement->hasAttribute('r:embed')) {
+            return $oShape;
+        }
+        if (!isset($this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'])) {
+            return $oShape;
+        }
+
+        $pathImage = 'ppt/slides/' . $this->arrayRels[$fileRels][$oElement->getAttribute('r:embed')]['Target'];
+        $pathImage = explode('/', $pathImage);
+        foreach ($pathImage as $key => $partPath) {
+            if ('..' == $partPath) {
+                unset($pathImage[$key - 1], $pathImage[$key]);
+            }
+        }
+        $pathImage = implode('/', $pathImage);
+        $imageFile = $this->oZip->getFromName($pathImage);
+        if (!$imageFile) {
+            return $oShape;
+        }
+
+        if ($oShape instanceof Gd) {
+            $info = getimagesizefromstring($imageFile);
+            if (!$info) {
+                return $oShape;
+            }
+            $oShape->setMimeType($info['mime']);
+            $oShape->setRenderingFunction(str_replace('/', '', $info['mime']));
+            $image = @imagecreatefromstring($imageFile);
+            if (!$image) {
+                return $oShape;
+            }
+            $oShape->setImageResource($image);
+        } elseif ($oShape instanceof Base64) {
+            $oShape->setData('data:image/svg+xml;base64,' . base64_encode($imageFile));
+        }
+
+        return $oShape;
     }
 
     /**

--- a/src/PhpPresentation/Shape/Drawing/File.php
+++ b/src/PhpPresentation/Shape/Drawing/File.php
@@ -31,6 +31,11 @@ class File extends AbstractDrawingAdapter
     protected $path = '';
 
     /**
+     * @var string Name of the file
+     */
+    protected $fileName = '';
+
+    /**
      * Get Path.
      */
     public function getPath(): string
@@ -59,6 +64,24 @@ class File extends AbstractDrawingAdapter
             }
         }
 
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * @param string $fileName
+     * @return File
+     */
+    public function setFileName(string $fileName): File
+    {
+        $this->fileName = $fileName;
         return $this;
     }
 


### PR DESCRIPTION
### Description

#### Motivation
I work on behalf of an e-Learning authoring tool.  We are adding powerpoint import as an option for client learning designers to quickly import proprietary information into their course designs.

We wanted to add support for importing the following data from a powerpoint:
- text
- images
- video
- audio

I noticed that, although text and images were being loaded, there were no signs of embedded files.  This PR aims to ameliorate that.

#### Changes
- The Powerpoint 2007 loader now reads in embedded media files
- The OpenDocument Presentation loader now reads in embedded media files

I tried not to deviate too far from existing code norms, and didn't over-optimise by refactoring common bits between loading shapes.

#### Limitations
Not sure where to start for Powerpoint 97 (PPT) formats. 🤔 

#### Observations
The (untouched) parent classes of `Media` and `File` look very biased to images.

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.2.0.md)