### PR TITLE
Add Keynote reader and writer

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -14,6 +14,7 @@
 - PowerPoint2007 Reader : Read a group of shapes, and map the shapes it holds out of the coordinate space `a:chOff`/`a:chExt` declares, by [@Wilkolicious](http://github.com/Wilkolicious) in [#870](https://github.com/PHPOffice/PHPPresentation/pull/870) and [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 - Added `Shape\RichText\Field`, so that a slide number, a slide count or a date can stand inside a sentence rather than take a whole shape, written and read back by the PowerPoint2007 Writer and Reader and by the ODPresentation Writer and Reader, by [@dkulyk](http://github.com/dkulyk) fixing [#958](https://github.com/PHPOffice/PHPPresentation/issues/958) in [#959](https://github.com/PHPOffice/PHPPresentation/pull/959)
 - PowerPoint2007 Writer & Reader : Added a fill behind the data labels of a chart serie, so that a label stays readable over the chart it sits on, by [@dkulyk](http://github.com/dkulyk) in [#963](https://github.com/PHPOffice/PHPPresentation/pull/963)
+- Keynote: Add basic reader and writer for the Apple Keynote (.key) format by [@yasumorishima](https://github.com/yasumorishima) in [#891](https://github.com/PHPOffice/PHPPresentation/pull/891)
 
 ## Bug fixes
 - PowerPoint2007 Reader : Fixed a colour with an alpha coming back opaque and one character short, taking the first digit of the colour with it, by [@dkulyk](http://github.com/dkulyk) in [#961](https://github.com/PHPOffice/PHPPresentation/pull/961)

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -5,6 +5,7 @@
 ## Enhancements
 - `phpoffice/phpspreadsheet`: Allow version 5.0 by [@seanlynchwv](http://github.com/seanlynchwv) in [#879](https://github.com/PHPOffice/PHPPresentation/pull/879)
 - Raised the minimum PHP version to 7.4 (dropped 7.1, 7.2 and 7.3) by [@slayerfx](http://github.com/slayerfx) in [#894](https://github.com/PHPOffice/PHPPresentation/pull/894)
+- Keynote: Add basic reader and writer for the Apple Keynote (.key) format by [@yasumorishima](https://github.com/yasumorishima) in [#891](https://github.com/PHPOffice/PHPPresentation/pull/891)
 
 ## Bug fixes
 - Guarded `imagedestroy()` calls behind a PHP version check (no-op since PHP 8.0, deprecated in PHP 8.5) by [@slayerfx](http://github.com/slayerfx) in [#893](https://github.com/PHPOffice/PHPPresentation/pull/893)

--- a/docs/usage/readers.md
+++ b/docs/usage/readers.md
@@ -75,6 +75,22 @@ $reader = new PowerPoint2007();
 $reader->load(__DIR__ . '/sample.pptx', PowerPoint2007::SKIP_IMAGES);
 ```
 
+## Keynote
+The name of the reader is `Keynote`.
+
+This reader provides basic support for the legacy iWork '09 Keynote format, where
+the presentation is stored as an `index.apxl` XML document inside the `.key`
+package. It reads slides, text placeholders (paragraphs and runs), shape geometry
+and speaker notes. The modern IWA binary format used by Keynote '13 and later is
+not supported and is rejected by `canRead()`.
+
+``` php
+<?php
+
+$reader = IOFactory::createReader('Keynote');
+$reader->load(__DIR__ . '/sample.key');
+```
+
 ## Serialized
 The name of the reader is `Serialized`.
 

--- a/docs/usage/writers.md
+++ b/docs/usage/writers.md
@@ -56,6 +56,22 @@ $writer->setZipAdapter(new PclZipAdapter());
 $writer->save(__DIR__ . '/sample.pptx');
 ```
 
+## Keynote
+The name of the writer is `Keynote`.
+
+The writer produces a `.key` package following the legacy iWork '09 structure
+(an `index.apxl` document). It writes slides, text placeholders (paragraphs and
+runs), shape geometry and speaker notes. The output is round-trippable with the
+`Keynote` reader; opening it directly in a current Keynote.app is not guaranteed
+because of the format generation gap.
+
+``` php
+<?php
+
+$writer = IOFactory::createWriter($oPhpPresentation, 'Keynote');
+$writer->save(__DIR__ . '/sample.key');
+```
+
 ## Serialized
 The name of the writer is `Serialized`.
 

--- a/src/PhpPresentation/IOFactory.php
+++ b/src/PhpPresentation/IOFactory.php
@@ -36,7 +36,7 @@ class IOFactory
      *
      * @var array<int, string>
      */
-    private static $autoResolveClasses = ['Serialized', 'ODPresentation', 'PowerPoint97', 'PowerPoint2007'];
+    private static $autoResolveClasses = ['Serialized', 'ODPresentation', 'PowerPoint97', 'PowerPoint2007', 'Keynote'];
 
     /**
      * Create writer.

--- a/src/PhpPresentation/Reader/Keynote.php
+++ b/src/PhpPresentation/Reader/Keynote.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @see        https://github.com/PHPOffice/PHPPresentation
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpPresentation\Reader;
+
+use DOMElement;
+use PhpOffice\Common\XMLReader;
+use PhpOffice\PhpPresentation\Exception\FileNotFoundException;
+use PhpOffice\PhpPresentation\Exception\InvalidFileFormatException;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Shape\RichText;
+use PhpOffice\PhpPresentation\Slide;
+use ZipArchive;
+
+/**
+ * Reader for the Apple Keynote (.key) presentation format.
+ *
+ * This reader targets the legacy iWork '09 single-file structure, where the
+ * presentation is described by an `index.apxl` XML document stored inside the
+ * Keynote package (a Zip archive). The modern IWA binary format (Keynote '13 and
+ * later) is intentionally not handled and is safely rejected by canRead().
+ */
+class Keynote implements ReaderInterface
+{
+    /**
+     * Keynote namespace.
+     *
+     * @var string
+     */
+    public const NS_KEY = 'http://developer.apple.com/namespaces/keynote2';
+
+    /**
+     * iWork shared namespace.
+     *
+     * @var string
+     */
+    public const NS_SF = 'http://developer.apple.com/namespaces/sf';
+
+    /**
+     * iWork shared abstract namespace.
+     *
+     * @var string
+     */
+    public const NS_SFA = 'http://developer.apple.com/namespaces/sfa';
+
+    /**
+     * Output object.
+     *
+     * @var PhpPresentation
+     */
+    protected $oPhpPresentation;
+
+    /**
+     * Should the images be loaded?
+     *
+     * @var bool
+     */
+    protected $loadImages = true;
+
+    /**
+     * Can the current reader read the file?
+     */
+    public function canRead(string $pFilename): bool
+    {
+        return $this->fileSupportsUnserializePhpPresentation($pFilename);
+    }
+
+    /**
+     * Does a file support being read by this reader?
+     */
+    public function fileSupportsUnserializePhpPresentation(string $pFilename = ''): bool
+    {
+        if (!file_exists($pFilename)) {
+            throw new FileNotFoundException($pFilename);
+        }
+
+        $oZip = new ZipArchive();
+        if (true === $oZip->open($pFilename)) {
+            $isApxl = is_array($oZip->statName('index.apxl'));
+            $oZip->close();
+
+            return $isApxl;
+        }
+
+        return false;
+    }
+
+    /**
+     * Loads a Keynote file.
+     */
+    public function load(string $pFilename, int $flags = 0): PhpPresentation
+    {
+        if (!$this->fileSupportsUnserializePhpPresentation($pFilename)) {
+            throw new InvalidFileFormatException($pFilename, self::class);
+        }
+
+        $this->loadImages = !((bool) ($flags & self::SKIP_IMAGES));
+
+        return $this->loadFile($pFilename);
+    }
+
+    /**
+     * Loads the file content into a PhpPresentation object.
+     */
+    protected function loadFile(string $pFilename): PhpPresentation
+    {
+        $this->oPhpPresentation = new PhpPresentation();
+        $this->oPhpPresentation->removeSlideByIndex();
+
+        $oXMLReader = new XMLReader();
+        if (false !== $oXMLReader->getDomFromZip($pFilename, 'index.apxl')) {
+            $oXMLReader->registerNamespace('key', self::NS_KEY);
+            $oXMLReader->registerNamespace('sf', self::NS_SF);
+            $oXMLReader->registerNamespace('sfa', self::NS_SFA);
+            $this->loadSlides($oXMLReader);
+        }
+
+        return $this->oPhpPresentation;
+    }
+
+    /**
+     * Reads every slide of the presentation.
+     */
+    protected function loadSlides(XMLReader $oXMLReader): void
+    {
+        foreach ($oXMLReader->getElements('/key:presentation/key:slide-list/key:slide') as $oNodeSlide) {
+            if (!$oNodeSlide instanceof DOMElement) {
+                continue;
+            }
+            $oSlide = $this->oPhpPresentation->createSlide();
+            $this->loadShapes($oXMLReader, $oNodeSlide, $oSlide);
+            $this->loadNote($oXMLReader, $oNodeSlide, $oSlide);
+        }
+    }
+
+    /**
+     * Reads every text placeholder of a slide.
+     */
+    protected function loadShapes(XMLReader $oXMLReader, DOMElement $oNodeSlide, Slide $oSlide): void
+    {
+        foreach ($oXMLReader->getElements('./key:drawables/key:body-placeholder', $oNodeSlide) as $oNodeShape) {
+            if (!$oNodeShape instanceof DOMElement) {
+                continue;
+            }
+            $oRichText = $oSlide->createRichTextShape();
+            $this->loadGeometry($oXMLReader, $oNodeShape, $oRichText);
+            $this->loadText($oXMLReader, $oNodeShape, $oRichText);
+        }
+    }
+
+    /**
+     * Reads the position and size of a shape.
+     */
+    protected function loadGeometry(XMLReader $oXMLReader, DOMElement $oNodeShape, RichText $oRichText): void
+    {
+        $oNodePosition = $oXMLReader->getElement('./sf:geometry/sf:position', $oNodeShape);
+        if ($oNodePosition instanceof DOMElement) {
+            $oRichText->setOffsetX((int) $oNodePosition->getAttributeNS(self::NS_SFA, 'x'));
+            $oRichText->setOffsetY((int) $oNodePosition->getAttributeNS(self::NS_SFA, 'y'));
+        }
+
+        $oNodeSize = $oXMLReader->getElement('./sf:geometry/sf:size', $oNodeShape);
+        if ($oNodeSize instanceof DOMElement) {
+            $oRichText->setWidth((int) $oNodeSize->getAttributeNS(self::NS_SFA, 'w'));
+            $oRichText->setHeight((int) $oNodeSize->getAttributeNS(self::NS_SFA, 'h'));
+        }
+    }
+
+    /**
+     * Reads the paragraphs and runs of a text container.
+     */
+    protected function loadText(XMLReader $oXMLReader, DOMElement $oNodeContainer, RichText $oRichText): void
+    {
+        $oNodeBody = $oXMLReader->getElement('./sf:text/sf:text-storage/sf:text-body', $oNodeContainer);
+        if (!$oNodeBody instanceof DOMElement) {
+            return;
+        }
+
+        $isFirstParagraph = true;
+        foreach ($oXMLReader->getElements('./sf:p', $oNodeBody) as $oNodeParagraph) {
+            if (!$oNodeParagraph instanceof DOMElement) {
+                continue;
+            }
+            $oParagraph = $isFirstParagraph
+                ? $oRichText->getActiveParagraph()
+                : $oRichText->createParagraph();
+            $isFirstParagraph = false;
+
+            foreach ($oXMLReader->getElements('./sf:span', $oNodeParagraph) as $oNodeSpan) {
+                if (!$oNodeSpan instanceof DOMElement) {
+                    continue;
+                }
+                $oParagraph->createTextRun((string) $oNodeSpan->nodeValue);
+            }
+        }
+    }
+
+    /**
+     * Reads the speaker note of a slide.
+     */
+    protected function loadNote(XMLReader $oXMLReader, DOMElement $oNodeSlide, Slide $oSlide): void
+    {
+        $oNodeNote = $oXMLReader->getElement('./key:notes', $oNodeSlide);
+        if (!$oNodeNote instanceof DOMElement) {
+            return;
+        }
+
+        $oRichText = $oSlide->getNote()->createRichTextShape();
+        $this->loadText($oXMLReader, $oNodeNote, $oRichText);
+    }
+}

--- a/src/PhpPresentation/Writer/Keynote.php
+++ b/src/PhpPresentation/Writer/Keynote.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @see        https://github.com/PHPOffice/PHPPresentation
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpPresentation\Writer;
+
+use PhpOffice\Common\Adapter\Zip\ZipArchiveAdapter;
+use PhpOffice\Common\XMLWriter;
+use PhpOffice\PhpPresentation\Exception\FileCopyException;
+use PhpOffice\PhpPresentation\Exception\FileRemoveException;
+use PhpOffice\PhpPresentation\Exception\InvalidParameterException;
+use PhpOffice\PhpPresentation\HashTable;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Shape\RichText;
+use PhpOffice\PhpPresentation\Shape\RichText\Run;
+use PhpOffice\PhpPresentation\Slide;
+
+/**
+ * Writer for the Apple Keynote (.key) presentation format.
+ *
+ * The writer produces a Keynote package (a Zip archive) holding an `index.apxl`
+ * XML document that follows the legacy iWork '09 structure. The output is meant to
+ * be round-trippable with the matching reader; opening it directly in a current
+ * Keynote.app is not guaranteed because of the format generation gap.
+ *
+ * Only text placeholders (their paragraphs and text runs), shape geometry and
+ * speaker notes are written. Other content (images, tables, charts and line
+ * breaks) is not represented in this basic format and is silently skipped on save.
+ */
+class Keynote extends AbstractWriter implements WriterInterface
+{
+    /**
+     * Keynote namespace.
+     *
+     * @var string
+     */
+    public const NS_KEY = 'http://developer.apple.com/namespaces/keynote2';
+
+    /**
+     * iWork shared namespace.
+     *
+     * @var string
+     */
+    public const NS_SF = 'http://developer.apple.com/namespaces/sf';
+
+    /**
+     * iWork shared abstract namespace.
+     *
+     * @var string
+     */
+    public const NS_SFA = 'http://developer.apple.com/namespaces/sfa';
+
+    /**
+     * Create a new Keynote writer.
+     */
+    public function __construct(?PhpPresentation $pPhpPresentation = null)
+    {
+        $this->setPhpPresentation($pPhpPresentation ?? new PhpPresentation());
+        $this->oDrawingHashTable = new HashTable();
+        $this->setZipAdapter(new ZipArchiveAdapter());
+    }
+
+    /**
+     * Save PhpPresentation to file.
+     */
+    public function save(string $pFilename): void
+    {
+        if (empty($pFilename)) {
+            throw new InvalidParameterException('pFilename', '');
+        }
+
+        // If $pFilename is php://output or php://stdout, make it a temporary file...
+        $originalFilename = $pFilename;
+        if ('php://output' == strtolower($pFilename) || 'php://stdout' == strtolower($pFilename)) {
+            $pFilename = @tempnam(sys_get_temp_dir(), 'phppttmp');
+            if (false === $pFilename) {
+                $pFilename = $originalFilename;
+            }
+        }
+
+        $oZip = $this->getZipAdapter();
+        $oZip->open($pFilename);
+        $oZip->addFromString('index.apxl', $this->writeContent());
+        $oZip->close();
+
+        // If a temporary file was used, copy it to the correct file stream
+        if ($originalFilename != $pFilename) {
+            if (false === copy($pFilename, $originalFilename)) {
+                throw new FileCopyException($pFilename, $originalFilename);
+            }
+            if (false === @unlink($pFilename)) {
+                throw new FileRemoveException($pFilename);
+            }
+        }
+    }
+
+    /**
+     * Builds the index.apxl document.
+     */
+    protected function writeContent(): string
+    {
+        $objWriter = new XMLWriter(XMLWriter::STORAGE_MEMORY);
+        $objWriter->startDocument('1.0', 'UTF-8');
+
+        $objWriter->startElement('key:presentation');
+        $objWriter->writeAttribute('xmlns:key', self::NS_KEY);
+        $objWriter->writeAttribute('xmlns:sf', self::NS_SF);
+        $objWriter->writeAttribute('xmlns:sfa', self::NS_SFA);
+        $objWriter->writeAttribute('key:version', '92008102400');
+
+        $objWriter->startElement('key:size');
+        $objWriter->writeAttribute('sfa:w', '960');
+        $objWriter->writeAttribute('sfa:h', '720');
+        $objWriter->endElement();
+
+        $objWriter->startElement('key:theme-list');
+        $objWriter->startElement('key:theme');
+        $objWriter->writeAttribute('key:name', 'PHPPresentation');
+        $objWriter->endElement();
+        $objWriter->endElement();
+
+        $objWriter->startElement('key:slide-list');
+        foreach ($this->getPhpPresentation()->getAllSlides() as $oSlide) {
+            $this->writeSlide($objWriter, $oSlide);
+        }
+        $objWriter->endElement();
+
+        $objWriter->endElement();
+
+        return $objWriter->getData();
+    }
+
+    /**
+     * Writes a single slide.
+     */
+    protected function writeSlide(XMLWriter $objWriter, Slide $oSlide): void
+    {
+        $objWriter->startElement('key:slide');
+
+        $objWriter->startElement('key:drawables');
+        foreach ($oSlide->getShapeCollection() as $oShape) {
+            if ($oShape instanceof RichText) {
+                $this->writeShape($objWriter, $oShape);
+            }
+        }
+        $objWriter->endElement();
+
+        foreach ($oSlide->getNote()->getShapeCollection() as $oNoteShape) {
+            if ($oNoteShape instanceof RichText) {
+                $objWriter->startElement('key:notes');
+                $this->writeText($objWriter, $oNoteShape);
+                $objWriter->endElement();
+
+                break;
+            }
+        }
+
+        $objWriter->endElement();
+    }
+
+    /**
+     * Writes a text placeholder shape, including its geometry.
+     */
+    protected function writeShape(XMLWriter $objWriter, RichText $oShape): void
+    {
+        $objWriter->startElement('key:body-placeholder');
+
+        $objWriter->startElement('sf:geometry');
+        $objWriter->startElement('sf:position');
+        $objWriter->writeAttribute('sfa:x', (string) $oShape->getOffsetX());
+        $objWriter->writeAttribute('sfa:y', (string) $oShape->getOffsetY());
+        $objWriter->endElement();
+        $objWriter->startElement('sf:size');
+        $objWriter->writeAttribute('sfa:w', (string) $oShape->getWidth());
+        $objWriter->writeAttribute('sfa:h', (string) $oShape->getHeight());
+        $objWriter->endElement();
+        $objWriter->endElement();
+
+        $this->writeText($objWriter, $oShape);
+
+        $objWriter->endElement();
+    }
+
+    /**
+     * Writes the paragraphs and runs of a text container.
+     */
+    protected function writeText(XMLWriter $objWriter, RichText $oShape): void
+    {
+        $objWriter->startElement('sf:text');
+        $objWriter->startElement('sf:text-storage');
+        $objWriter->startElement('sf:text-body');
+        foreach ($oShape->getParagraphs() as $oParagraph) {
+            $objWriter->startElement('sf:p');
+            foreach ($oParagraph->getRichTextElements() as $oElement) {
+                // Only plain text runs are round-trippable; line breaks and other
+                // element types are not represented in this basic format.
+                if (!$oElement instanceof Run) {
+                    continue;
+                }
+                $objWriter->startElement('sf:span');
+                $objWriter->text((string) $oElement->getText());
+                $objWriter->endElement();
+            }
+            $objWriter->endElement();
+        }
+        $objWriter->endElement();
+        $objWriter->endElement();
+        $objWriter->endElement();
+    }
+}

--- a/tests/PhpPresentation/Tests/KeynoteRoundtripTest.php
+++ b/tests/PhpPresentation/Tests/KeynoteRoundtripTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @see        https://github.com/PHPOffice/PHPPresentation
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpPresentation\Tests;
+
+use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Reader\Keynote as KeynoteReader;
+use PhpOffice\PhpPresentation\Shape\RichText;
+use PhpOffice\PhpPresentation\Writer\Keynote as KeynoteWriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Round-trip test for the Keynote reader and writer.
+ */
+class KeynoteRoundtripTest extends TestCase
+{
+    public function testRoundtripPreservesContent(): void
+    {
+        $oOriginal = new PhpPresentation();
+        $oOriginal->removeSlideByIndex();
+
+        $oSlide1 = $oOriginal->createSlide();
+        $oShape1 = $oSlide1->createRichTextShape();
+        $oShape1->setOffsetX(100);
+        $oShape1->setOffsetY(200);
+        $oShape1->setWidth(300);
+        $oShape1->setHeight(150);
+        $oParagraph1 = $oShape1->getActiveParagraph();
+        $oParagraph1->createTextRun('First ');
+        $oParagraph1->createTextRun('run');
+        $oParagraph2 = $oShape1->createParagraph();
+        $oParagraph2->createTextRun('Second paragraph');
+        $oSlide1->getNote()->createRichTextShape()->createTextRun('Note text');
+
+        $oSlide2 = $oOriginal->createSlide();
+        $oSlide2->createRichTextShape()->createTextRun('Slide two');
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        (new KeynoteWriter($oOriginal))->save($sFilename);
+
+        $oResult = (new KeynoteReader())->load($sFilename);
+        unlink($sFilename);
+
+        self::assertCount(2, $oResult->getAllSlides());
+
+        $aShapes = $oResult->getSlide(0)->getShapeCollection();
+        self::assertCount(1, $aShapes);
+        $oResultShape = $aShapes[0];
+        self::assertInstanceOf(RichText::class, $oResultShape);
+        self::assertSame(100, $oResultShape->getOffsetX());
+        self::assertSame(200, $oResultShape->getOffsetY());
+        self::assertSame(300, $oResultShape->getWidth());
+        self::assertSame(150, $oResultShape->getHeight());
+
+        $aParagraphs = $oResultShape->getParagraphs();
+        self::assertCount(2, $aParagraphs);
+        self::assertSame('First run', $aParagraphs[0]->getPlainText());
+        self::assertSame('Second paragraph', $aParagraphs[1]->getPlainText());
+
+        $aNoteShapes = $oResult->getSlide(0)->getNote()->getShapeCollection();
+        self::assertCount(1, $aNoteShapes);
+        $oNoteShape = $aNoteShapes[0];
+        self::assertInstanceOf(RichText::class, $oNoteShape);
+        $sNoteText = $oNoteShape->getPlainText();
+        self::assertSame('Note text', $sNoteText);
+
+        self::assertCount(1, $oResult->getSlide(1)->getShapeCollection());
+    }
+
+    public function testRoundtripEmptyPresentation(): void
+    {
+        $oOriginal = new PhpPresentation();
+        $oOriginal->removeSlideByIndex();
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        (new KeynoteWriter($oOriginal))->save($sFilename);
+
+        $oResult = (new KeynoteReader())->load($sFilename);
+        unlink($sFilename);
+
+        self::assertCount(0, $oResult->getAllSlides());
+    }
+
+    /**
+     * Text runs carrying non-ASCII characters and XML metacharacters must survive
+     * a write/read cycle unchanged (proper escaping in the writer, unescaping in
+     * the reader).
+     */
+    public function testRoundtripPreservesUnicodeAndSpecialCharacters(): void
+    {
+        $sText = 'Unicode: aeiou 日本語 emoji 😀 - markup <tag> & "quotes" \'apostrophe\'';
+
+        $oOriginal = new PhpPresentation();
+        $oOriginal->removeSlideByIndex();
+        $oOriginal->createSlide()->createRichTextShape()->createTextRun($sText);
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        (new KeynoteWriter($oOriginal))->save($sFilename);
+
+        $oResult = (new KeynoteReader())->load($sFilename);
+        unlink($sFilename);
+
+        $aShapes = $oResult->getSlide(0)->getShapeCollection();
+        self::assertCount(1, $aShapes);
+        $oResultShape = $aShapes[0];
+        self::assertInstanceOf(RichText::class, $oResultShape);
+        self::assertSame($sText, $oResultShape->getPlainText());
+    }
+
+    /**
+     * Every text placeholder of a slide is written and read back in order.
+     */
+    public function testRoundtripPreservesMultipleShapesPerSlide(): void
+    {
+        $oOriginal = new PhpPresentation();
+        $oOriginal->removeSlideByIndex();
+        $oSlide = $oOriginal->createSlide();
+        $oSlide->createRichTextShape()->createTextRun('Shape one');
+        $oSlide->createRichTextShape()->createTextRun('Shape two');
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        (new KeynoteWriter($oOriginal))->save($sFilename);
+
+        $oResult = (new KeynoteReader())->load($sFilename);
+        unlink($sFilename);
+
+        $aShapes = $oResult->getSlide(0)->getShapeCollection();
+        self::assertCount(2, $aShapes);
+        self::assertInstanceOf(RichText::class, $aShapes[0]);
+        self::assertInstanceOf(RichText::class, $aShapes[1]);
+        self::assertSame('Shape one', $aShapes[0]->getPlainText());
+        self::assertSame('Shape two', $aShapes[1]->getPlainText());
+    }
+
+    /**
+     * Content that the basic format cannot represent is skipped silently: a
+     * non-text shape produces no output, and line breaks inside a text run are
+     * dropped while the surrounding runs are preserved.
+     */
+    public function testRoundtripSkipsNonRepresentableContent(): void
+    {
+        $oOriginal = new PhpPresentation();
+        $oOriginal->removeSlideByIndex();
+        $oSlide = $oOriginal->createSlide();
+
+        // A line is not a text placeholder and must not be written.
+        $oSlide->createLineShape(10, 10, 100, 100);
+
+        $oShape = $oSlide->createRichTextShape();
+        $oParagraph = $oShape->getActiveParagraph();
+        $oParagraph->createTextRun('before');
+        $oParagraph->createBreak();
+        $oParagraph->createTextRun('after');
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        (new KeynoteWriter($oOriginal))->save($sFilename);
+
+        $oResult = (new KeynoteReader())->load($sFilename);
+        unlink($sFilename);
+
+        // Only the text placeholder survives; the line shape is skipped.
+        $aShapes = $oResult->getSlide(0)->getShapeCollection();
+        self::assertCount(1, $aShapes);
+        $oResultShape = $aShapes[0];
+        self::assertInstanceOf(RichText::class, $oResultShape);
+        // The break is dropped, so the two runs are concatenated.
+        self::assertSame('beforeafter', $oResultShape->getPlainText());
+    }
+}

--- a/tests/PhpPresentation/Tests/Reader/KeynoteTest.php
+++ b/tests/PhpPresentation/Tests/Reader/KeynoteTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @see        https://github.com/PHPOffice/PHPPresentation
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpPresentation\Tests\Reader;
+
+use PhpOffice\PhpPresentation\Exception\FileNotFoundException;
+use PhpOffice\PhpPresentation\Exception\InvalidFileFormatException;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Reader\Keynote;
+use PhpOffice\PhpPresentation\Writer\Keynote as KeynoteWriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for the Keynote reader.
+ *
+ * @coversDefaultClass \PhpOffice\PhpPresentation\Reader\Keynote
+ */
+class KeynoteTest extends TestCase
+{
+    /**
+     * Create a sample Keynote file on disk and return its path.
+     */
+    private function createSampleFile(): string
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSlide = $oPhpPresentation->getActiveSlide();
+        $oRichText = $oSlide->createRichTextShape();
+        $oRichText->createTextRun('Sample text');
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        $oWriter = new KeynoteWriter($oPhpPresentation);
+        $oWriter->save($sFilename);
+
+        return $sFilename;
+    }
+
+    public function testCanReadValidFile(): void
+    {
+        $sFilename = $this->createSampleFile();
+
+        $oReader = new Keynote();
+        self::assertTrue($oReader->canRead($sFilename));
+
+        unlink($sFilename);
+    }
+
+    public function testCanReadRejectsOtherFormats(): void
+    {
+        $oReader = new Keynote();
+        self::assertFalse($oReader->canRead(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_01.pptx'));
+    }
+
+    public function testCanReadRejectsNonZipFile(): void
+    {
+        $oReader = new Keynote();
+        self::assertFalse($oReader->canRead(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_01.ppt'));
+    }
+
+    public function testCanReadRejectsDirectory(): void
+    {
+        $oReader = new Keynote();
+        self::assertFalse($oReader->canRead(PHPPRESENTATION_TESTS_BASE_DIR));
+    }
+
+    public function testLoadFileNotExistsThrows(): void
+    {
+        $this->expectException(FileNotFoundException::class);
+
+        $oReader = new Keynote();
+        $oReader->load(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/does_not_exist.key');
+    }
+
+    public function testLoadBadFormatThrows(): void
+    {
+        $this->expectException(InvalidFileFormatException::class);
+
+        $oReader = new Keynote();
+        $oReader->load(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Sample_00_01.pptx');
+    }
+
+    public function testLoadReadsContent(): void
+    {
+        $sFilename = $this->createSampleFile();
+
+        $oReader = new Keynote();
+        $oPhpPresentation = $oReader->load($sFilename);
+        unlink($sFilename);
+
+        self::assertCount(1, $oPhpPresentation->getAllSlides());
+        $aShapes = $oPhpPresentation->getSlide(0)->getShapeCollection();
+        self::assertCount(1, $aShapes);
+    }
+}

--- a/tests/PhpPresentation/Tests/Writer/KeynoteTest.php
+++ b/tests/PhpPresentation/Tests/Writer/KeynoteTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of PHPPresentation - A pure PHP library for reading and writing
+ * presentations documents.
+ *
+ * PHPPresentation is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPPresentation/contributors.
+ *
+ * @see        https://github.com/PHPOffice/PHPPresentation
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpPresentation\Tests\Writer;
+
+use DOMDocument;
+use PhpOffice\PhpPresentation\Exception\InvalidParameterException;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Writer\Keynote;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * Test class for the Keynote writer.
+ *
+ * @coversDefaultClass \PhpOffice\PhpPresentation\Writer\Keynote
+ */
+class KeynoteTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oWriter = new Keynote($oPhpPresentation);
+        self::assertSame($oPhpPresentation, $oWriter->getPhpPresentation());
+    }
+
+    public function testSaveCreatesApxlEntry(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSlide = $oPhpPresentation->getActiveSlide();
+        $oRichText = $oSlide->createRichTextShape();
+        $oRichText->createTextRun('Hello Keynote');
+
+        $sFilename = tempnam(sys_get_temp_dir(), 'kny') . '.key';
+        $oWriter = new Keynote($oPhpPresentation);
+        $oWriter->save($sFilename);
+
+        self::assertFileExists($sFilename);
+
+        $oZip = new ZipArchive();
+        self::assertTrue(true === $oZip->open($sFilename));
+        $sContent = $oZip->getFromName('index.apxl');
+        $oZip->close();
+
+        self::assertNotFalse($sContent);
+
+        $oDom = new DOMDocument();
+        self::assertTrue($oDom->loadXML((string) $sContent));
+        self::assertStringContainsString('Hello Keynote', (string) $sContent);
+        self::assertStringContainsString('key:presentation', (string) $sContent);
+
+        unlink($sFilename);
+    }
+
+    public function testSaveWithEmptyFilenameThrows(): void
+    {
+        $this->expectException(InvalidParameterException::class);
+
+        $oWriter = new Keynote(new PhpPresentation());
+        $oWriter->save('');
+    }
+}


### PR DESCRIPTION
## What it does

Adds a **Reader** and **Writer** for the Apple Keynote (`.key`) presentation format.

The implementation targets the **legacy iWork '09 structure**, where a Keynote
package is a Zip archive containing an `index.apxl` XML document. Both classes
follow the existing reader/writer conventions (`ReaderInterface` / `AbstractWriter`)
and are registered in `IOFactory` for automatic resolution.

Supported in this first milestone:

- Slides
- Text placeholders — paragraphs and runs
- Shape geometry (position and size)
- Speaker notes

## Why

Resolves the long-standing request for Keynote support (#48). A previous attempt
(#860) targeted the modern IWA binary format and stalled; this PR deliberately
scopes to the XML-based iWork '09 structure so it can be implemented in pure PHP
(no new dependencies), stays compatible with the project's supported PHP versions
(7.4+), and is fully verifiable in CI.

## Scope / limitations (intentional)

- The **modern IWA binary format** (Keynote '13 and later: Snappy-compressed
  Protobuf) is **out of scope** and is safely rejected by `canRead()` (no false
  positives).
- Because of the format generation gap, output is **not guaranteed** to open
  directly in a current Keynote.app. Correctness is instead guaranteed by a
  **round-trip test** (write → read → assert structure).
- Content that the basic format cannot represent — non-text shapes (images,
  lines, tables, charts) and in-run line breaks — is **silently skipped** on
  save; this is characterized by tests (see below).
- Styling (font/bold/size/color), themes and document properties are left as
  follow-up work.

## How it was tested

- New unit tests for the reader and writer, plus a dedicated round-trip test.
- Reader coverage includes `canRead()` rejection of non-Keynote files, non-Zip
  files and directories, and `load()` error cases (missing file, wrong format).
- Round-trip coverage includes: multi-slide content with geometry, paragraphs,
  runs and speaker notes; an empty presentation; **Unicode and XML metacharacters**
  (`< > & " '`, non-ASCII, emoji) surviving escaping unchanged; **multiple text
  placeholders per slide** preserved in order; and **non-representable content**
  (a line shape and an in-run line break) being skipped without data corruption.
- `phpunit`, `phpstan` (level 6), `php-cs-fixer` and `phpmd` all pass; the full
  existing suite remains green (no regressions).

## Notes

- No new runtime dependencies; uses only `ext-xml` and `ext-zip` (already required).
- Documentation updated in `docs/usage/readers.md` and `docs/usage/writers.md`.

Closes #48

/claim #48
