### PR TITLE
Powerpoint2007 reader: Added support for loading text run without properties

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -4,6 +4,6 @@
 
 ## Enhancements
 - `phpoffice/phpspreadsheet`: Allow version 5.0 by [@seanlynchwv](http://github.com/seanlynchwv) in [#879](https://github.com/PHPOffice/PHPPresentation/pull/879)
+- PowerPoint2007 Reader: Added support for loading text run without properties by [@Wilkolicious](http://github.com/Wilkolicious) in [#871](https://github.com/PHPOffice/PHPPresentation/pull/871)
 
 ## Bug fixes
-

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1511,9 +1511,9 @@ class PowerPoint2007 implements ReaderInterface
             }
             if ('a:r' == $oSubElement->tagName) {
                 $oElementrPr = $document->getElement('a:rPr', $oSubElement);
-                if (is_object($oElementrPr)) {
-                    $oText = $oParagraph->createTextRun();
 
+                $oText = $oParagraph->createTextRun();
+                if (is_object($oElementrPr)) {
                     if ($oElementrPr->hasAttribute('b')) {
                         $att = $oElementrPr->getAttribute('b');
                         $oText->getFont()->setBold('true' == $att || '1' == $att ? true : false);
@@ -1591,10 +1591,9 @@ class PowerPoint2007 implements ReaderInterface
                             $oText->getFont()->setCharset((int) $oElementFont->getAttribute('charset'));
                         }
                     }
-
-                    $oSubSubElement = $document->getElement('a:t', $oSubElement);
-                    $oText->setText($oSubSubElement->nodeValue);
                 }
+                $oSubSubElement = $document->getElement('a:t', $oSubElement);
+                $oText->setText($oSubSubElement->nodeValue);
             }
         }
     }


### PR DESCRIPTION
### Description

Adds support for scenarios where a text run is stated without text run properties.

Also see: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.runproperties?view=openxml-3.0.1

<details>
<summary>Example XML with text run without properties</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
    xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
    xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
    xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" showMasterSp="1"
    showMasterPhAnim="1">
    <p:cSld>
        <p:bg>
            <p:bgPr>
                <a:solidFill>
                    <a:srgbClr val="1893F8" />
                </a:solidFill>
            </p:bgPr>
        </p:bg>
        <p:spTree>
            <p:nvGrpSpPr>
                <p:cNvPr id="191" name="Google Shape;100;p2" />
                <p:cNvGrpSpPr />
                <p:nvPr />
            </p:nvGrpSpPr>
            <p:grpSpPr>
                <a:xfrm>
                    <a:off x="11797752" y="4618213" />
                    <a:ext cx="10123873" cy="2533542" />
                    <a:chOff x="0" y="0" />
                    <a:chExt cx="10123872" cy="2533541" />
                </a:xfrm>
            </p:grpSpPr>
            <p:sp>
                <p:nvSpPr>
                    <p:cNvPr id="185" name="Google Shape;101;p2" />
                    <p:cNvSpPr txBox="1" />
                    <p:nvPr />
                </p:nvSpPr>
                <p:spPr>
                    <a:xfrm>
                        <a:off x="0" y="0" />
                        <a:ext cx="1531523" cy="554881" />
                    </a:xfrm>
                    <a:prstGeom prst="rect">
                        <a:avLst />
                    </a:prstGeom>
                    <a:noFill />
                    <a:ln w="12700" cap="flat">
                        <a:noFill />
                        <a:miter lim="400000" />
                    </a:ln>
                    <a:effectLst />
                    <a:extLst>
                        <a:ext uri="{C572A759-6A51-4108-AA02-DFA0A04FC94B}">
                            <ma14:wrappingTextBoxFlag val="1"
                                xmlns:ma14="http://schemas.microsoft.com/office/mac/drawingml/2011/main" />
                        </a:ext>
                    </a:extLst>
                </p:spPr>
                <p:txBody>
                    <a:bodyPr wrap="square" lIns="0" tIns="0" rIns="0" bIns="0" numCol="1"
                        anchor="t">
                        <a:spAutoFit />
                    </a:bodyPr>
                    <a:lstStyle>
                        <a:lvl1pPr algn="just" defTabSz="1219200">
                            <a:lnSpc>
                                <a:spcPct val="166000" />
                            </a:lnSpc>
                            <a:spcBef>
                                <a:spcPts val="0" />
                            </a:spcBef>
                            <a:defRPr sz="4000">
                                <a:solidFill>
                                    <a:srgbClr val="B8ED37" />
                                </a:solidFill>
                                <a:latin typeface="Arial" />
                                <a:ea typeface="Arial" />
                                <a:cs typeface="Arial" />
                                <a:sym typeface="Arial" />
                            </a:defRPr>
                        </a:lvl1pPr>
                    </a:lstStyle>
                    <a:p>
                        <a:pPr />
                        <a:r>
                            <a:t>Part 1:</a:t>
                        </a:r>
                    </a:p>
                </p:txBody>
            </p:sp>
        </p:spTree>
    </p:cSld>
    <p:clrMapOvr>
        <a:masterClrMapping />
    </p:clrMapOvr>
    <p:transition xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" spd="med"
        advClick="1" />
</p:sld>
```
</details>

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)