### PR TITLE
Set Rounded Corners on Rectangle

### DIFF
--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -17,6 +17,7 @@
 - `phpoffice/phpspreadsheet`: Allow version 4.0 by [@nreynis](https://github.com/nreynis) in [#861](https://github.com/PHPOffice/PHPPresentation/pull/861)
 - Smaller package size by [@nreynis](https://github.com/nreynis) in [#862](https://github.com/PHPOffice/PHPPresentation/pull/862)
 - Added setFirstSliceAngle to Doughnut Chart by [@seanlynchwv](http://github.com/seanlynchwv) in [#872](https://github.com/PHPOffice/PHPPresentation/pull/872)
+- Added ability to set rounded corner radius by [@seanlynchwv](http://github.com/seanlynchwv) in [#880](https://github.com/PHPOffice/PHPPresentation/pull/880)
 
 ## Bug fixes
 

--- a/docs/changes/1.2.0.md
+++ b/docs/changes/1.2.0.md
@@ -17,7 +17,6 @@
 - `phpoffice/phpspreadsheet`: Allow version 4.0 by [@nreynis](https://github.com/nreynis) in [#861](https://github.com/PHPOffice/PHPPresentation/pull/861)
 - Smaller package size by [@nreynis](https://github.com/nreynis) in [#862](https://github.com/PHPOffice/PHPPresentation/pull/862)
 - Added setFirstSliceAngle to Doughnut Chart by [@seanlynchwv](http://github.com/seanlynchwv) in [#872](https://github.com/PHPOffice/PHPPresentation/pull/872)
-- Added ability to set rounded corner radius by [@seanlynchwv](http://github.com/seanlynchwv) in [#880](https://github.com/PHPOffice/PHPPresentation/pull/880)
 
 ## Bug fixes
 

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 - `phpoffice/phpspreadsheet`: Allow version 5.0 by [@seanlynchwv](http://github.com/seanlynchwv) in [#879](https://github.com/PHPOffice/PHPPresentation/pull/879)
+- Added ability to set rounded corner radius by [@seanlynchwv](http://github.com/seanlynchwv) in [#880](https://github.com/PHPOffice/PHPPresentation/pull/880)
 
 ## Bug fixes
 

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -274,7 +274,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
         return $this;
     }
 
-    /** @var int|null */
+    /** @var null|int */
     private $roundRectAdj;
 
     public function getRoundRectAdj(): ?int
@@ -291,6 +291,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
         if ($minHalf > 0) {
             $this->roundRectAdj = max(0, min(50000, (int) round($px / $minHalf * 50000)));
         }
+
         return $this;
     }
 

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -274,7 +274,8 @@ class AutoShape extends AbstractShape implements ComparableInterface
         return $this;
     }
 
-    private int $roundRectAdj = null;
+    /** @var int|null */
+    private $roundRectAdj = null;
 
     public function getRoundRectAdj(): ?int
     {

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -275,7 +275,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
     }
 
     /** @var int|null */
-    private $roundRectAdj = null;
+    private $roundRectAdj;
 
     public function getRoundRectAdj(): ?int
     {

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -285,11 +285,11 @@ class AutoShape extends AbstractShape implements ComparableInterface
     /**
      * Set corner radius.
      */
-    public function setRoundRectCorner(int $px): self
+    public function setRoundRectCorner(int $pixels): self
     {
         $minHalf = (int) floor(min($this->width, $this->height) / 2);
         if ($minHalf > 0) {
-            $this->roundRectAdj = max(0, min(50000, (int) round($px / $minHalf * 50000)));
+            $this->roundRectAdj = max(0, min(50000, (int) round($pixels / $minHalf * 50000)));
         }
 
         return $this;

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -274,7 +274,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
         return $this;
     }
 
-    private $roundRectAdj = null;
+    private int $roundRectAdj = null;
 
     public function getRoundRectAdj(): ?int
     {

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -273,4 +273,29 @@ class AutoShape extends AbstractShape implements ComparableInterface
 
         return $this;
     }
+
+    private $roundRectAdj = null;
+
+    public function getRoundRectAdj(): ?int
+    {
+        return $this->roundRectAdj;
+    }
+
+    /**
+     * Set corner radius.
+     */
+    public function setRoundRectCorner(int $px): self
+    {
+        $minHalf = (int) floor(min($this->width, $this->height) / 2);
+        if ($minHalf > 0) {
+            $this->roundRectAdj = max(0, min(50000, (int) round($px / $minHalf * 50000)));
+        }
+        return $this;
+    }
+
+    // override the hash so radius works
+    public function getHashCode(): string
+    {
+        return md5(parent::getHashCode() . $this->type . $this->text . (string) $this->roundRectAdj . __CLASS__);
+    }
 }

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -275,7 +275,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
     }
 
     /** @var null|int */
-    private $roundRectAdj;
+    protected $roundRectAdj;
 
     public function getRoundRectAdj(): ?int
     {

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -275,11 +275,11 @@ class AutoShape extends AbstractShape implements ComparableInterface
     }
 
     /** @var null|int */
-    private $roundRectAdj;
+    private $roundRectCorner;
 
-    public function getRoundRectAdj(): ?int
+    public function getRoundRectCorner(): ?int
     {
-        return $this->roundRectAdj;
+        return $this->roundRectCorner;
     }
 
     /**
@@ -287,10 +287,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
      */
     public function setRoundRectCorner(int $pixels): self
     {
-        $minHalf = (int) floor(min($this->width, $this->height) / 2);
-        if ($minHalf > 0) {
-            $this->roundRectAdj = max(0, min(50000, (int) round($pixels / $minHalf * 50000)));
-        }
+        $this->roundRectCorner = max(0, $pixels);
 
         return $this;
     }
@@ -298,6 +295,6 @@ class AutoShape extends AbstractShape implements ComparableInterface
     // override the hash so radius works
     public function getHashCode(): string
     {
-        return md5(parent::getHashCode() . $this->type . $this->text . (string) $this->roundRectAdj . __CLASS__);
+        return md5(parent::getHashCode() . $this->type . $this->text . (string) $this->roundRectCorner . __CLASS__);
     }
 }

--- a/src/PhpPresentation/Shape/AutoShape.php
+++ b/src/PhpPresentation/Shape/AutoShape.php
@@ -285,7 +285,7 @@ class AutoShape extends AbstractShape implements ComparableInterface
     /**
      * Set corner radius.
      */
-    public function setRoundRectCorner(int $pixels): self
+    public function setRoundRectCorner(?int $pixels): self
     {
         $this->roundRectCorner = max(0, $pixels);
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -1189,7 +1189,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('prst', $shape->getType());
 
         // a:avLst (+ optional adj for roundRect)
-        $needsAdj = ($shape->getType() === \PhpOffice\PhpPresentation\Shape\AutoShape::TYPE_ROUNDED_RECTANGLE);
+        $needsAdj = ($shape->getType() === AutoShape::TYPE_ROUNDED_RECTANGLE);
         $adj = $shape->getRoundRectAdj();
 
         if ($needsAdj && $adj !== null) {

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -1187,9 +1187,21 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         // p:sp\p:spPr\a:prstGeom
         $objWriter->startElement('a:prstGeom');
         $objWriter->writeAttribute('prst', $shape->getType());
-        // p:sp\p:spPr\a:prstGeom\a:avLst
-        $objWriter->writeElement('a:avLst');
-        // p:sp\p:spPr\a:prstGeom\
+
+        // a:avLst (+ optional adj for roundRect)
+        $needsAdj = ($shape->getType() === \PhpOffice\PhpPresentation\Shape\AutoShape::TYPE_ROUNDED_RECTANGLE);
+        $adj = $shape->getRoundRectAdj();
+
+        if ($needsAdj && $adj !== null) {
+            $objWriter->startElement('a:avLst');
+            $objWriter->startElement('a:gd');
+            $objWriter->writeAttribute('name', 'adj');
+            $objWriter->writeAttribute('fmla', 'val ' . (string) $adj); // 0..50000
+            $objWriter->endElement(); // a:gd
+            $objWriter->endElement(); // a:avLst
+        } else {
+            $objWriter->writeElement('a:avLst');
+        }
         $objWriter->endElement();
         // Fill
         $this->writeFill($objWriter, $shape->getFill());

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -1190,15 +1190,25 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
 
         // a:avLst (+ optional adj for roundRect)
         $needsAdj = ($shape->getType() === AutoShape::TYPE_ROUNDED_RECTANGLE);
-        $adj = $shape->getRoundRectAdj();
+        $cornerPx = $shape->getRoundRectCorner();
 
-        if ($needsAdj && $adj !== null) {
-            $objWriter->startElement('a:avLst');
-            $objWriter->startElement('a:gd');
-            $objWriter->writeAttribute('name', 'adj');
-            $objWriter->writeAttribute('fmla', 'val ' . (string) $adj); // 0..50000
-            $objWriter->endElement(); // a:gd
-            $objWriter->endElement(); // a:avLst
+        if ($needsAdj && $cornerPx !== null) {
+            $minHalf = (int) floor(min($shape->getWidth(), $shape->getHeight()) / 2);
+
+            if ($minHalf > 0) {
+                $adj = (int) round($cornerPx / $minHalf * 50000);
+                $adj = max(0, min(50000, $adj));
+
+                $objWriter->startElement('a:avLst');
+                $objWriter->startElement('a:gd');
+                $objWriter->writeAttribute('name', 'adj');
+                $objWriter->writeAttribute('fmla', 'val ' . (string) $adj);
+                $objWriter->endElement(); // a:gd
+                $objWriter->endElement(); // a:avLst
+            } else {
+                // invalid size, just emit empty avLst
+                $objWriter->writeElement('a:avLst');
+            }
         } else {
             $objWriter->writeElement('a:avLst');
         }

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -20,9 +20,14 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
+use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\Shape\AutoShape;
+use PhpOffice\PhpPresentation\Style\Color;
+use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Outline;
+use PhpOffice\PhpPresentation\Writer\PowerPoint2007;
 use PHPUnit\Framework\TestCase;
+use ZipArchive;
 
 class AutoShapeTest extends TestCase
 {
@@ -63,5 +68,80 @@ class AutoShapeTest extends TestCase
         self::assertEquals(AutoShape::TYPE_HEART, $object->getType());
         self::assertInstanceOf(AutoShape::class, $object->setType(AutoShape::TYPE_HEXAGON));
         self::assertEquals(AutoShape::TYPE_HEXAGON, $object->getType());
+    }
+
+    public function testPixelSetterComputesAdjAndAffectsHash(): void
+    {
+        $w = 200;  // px
+        $h = 100;  // px
+        $px1 = 5;  // softer radius
+        $px2 = 10; // larger radius
+
+        $s1 = (new AutoShape())
+            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
+            ->setWidth($w)->setHeight($h)
+            ->setRoundRectCorner($px1);
+
+        $s2 = (clone $s1)->setRoundRectCorner($px2);
+
+        // adj expected: round(px / (min(w,h)/2) * 50000)
+        $minHalf = (int) floor(min($w, $h) / 2); // 50
+        $expectedAdj1 = (int) round($px1 / $minHalf * 50000); // 5/50 * 50000 = 5000
+        $expectedAdj2 = (int) round($px2 / $minHalf * 50000); // 10/50 * 50000 = 10000
+
+        self::assertSame($expectedAdj1, $s1->getRoundRectAdj());
+        self::assertSame($expectedAdj2, $s2->getRoundRectAdj());
+
+        // Hash must differ when radius differs
+        self::assertNotSame($s1->getHashCode(), $s2->getHashCode());
+    }
+
+    public function testNoRadiusByDefaultIsNull(): void
+    {
+        $shape = new AutoShape();
+        self::assertNull($shape->getRoundRectAdj());
+    }
+
+    public function testWriterEmitsAdjGuideForRoundRect(): void
+    {
+        $ppt = new PhpPresentation();
+        $slide = $ppt->getActiveSlide();
+
+        $width = 200;
+        $height = 100;
+        $padding = 5;
+        $minHalf = (int) floor(min($width, $height) / 2);
+        $expectedAdj = (int) round($padding / $minHalf * 50000); // 5000
+
+        $shape = (new AutoShape())
+            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
+            ->setWidth($width)->setHeight($height)
+            ->setRoundRectCorner($padding);
+
+        // Give it a fill so it's an obvious shape
+        $shape->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFFFFFFF'));
+        $slide->addShape($shape);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'pptx_');
+        $writer = new PowerPoint2007($ppt);
+        $writer->save($tmpFile);
+
+        // Open the pptx and read slide1.xml
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($tmpFile) === true, 'Failed to open pptx zip');
+        $xml = $zip->getFromName('ppt/slides/slide1.xml');
+        $zip->close();
+        @unlink($tmpFile);
+
+        $this->assertIsString($xml);
+
+        // Must contain roundRect geometry and the adj guide with expected value
+        $this->assertStringContainsString('<a:prstGeom prst="roundRect">', $xml);
+
+        // fmla="val N" (there is a space after 'val' in writer)
+        $this->assertMatchesRegularExpression(
+            sprintf('/<a:gd[^>]+name="adj"[^>]+fmla="val %d"/', $expectedAdj),
+            $xml
+        );
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -72,28 +72,29 @@ class AutoShapeTest extends TestCase
 
     public function testPixelSetterComputesAdjAndAffectsHash(): void
     {
-        $w = 200;  // px
-        $h = 100;  // px
+        $width = 200;  // px
+        $height = 100;  // px
         $px1 = 5;  // softer radius
         $px2 = 10; // larger radius
 
-        $s1 = (new AutoShape())
+        $shape1 = (new AutoShape())
             ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
-            ->setWidth($w)->setHeight($h)
+            ->setWidth($width)
+            ->setHeight($height)
             ->setRoundRectCorner($px1);
 
-        $s2 = (clone $s1)->setRoundRectCorner($px2);
+        $shape2 = (clone $shape1)->setRoundRectCorner($px2);
 
         // adj expected: round(px / (min(w,h)/2) * 50000)
-        $minHalf = (int) floor(min($w, $h) / 2); // 50
+        $minHalf = (int) floor(min($width, $height) / 2); // 50
         $expectedAdj1 = (int) round($px1 / $minHalf * 50000); // 5/50 * 50000 = 5000
         $expectedAdj2 = (int) round($px2 / $minHalf * 50000); // 10/50 * 50000 = 10000
 
-        self::assertSame($expectedAdj1, $s1->getRoundRectAdj());
-        self::assertSame($expectedAdj2, $s2->getRoundRectAdj());
+        self::assertSame($expectedAdj1, $shape1->getRoundRectAdj());
+        self::assertSame($expectedAdj2, $shape2->getRoundRectAdj());
 
         // Hash must differ when radius differs
-        self::assertNotSame($s1->getHashCode(), $s2->getHashCode());
+        self::assertNotSame($shape1->getHashCode(), $shape2->getHashCode());
     }
 
     public function testNoRadiusByDefaultIsNull(): void

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -128,18 +128,18 @@ class AutoShapeTest extends TestCase
 
         // Open the pptx and read slide1.xml
         $zip = new ZipArchive();
-        $this->assertTrue($zip->open($tmpFile) === true, 'Failed to open pptx zip');
+        self::assertTrue($zip->open($tmpFile) === true, 'Failed to open pptx zip');
         $xml = $zip->getFromName('ppt/slides/slide1.xml');
         $zip->close();
         @unlink($tmpFile);
 
-        $this->assertIsString($xml);
+        self::assertIsString($xml);
 
         // Must contain roundRect geometry and the adj guide with expected value
-        $this->assertStringContainsString('<a:prstGeom prst="roundRect">', $xml);
+        self::assertStringContainsString('<a:prstGeom prst="roundRect">', $xml);
 
         // fmla="val N" (there is a space after 'val' in writer)
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             sprintf('/<a:gd[^>]+name="adj"[^>]+fmla="val %d"/', $expectedAdj),
             $xml
         );

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -139,9 +139,12 @@ class AutoShapeTest extends TestCase
         self::assertStringContainsString('<a:prstGeom prst="roundRect">', $xml);
 
         // fmla="val N" (there is a space after 'val' in writer)
-        self::assertMatchesRegularExpression(
-            sprintf('/<a:gd[^>]+name="adj"[^>]+fmla="val %d"/', $expectedAdj),
-            $xml
+        self::assertSame(
+            1,
+            preg_match(
+                sprintf('/<a:gd[^>]+name="adj"[^>]+fmla="val %d"/', $expectedAdj),
+                (string) $xml
+            )
         );
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -70,33 +70,6 @@ class AutoShapeTest extends TestCase
         self::assertEquals(AutoShape::TYPE_HEXAGON, $object->getType());
     }
 
-    public function testPixelSetterComputesAdjAndAffectsHash(): void
-    {
-        $width = 200;  // px
-        $height = 100;  // px
-        $px1 = 5;  // softer radius
-        $px2 = 10; // larger radius
-
-        $shape1 = (new AutoShape())
-            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
-            ->setWidth($width)
-            ->setHeight($height)
-            ->setRoundRectCorner($px1);
-
-        $shape2 = (clone $shape1)->setRoundRectCorner($px2);
-
-        // adj expected: round(px / (min(w,h)/2) * 50000)
-        $minHalf = (int) floor(min($width, $height) / 2); // 50
-        $expectedAdj1 = (int) round($px1 / $minHalf * 50000); // 5/50 * 50000 = 5000
-        $expectedAdj2 = (int) round($px2 / $minHalf * 50000); // 10/50 * 50000 = 10000
-
-        self::assertSame($expectedAdj1, $shape1->getRoundRectAdj());
-        self::assertSame($expectedAdj2, $shape2->getRoundRectAdj());
-
-        // Hash must differ when radius differs
-        self::assertNotSame($shape1->getHashCode(), $shape2->getHashCode());
-    }
-
     public function testNoRadiusByDefaultIsNull(): void
     {
         $shape = new AutoShape();

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -73,7 +73,7 @@ class AutoShapeTest extends TestCase
     public function testNoRadiusByDefaultIsNull(): void
     {
         $shape = new AutoShape();
-        self::assertNull($shape->getRoundRectAdj());
+        self::assertNull($shape->getRoundRectCorner());
     }
 
     public function testWriterEmitsAdjGuideForRoundRect(): void

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -20,15 +20,10 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Tests\Shape;
 
-use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\Shape\AutoShape;
-use PhpOffice\PhpPresentation\Style\Color;
-use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Outline;
-use PhpOffice\PhpPresentation\Writer\PowerPoint2007;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ZipArchive;
 
 class AutoShapeTest extends TestCase
 {
@@ -75,51 +70,5 @@ class AutoShapeTest extends TestCase
     {
         $shape = new AutoShape();
         self::assertNull($shape->getRoundRectCorner());
-    }
-
-    public function testWriterEmitsAdjGuideForRoundRect(): void
-    {
-        $ppt = new PhpPresentation();
-        $slide = $ppt->getActiveSlide();
-
-        $width = 200;
-        $height = 100;
-        $padding = 5;
-        $minHalf = (int) floor(min($width, $height) / 2);
-        $expectedAdj = (int) round($padding / $minHalf * 50000); // 5000
-
-        $shape = (new AutoShape())
-            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
-            ->setWidth($width)->setHeight($height)
-            ->setRoundRectCorner($padding);
-
-        // Give it a fill so it's an obvious shape
-        $shape->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFFFFFFF'));
-        $slide->addShape($shape);
-
-        $tmpFile = tempnam(sys_get_temp_dir(), 'pptx_');
-        $writer = new PowerPoint2007($ppt);
-        $writer->save($tmpFile);
-
-        // Open the pptx and read slide1.xml
-        $zip = new ZipArchive();
-        self::assertTrue($zip->open($tmpFile) === true, 'Failed to open pptx zip');
-        $xml = $zip->getFromName('ppt/slides/slide1.xml');
-        $zip->close();
-        @unlink($tmpFile);
-
-        self::assertIsString($xml);
-
-        // Must contain roundRect geometry and the adj guide with expected value
-        self::assertStringContainsString('<a:prstGeom prst="roundRect">', $xml);
-
-        // fmla="val N" (there is a space after 'val' in writer)
-        self::assertSame(
-            1,
-            preg_match(
-                sprintf('/<a:gd[^>]+name="adj"[^>]+fmla="val %d"/', $expectedAdj),
-                (string) $xml
-            )
-        );
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -71,4 +71,26 @@ class AutoShapeTest extends TestCase
         $shape = new AutoShape();
         self::assertNull($shape->getRoundRectCorner());
     }
+
+    public function testRoundRectCornerPixelRadiusStoredAndAffectsHash(): void
+    {
+        $width = 200;  // px
+        $height = 100;  // px
+        $px1 = 5;  // softer radius
+        $px2 = 10; // larger radius
+
+        $shape1 = (new AutoShape())
+            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
+            ->setWidth($width)
+            ->setHeight($height)
+            ->setRoundRectCorner($px1);
+
+        $shape2 = (clone $shape1)->setRoundRectCorner($px2);
+
+        self::assertSame($px1, $shape1->getRoundRectCorner());
+        self::assertSame($px2, $shape2->getRoundRectCorner());
+
+        // Hash must differ when radius differs
+        self::assertNotSame($shape1->getHashCode(), $shape2->getHashCode());
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
@@ -578,7 +578,7 @@ class ObjectsChartTest extends PhpPresentationTestCase
 
     public function testTypeAxisUnit(): void
     {
-        $value = mt_rand(0, 100);
+        $value = max(1, mt_rand(0, 100));
 
         $series = new Series('Downloads', $this->seriesData);
         $line = new Line();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -739,6 +739,28 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testRoundRectCornerPixelRadiusStoredAndAffectsHash(): void
+    {
+        $width = 200;  // px
+        $height = 100;  // px
+        $px1 = 5;  // softer radius
+        $px2 = 10; // larger radius
+
+        $shape1 = (new AutoShape())
+            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
+            ->setWidth($width)
+            ->setHeight($height)
+            ->setRoundRectCorner($px1);
+
+        $shape2 = (clone $shape1)->setRoundRectCorner($px2);
+
+        self::assertSame($px1, $shape1->getRoundRectCorner());
+        self::assertSame($px2, $shape2->getRoundRectCorner());
+
+        // Hash must differ when radius differs
+        self::assertNotSame($shape1->getHashCode(), $shape2->getHashCode());
+    }
+
     public function testPlaceHolder(): void
     {
         $expectedType = Placeholder::PH_TYPE_SLIDENUM;

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -169,6 +169,34 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testWriterEmitsAdjGuideForRoundRect(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+
+        $width = 200;
+        $height = 100;
+        $padding = 5;
+        $minHalf = (int) floor(min($width, $height) / 2);
+        $expectedAdj = (int) round($padding / $minHalf * 50000); // 5000
+
+        $oShape = (new AutoShape())
+            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
+            ->setWidth($width)->setHeight($height)
+            ->setRoundRectCorner($padding);
+        $oShape->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFFFFFFF'));
+        $oSlide->addShape($oShape);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:spPr/a:prstGeom';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'prst', AutoShape::TYPE_ROUNDED_RECTANGLE);
+
+        $guideElement = $element . '/a:avLst/a:gd';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $guideElement);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $guideElement, 'name', 'adj');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $guideElement, 'fmla', 'val ' . $expectedAdj);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testCommentRelationship(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -767,28 +767,6 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
-    public function testRoundRectCornerPixelRadiusStoredAndAffectsHash(): void
-    {
-        $width = 200;  // px
-        $height = 100;  // px
-        $px1 = 5;  // softer radius
-        $px2 = 10; // larger radius
-
-        $shape1 = (new AutoShape())
-            ->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
-            ->setWidth($width)
-            ->setHeight($height)
-            ->setRoundRectCorner($px1);
-
-        $shape2 = (clone $shape1)->setRoundRectCorner($px2);
-
-        self::assertSame($px1, $shape1->getRoundRectCorner());
-        self::assertSame($px2, $shape2->getRoundRectCorner());
-
-        // Hash must differ when radius differs
-        self::assertNotSame($shape1->getHashCode(), $shape2->getHashCode());
-    }
-
     public function testPlaceHolder(): void
     {
         $expectedType = Placeholder::PH_TYPE_SLIDENUM;


### PR DESCRIPTION
### Description

It's now possible to set the radius to create rounded corners on rectangle shapes.

```
        $panel = new AutoShape();
        $panel->setType(AutoShape::TYPE_ROUNDED_RECTANGLE)
            ->setOffsetX($x)
            ->setOffsetY($y)
            ->setWidth($w)
            ->setHeight($h)
            ->setRoundRectCorner(4); // new
```

Previously the corners were hard coded to a large value making custom designs difficult.

Fixes # (issue)
https://github.com/PHPOffice/PHPPresentation/issues/854

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)