### PR TITLE
PhpOffice\PhpPresentation\Style\TextStyle : Fixed typo for default indent

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -26,6 +26,7 @@
 - `createDrawingShape` has no container defined by [@Progi1984](https://github.com/Progi1984) fixing [#820](https://github.com/PHPOffice/PHPPresentation/pull/820) in [#845](https://github.com/PHPOffice/PHPPresentation/pull/845)
 - ODPresentation Reader : Read differents units for margin by [@Progi1984](https://github.com/Progi1984) fixing [#830](https://github.com/PHPOffice/PHPPresentation/pull/830) in [#847](https://github.com/PHPOffice/PHPPresentation/pull/847)
 - PowerPoint2007 Reader : Fixed loading of fonts by [@ag3202](https://github.com/ag3202) and [@Progi1984](https://github.com/Progi1984) in [#851](https://github.com/PHPOffice/PHPPresentation/pull/851)
+- PhpOffice\PhpPresentation\Style\TextStyle : Fixed typo for default indent by [@Progi1984](https://github.com/Progi1984) in [#857](https://github.com/PHPOffice/PHPPresentation/pull/857)
 
 ## Miscellaneous
 - CI: Added ODFValidator by [@Progi1984](https://github.com/Progi1984) fixing [#678](https://github.com/PHPOffice/PHPWord/issues/678) in [#653](https://github.com/PHPOffice/PHPWord/pull/653)

--- a/src/PhpPresentation/Style/TextStyle.php
+++ b/src/PhpPresentation/Style/TextStyle.php
@@ -53,7 +53,7 @@ class TextStyle
             $oRTParagraphBody = new RichTextParagraph();
             $oRTParagraphBody->getAlignment()
                 ->setHorizontal(Alignment::HORIZONTAL_CENTER)
-                ->setIndent(-324900 / 9525)
+                ->setIndent(-342900 / 9525)
                 ->setMarginLeft(342900 / 9525);
             $oRTParagraphBody->getFont()->setSize(32)->setColor($oColorTX1);
             $this->bodyStyle[1] = $oRTParagraphBody;

--- a/tests/PhpPresentation/Tests/Style/TextStyleTest.php
+++ b/tests/PhpPresentation/Tests/Style/TextStyleTest.php
@@ -42,7 +42,7 @@ class TextStyleTest extends TestCase
         $oParagraph = $object->getBodyStyleAtLvl(1);
         self::assertInstanceOf('PhpOffice\PhpPresentation\Shape\RichText\Paragraph', $oParagraph);
         self::assertEquals(Alignment::HORIZONTAL_CENTER, $oParagraph->getAlignment()->getHorizontal());
-        self::assertEquals((-324900 / 9525), $oParagraph->getAlignment()->getIndent());
+        self::assertEquals((-342900 / 9525), $oParagraph->getAlignment()->getIndent());
         self::assertEquals(0, $oParagraph->getAlignment()->getMarginLeft());
         self::assertEquals(32, $oParagraph->getFont()->getSize());
         /** @var SchemeColor $color */


### PR DESCRIPTION
### Description

PhpOffice\PhpPresentation\Style\TextStyle : Fixed typo for default indent

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)