### PR TITLE
Refactor shadow style handling in HTML writer

### DIFF
--- a/src/PhpPresentation/Writer/HTML.php
+++ b/src/PhpPresentation/Writer/HTML.php
@@ -229,7 +229,9 @@ class HTML extends AbstractWriter implements WriterInterface
         $styles[] = 'height: ' . $shape->getHeight() . 'px';
         $styles[] = 'top: ' . $shape->getOffsetY() . 'px';
         $styles[] = 'left: ' . $shape->getOffsetX() . 'px';
-        $styles = array_merge($styles, $this->getStyleShadow($shape->getShadow()));
+        if (!is_null($shape->getShadow())) {
+            $styles = array_merge($styles, $this->getStyleShadow($shape->getShadow()));
+        }
 
         $this->bodySlides .= '<img src="' . $imageData . '" style="' . implode(';', $styles) . '" alt="' . $shape->getDescription() . '" title="' . $shape->getDescription() . '" />';
     }
@@ -365,7 +367,7 @@ class HTML extends AbstractWriter implements WriterInterface
      */
     protected function getStyleShadow(Shadow $style): array
     {
-        if (!$style->isVisible()) {
+        if (is_null($style) or !is_null($style) and !$style->isVisible()) {
             return [];
         }
         $boxShadow = '';


### PR DESCRIPTION
### Description

There is a bug in the case the is_null($style) and !is_null($shape->getShadow()) too

Fixes # (issue)

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)