### PR TITLE
Fix code coverage configuration for PHPUnit 10+

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -8,4 +8,5 @@
 
 ## Bug fixes
 - Guarded `imagedestroy()` calls behind a PHP version check (no-op since PHP 8.0, deprecated in PHP 8.5) by [@slayerfx](http://github.com/slayerfx) in [#893](https://github.com/PHPOffice/PHPPresentation/pull/893)
+- Fixed code coverage configuration for PHPUnit 10+ by [@slayerfx](http://github.com/slayerfx) in [#895](https://github.com/PHPOffice/PHPPresentation/pull/895)
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,20 +2,17 @@
 <phpunit 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="./tests/bootstrap.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    convertDeprecationsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
+  <source>
     <include>
       <directory suffix=".php">./src</directory>
     </include>
+  </source>
+  <coverage>
     <report>
       <clover outputFile="./build/logs/clover.xml"/>
       <html outputDirectory="./build/coverage"/>


### PR DESCRIPTION
The `PHPUnit 8.3` job (the only one running coverage) was failing on `master` because `phpunit.xml.dist` used the PHPUnit 9 coverage format (`<coverage><include>`) and kept attributes removed in PHPUnit 10.

Moved the `<include>` into a `<source>` element and dropped the obsolete attributes. All PHPUnit jobs are now green from 7.4 to 8.5.
