### PR TITLE
Add missing slide names

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -6,4 +6,5 @@
 - `phpoffice/phpspreadsheet`: Allow version 5.0 by [@seanlynchwv](http://github.com/seanlynchwv) in [#879](https://github.com/PHPOffice/PHPPresentation/pull/879)
 
 ## Bug fixes
+- PowerPoint2007 Writer: Add missing name attribute to slides by [@potofcoffee](https://github.com/potofcoffee) in [#882](https://github.com/PHPOffice/PHPPresentation/issues/882)
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
@@ -352,6 +352,9 @@ class PptSlides extends AbstractSlide
 
         // p:sld/p:cSld
         $objWriter->startElement('p:cSld');
+        if (!empty($pSlide->getName())) {
+            $objWriter->writeAttribute('name', $pSlide->getName());
+        }
 
         // Background
         if ($pSlide->getBackground() instanceof Slide\AbstractBackground) {


### PR DESCRIPTION
Fixes #882

### Description

This includes the missing slide name attribute in PowerPoint2007 writer. No docs update necessary, since this should have been there all along.

Fixes #882 

### Checklist:

- [X] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [X] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)