### PR TITLE
Guard imagedestroy() calls behind a PHP version check (#886)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -7,4 +7,5 @@
 - Raised the minimum PHP version to 7.4 (dropped 7.1, 7.2 and 7.3) by [@slayerfx](http://github.com/slayerfx) in [#894](https://github.com/PHPOffice/PHPPresentation/pull/894)
 
 ## Bug fixes
+- Guarded `imagedestroy()` calls behind a PHP version check (no-op since PHP 8.0, deprecated in PHP 8.5) by [@slayerfx](http://github.com/slayerfx) in [#893](https://github.com/PHPOffice/PHPPresentation/pull/893)
 

--- a/src/PhpPresentation/Writer/ODPresentation/MetaInfManifest.php
+++ b/src/PhpPresentation/Writer/ODPresentation/MetaInfManifest.php
@@ -106,7 +106,9 @@ class MetaInfManifest extends AbstractDecoratorWriter
             // PNG : 8bit, non-interlaced with full alpha transparency
             $gdImage = imagecreatefromstring(file_get_contents($pathThumbnail));
             if ($gdImage) {
-                imagedestroy($gdImage);
+                if (PHP_VERSION_ID < 80000) {
+                    imagedestroy($gdImage);
+                }
                 $objWriter->startElement('manifest:file-entry');
                 $objWriter->writeAttribute('manifest:media-type', 'image/png');
                 $objWriter->writeAttribute('manifest:full-path', 'Thumbnails/thumbnail.png');

--- a/src/PhpPresentation/Writer/ODPresentation/ThumbnailsThumbnail.php
+++ b/src/PhpPresentation/Writer/ODPresentation/ThumbnailsThumbnail.php
@@ -47,8 +47,10 @@ class ThumbnailsThumbnail extends AbstractDecoratorWriter
                 $imageContents = ob_get_contents();
                 ob_end_clean();
 
-                imagedestroy($gdRender);
-                imagedestroy($gdImage);
+                if (PHP_VERSION_ID < 80000) {
+                    imagedestroy($gdRender);
+                    imagedestroy($gdImage);
+                }
 
                 $this->getZip()->addFromString('Thumbnails/thumbnail.png', $imageContents);
             }

--- a/src/PhpPresentation/Writer/PowerPoint2007/DocPropsThumbnail.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/DocPropsThumbnail.php
@@ -34,7 +34,9 @@ class DocPropsThumbnail extends AbstractDecoratorWriter
                 imagejpeg($gdImage);
                 $imageContents = ob_get_contents();
                 ob_end_clean();
-                imagedestroy($gdImage);
+                if (PHP_VERSION_ID < 80000) {
+                    imagedestroy($gdImage);
+                }
                 $this->getZip()->addFromString('docProps/thumbnail.jpeg', $imageContents);
             }
         }

--- a/src/PhpPresentation/Writer/PowerPoint2007/Relationships.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/Relationships.php
@@ -70,7 +70,9 @@ class Relationships extends AbstractDecoratorWriter
         if ($thumnbail) {
             $gdImage = imagecreatefromstring($thumnbail);
             if ($gdImage) {
-                imagedestroy($gdImage);
+                if (PHP_VERSION_ID < 80000) {
+                    imagedestroy($gdImage);
+                }
                 // Relationship docProps/thumbnail.jpeg
                 $this->writeRelationship($objWriter, $idxRelation, 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail', 'docProps/thumbnail.jpeg');
                 // $idxRelation++;


### PR DESCRIPTION
### Description

`imagedestroy()` is deprecated in PHP 8.5 (and a no-op since PHP 8.0). Its 5 call
sites are now guarded by `if (PHP_VERSION_ID < 80000)`, so it only runs on PHP < 8.0
and no longer triggers the deprecation. No behaviour change on PHP 8+.

Fixes #886

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
- [x] I have updated the changelog
