### PR TITLE
Raise minimum PHP version to 7.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
@@ -68,14 +68,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2
           with:
               php-version: ${{ matrix.php }}
               extensions: gd, xml, zip
-              coverage: ${{ (matrix.php == '7.3') && 'xdebug' || 'none' }}
+              coverage: ${{ (matrix.php == '8.3') && 'xdebug' || 'none' }}
 
       -   uses: actions/checkout@v2
 
@@ -83,15 +83,15 @@ jobs:
           run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       -   name: Run phpunit
-          if: matrix.php != '7.3'
+          if: matrix.php != '8.3'
           run: ./vendor/bin/phpunit -c phpunit.xml.dist --no-coverage
 
       -   name: Run phpunit
-          if: matrix.php == '7.3'
+          if: matrix.php == '8.3'
           run: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/clover.xml
 
       -   name: Upload coverage results to Coveralls
-          if: matrix.php == '7.3'
+          if: matrix.php == '8.3'
           env:
             COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.4|^8.0",
         "ext-xml": "*",
         "ext-zip": "*",
         "phpoffice/common": "^1",

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 - `phpoffice/phpspreadsheet`: Allow version 5.0 by [@seanlynchwv](http://github.com/seanlynchwv) in [#879](https://github.com/PHPOffice/PHPPresentation/pull/879)
+- Raised the minimum PHP version to 7.4 (dropped 7.1, 7.2 and 7.3) by [@slayerfx](http://github.com/slayerfx) in [#894](https://github.com/PHPOffice/PHPPresentation/pull/894)
 
 ## Bug fixes
 


### PR DESCRIPTION
### Description

Raises the minimum PHP version to 7.4 and drops 7.1/7.2/7.3 from the CI matrix,
as discussed: phpspreadsheet no longer has a secure version installable on those
PHP versions. Coverage moved from 7.3 to 8.3.

### Checklist:

- [ ] My CI is :green_circle:
- [x] I have updated the changelog
