### PR TITLE
set min php 7.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,14 +68,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2
           with:
               php-version: ${{ matrix.php }}
               extensions: gd, xml, zip
-              coverage: ${{ (matrix.php == '7.3') && 'xdebug' || 'none' }}
+              coverage: ${{ (matrix.php == '7.4') && 'xdebug' || 'none' }}
 
       -   uses: actions/checkout@v2
 
@@ -83,15 +83,15 @@ jobs:
           run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       -   name: Run phpunit
-          if: matrix.php != '7.3'
+          if: matrix.php != '7.4'
           run: ./vendor/bin/phpunit -c phpunit.xml.dist --no-coverage
 
       -   name: Run phpunit
-          if: matrix.php == '7.3'
+          if: matrix.php == '7.4'
           run: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/clover.xml
 
       -   name: Upload coverage results to Coveralls
-          if: matrix.php == '7.3'
+          if: matrix.php == '7.4'
           env:
             COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -60,7 +60,7 @@ jobs:
             run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
         -   name: Run phpstan
-            run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist
+            run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist src
 
   phpunit:
     name: PHPUnit ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.4|^8.0",
         "ext-xml": "*",
         "ext-zip": "*",
         "phpoffice/common": "^1",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "phpunit/phpunit": ">=7.0",
         "phpmd/phpmd": "2.*",
         "phpstan/phpstan": "^0.12.88 || ^1.0.0",
-        "dompdf/dompdf": "^3.1"
+        "dompdf/dompdf": "^3.1",
+        "phpstan/phpstan-phpunit": "^1.0"
     },
     "suggest": {
         "ext-gd": "Required to add images"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+  - vendor/phpstan/phpstan-phpunit/extension.neon
+
 parameters:
   level: 6
   bootstrapFiles:


### PR DESCRIPTION
This PR raises the minimum supported PHP version for PHPPresentation to PHP 7.4.

Recent versions of PhpSpreadsheet (a core dependency) now require PHP 7.4+, which means PHPPresentation can no longer install or run correctly on PHP 7.2 or 7.3. 
CI was failing for these versions due to dependency resolution errors.

Changes in this PR:

Update Composer requirement from
^7.1 || ^8.0 → ^7.4 || ^8.0

Remove PHP 7.1–7.3 from GitHub Actions test matrices

Adjust coverage job from 7.3 → 7.4

Limit PHPStan analysis to the src directory to avoid unrelated legacy test warnings

PHP 7.4 reached end-of-life on 28 November 2022.