### PR TITLE
PHPSpreadsheet - Allow version 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "phpoffice/common": "^1",
-        "phpoffice/phpspreadsheet": "^1.9 || ^2.0 || ^3.0"
+        "phpoffice/phpspreadsheet": "^1.9 || ^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=7.0",

--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -14,6 +14,7 @@
 - HTML Writer by [@Progi1984](https://github.com/Progi1984) fixing [#221](https://github.com/PHPOffice/PHPPresentation/pull/221), [#567](https://github.com/PHPOffice/PHPPresentation/pull/567), [#644](https://github.com/PHPOffice/PHPPresentation/pull/644) in [#850](https://github.com/PHPOffice/PHPPresentation/pull/855)
 - PDF Writer by [@Progi1984](https://github.com/Progi1984) fixing [#181](https://github.com/PHPOffice/PHPPresentation/pull/181), [#381](https://github.com/PHPOffice/PHPPresentation/pull/381), [#472](https://github.com/PHPOffice/PHPPresentation/pull/472), [#693](https://github.com/PHPOffice/PHPPresentation/pull/693), [#725](https://github.com/PHPOffice/PHPPresentation/pull/725) in [#850](https://github.com/PHPOffice/PHPPresentation/pull/855)
 - PowerPoint2007 Reader : Support for BarChart by [@Progi1984](https://github.com/Progi1984) fixing [#824](https://github.com/PHPOffice/PHPPresentation/pull/824) in [#856](https://github.com/PHPOffice/PHPPresentation/pull/856)
+- `phpoffice/phpspreadsheet`: Allow version 4.0
 
 ## Bug fixes
 


### PR DESCRIPTION
### Description

Allow PHPSpreadsheet 4.x

Fixes # (issue)

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)