### PR TITLE
Fix static analysis on PHP 8.4 and 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=7.0",
         "phpmd/phpmd": "2.*",
-        "phpstan/phpstan": "^0.12.88 || ^1.0.0",
+        "phpstan/phpstan": "^2.2",
         "dompdf/dompdf": "^3.1"
     },
     "suggest": {

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -9,4 +9,5 @@
 ## Bug fixes
 - Guarded `imagedestroy()` calls behind a PHP version check (no-op since PHP 8.0, deprecated in PHP 8.5) by [@slayerfx](http://github.com/slayerfx) in [#893](https://github.com/PHPOffice/PHPPresentation/pull/893)
 - Fixed code coverage configuration for PHPUnit 10+ by [@slayerfx](http://github.com/slayerfx) in [#895](https://github.com/PHPOffice/PHPPresentation/pull/895)
+- Fixed static analysis on PHP 8.4 and 8.5 (PHPStan 1.x could not resolve the symbols of PHPUnit 13) by [@yasumorishima](http://github.com/yasumorishima) in [#897](https://github.com/PHPOffice/PHPPresentation/pull/897)
 

--- a/src/PhpPresentation/GeometryCalculator.php
+++ b/src/PhpPresentation/GeometryCalculator.php
@@ -37,7 +37,7 @@ class GeometryCalculator
     {
         $offsets = [self::X => 0, self::Y => 0];
 
-        if (null !== $container && 0 != count($container->getShapeCollection())) {
+        if (0 != count($container->getShapeCollection())) {
             $shapes = $container->getShapeCollection();
             if (null !== $shapes[0]) {
                 $offsets[self::X] = $shapes[0]->getOffsetX();
@@ -70,7 +70,7 @@ class GeometryCalculator
         /** @var array<string, int> $extents */
         $extents = [self::X => 0, self::Y => 0];
 
-        if (null !== $container && 0 != count($container->getShapeCollection())) {
+        if (0 != count($container->getShapeCollection())) {
             $shapes = $container->getShapeCollection();
             if (null !== $shapes[0]) {
                 $extents[self::X] = (int) ($shapes[0]->getOffsetX() + $shapes[0]->getWidth());

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -63,7 +63,7 @@ class ODPresentation implements ReaderInterface
     protected $oZip;
 
     /**
-     * @var array<string, array{alignment: null|Alignment, background: null, shadow: null|Shadow, fill: null|Fill, spacingAfter: null|int, spacingBefore: null|int, lineSpacingMode: null, lineSpacing: null, font: null, listStyle: null}>
+     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string}>
      */
     protected $arrayStyles = [];
 
@@ -662,7 +662,7 @@ class ODPresentation implements ReaderInterface
                     $oParagraph->setLineSpacingMode($this->arrayStyles[$keyStyle]['lineSpacingMode']);
                 }
                 if (!empty($this->arrayStyles[$keyStyle]['lineSpacing'])) {
-                    $oParagraph->setLineSpacing($this->arrayStyles[$keyStyle]['lineSpacing']);
+                    $oParagraph->setLineSpacing((int) $this->arrayStyles[$keyStyle]['lineSpacing']);
                 }
             }
         }

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -237,20 +237,26 @@ class PowerPoint2007 implements ReaderInterface
                 '/cp:coreProperties/dc:subject' => 'setSubject',
                 '/cp:coreProperties/cp:keywords' => 'setKeywords',
                 '/cp:coreProperties/cp:category' => 'setCategory',
-                '/cp:coreProperties/dcterms:created' => 'setCreated',
-                '/cp:coreProperties/dcterms:modified' => 'setModified',
                 '/cp:coreProperties/cp:revision' => 'setRevision',
                 '/cp:coreProperties/cp:contentStatus' => 'setStatus',
+            ];
+            $arrayDateProperties = [
+                '/cp:coreProperties/dcterms:created' => 'setCreated',
+                '/cp:coreProperties/dcterms:modified' => 'setModified',
             ];
             $oProperties = $this->oPhpPresentation->getDocumentProperties();
             foreach ($arrayProperties as $path => $property) {
                 $oElement = $xmlReader->getElement($path);
                 if ($oElement instanceof DOMElement) {
-                    if ($oElement->hasAttribute('xsi:type') && 'dcterms:W3CDTF' == $oElement->getAttribute('xsi:type')) {
-                        $dateTime = DateTime::createFromFormat(DateTime::W3C, $oElement->nodeValue);
+                    $oProperties->{$property}((string) $oElement->nodeValue);
+                }
+            }
+            foreach ($arrayDateProperties as $path => $property) {
+                $oElement = $xmlReader->getElement($path);
+                if ($oElement instanceof DOMElement) {
+                    $dateTime = DateTime::createFromFormat(DateTime::W3C, (string) $oElement->nodeValue);
+                    if (false !== $dateTime) {
                         $oProperties->{$property}($dateTime->getTimestamp());
-                    } else {
-                        $oProperties->{$property}($oElement->nodeValue);
                     }
                 }
             }
@@ -905,44 +911,42 @@ class PowerPoint2007 implements ReaderInterface
      */
     protected function loadShadow(XMLReader $document, DOMElement $node): ?Shadow
     {
-        if ($node instanceof DOMElement) {
-            $aNodes = $document->getElements('*', $node);
-            foreach ($aNodes as $nodeShadow) {
-                $type = explode(':', $nodeShadow->tagName);
-                $type = array_pop($type);
-                if ($type == Shadow::TYPE_SHADOW_INNER || $type == Shadow::TYPE_SHADOW_OUTER || $type == Shadow::TYPE_REFLECTION) {
-                    $oShadow = new Shadow();
-                    $oShadow->setVisible(true);
-                    $oShadow->setType($type);
-                    if ($nodeShadow->hasAttribute('blurRad')) {
-                        $oShadow->setBlurRadius((int) CommonDrawing::emuToPixels((int) $nodeShadow->getAttribute('blurRad')));
-                    }
-                    if ($nodeShadow->hasAttribute('dist')) {
-                        $oShadow->setDistance((int) CommonDrawing::emuToPixels((int) $nodeShadow->getAttribute('dist')));
-                    }
-                    if ($nodeShadow->hasAttribute('dir')) {
-                        $oShadow->setDirection((int) CommonDrawing::angleToDegrees((int) $nodeShadow->getAttribute('dir')));
-                    }
-                    if ($nodeShadow->hasAttribute('algn')) {
-                        $oShadow->setAlignment($node->getAttribute('algn'));
-                    }
-
-                    // Get color define by prstClr
-                    $oSubElement = $document->getElement('a:prstClr', $nodeShadow);
-                    if ($oSubElement instanceof DOMElement && $oSubElement->hasAttribute('val')) {
-                        $oColor = new Color();
-                        $oColor->setRGB($oSubElement->getAttribute('val'));
-
-                        $oSubElt = $document->getElement('a:alpha', $oSubElement);
-                        if ($oSubElt instanceof DOMElement && $oSubElt->hasAttribute('val')) {
-                            $oColor->setAlpha((int) $oSubElt->getAttribute('val') / 1000);
-                        }
-
-                        $oShadow->setColor($oColor);
-                    }
-
-                    return $oShadow;
+        $aNodes = $document->getElements('*', $node);
+        foreach ($aNodes as $nodeShadow) {
+            $type = explode(':', $nodeShadow->tagName);
+            $type = array_pop($type);
+            if ($type == Shadow::TYPE_SHADOW_INNER || $type == Shadow::TYPE_SHADOW_OUTER || $type == Shadow::TYPE_REFLECTION) {
+                $oShadow = new Shadow();
+                $oShadow->setVisible(true);
+                $oShadow->setType($type);
+                if ($nodeShadow->hasAttribute('blurRad')) {
+                    $oShadow->setBlurRadius((int) CommonDrawing::emuToPixels((int) $nodeShadow->getAttribute('blurRad')));
                 }
+                if ($nodeShadow->hasAttribute('dist')) {
+                    $oShadow->setDistance((int) CommonDrawing::emuToPixels((int) $nodeShadow->getAttribute('dist')));
+                }
+                if ($nodeShadow->hasAttribute('dir')) {
+                    $oShadow->setDirection((int) CommonDrawing::angleToDegrees((int) $nodeShadow->getAttribute('dir')));
+                }
+                if ($nodeShadow->hasAttribute('algn')) {
+                    $oShadow->setAlignment($node->getAttribute('algn'));
+                }
+
+                // Get color define by prstClr
+                $oSubElement = $document->getElement('a:prstClr', $nodeShadow);
+                if ($oSubElement instanceof DOMElement && $oSubElement->hasAttribute('val')) {
+                    $oColor = new Color();
+                    $oColor->setRGB($oSubElement->getAttribute('val'));
+
+                    $oSubElt = $document->getElement('a:alpha', $oSubElement);
+                    if ($oSubElt instanceof DOMElement && $oSubElt->hasAttribute('val')) {
+                        $oColor->setAlpha((int) $oSubElt->getAttribute('val') / 1000);
+                    }
+
+                    $oShadow->setColor($oColor);
+                }
+
+                return $oShadow;
             }
         }
 

--- a/src/PhpPresentation/Shape/Chart/Series.php
+++ b/src/PhpPresentation/Shape/Chart/Series.php
@@ -134,7 +134,7 @@ class Series implements ComparableInterface
     /**
      * Values (key/value).
      *
-     * @var array<string, null|string>
+     * @var array<array-key, null|string>
      */
     private $values = [];
 
@@ -146,7 +146,7 @@ class Series implements ComparableInterface
     private $hashIndex;
 
     /**
-     * @param array<string, null|string> $values
+     * @param array<array-key, null|string> $values
      */
     public function __construct(string $title = 'Series Title', array $values = [])
     {
@@ -239,7 +239,7 @@ class Series implements ComparableInterface
     /**
      * Get Values.
      *
-     * @return array<string, null|string>
+     * @return array<array-key, null|string>
      */
     public function getValues(): array
     {
@@ -249,7 +249,7 @@ class Series implements ComparableInterface
     /**
      * Set Values.
      *
-     * @param array<string, null|string> $values
+     * @param array<array-key, null|string> $values
      */
     public function setValues(array $values = []): self
     {

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -461,9 +461,7 @@ class Content extends AbstractDecoratorWriter
         $objWriter->writeAttribute('draw:style-name', 'gr' . $this->shapeId);
         // draw:image
         $objWriter->startElement('draw:image');
-        if ($shape instanceof AbstractDrawingAdapter) {
-            $objWriter->writeAttribute('xlink:href', 'Pictures/' . $shape->getIndexedFilename());
-        }
+        $objWriter->writeAttribute('xlink:href', 'Pictures/' . $shape->getIndexedFilename());
         $objWriter->writeAttribute('xlink:type', 'simple');
         $objWriter->writeAttribute('xlink:show', 'embed');
         $objWriter->writeAttribute('xlink:actuate', 'onLoad');

--- a/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
+++ b/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
@@ -557,8 +557,11 @@ class ObjectsChart extends AbstractDecoratorWriter
         $this->numSeries = 0;
         foreach ($chartType->getSeries() as $series) {
             $this->writeSeries($chart, $series);
-            ++$this->rangeCol;
             ++$this->numSeries;
+            // The first series is written in column B, so the next column is
+            // derived from its index. Incrementing the string is deprecated
+            // as of PHP 8.5.
+            $this->rangeCol = $this->getColumnName($this->numSeries + 2);
         }
 
         //**** Wall ****
@@ -997,5 +1000,21 @@ class ObjectsChart extends AbstractDecoratorWriter
         $this->xmlContent->endElement();
         // > style:style
         $this->xmlContent->endElement();
+    }
+
+    /**
+     * Returns the spreadsheet column name for a 1-based column index
+     * (1 => A, 2 => B, 26 => Z, 27 => AA).
+     */
+    private function getColumnName(int $index): string
+    {
+        $name = '';
+        while ($index > 0) {
+            $modulo = ($index - 1) % 26;
+            $name = chr(65 + $modulo) . $name;
+            $index = intdiv($index - $modulo, 26);
+        }
+
+        return $name;
     }
 }

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractDecoratorWriter.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractDecoratorWriter.php
@@ -62,10 +62,6 @@ abstract class AbstractDecoratorWriter extends \PhpOffice\PhpPresentation\Writer
      */
     protected function writeBorder(XMLWriter $objWriter, Border $pBorder, string $pElementName = 'L', bool $isMarker = false): void
     {
-        if (!($pBorder instanceof Border)) {
-            return;
-        }
-
         if (Border::LINE_NONE == $pBorder->getLineStyle() && '' == $pElementName && !$isMarker) {
             return;
         }

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -1354,9 +1354,7 @@ class PptCharts extends AbstractDecoratorWriter
             $objWriter->endElement();
         }
 
-        if (($angle = $subject->getFirstSliceAngle()) !== null) {
-            $this->writeElementWithValAttribute($objWriter, 'c:firstSliceAng', (string) $angle);
-        }
+        $this->writeElementWithValAttribute($objWriter, 'c:firstSliceAng', (string) $subject->getFirstSliceAngle());
 
         $this->writeElementWithValAttribute($objWriter, 'c:holeSize', (string) $subject->getHoleSize());
 

--- a/tests/PhpPresentation/Tests/DocumentPropertiesTest.php
+++ b/tests/PhpPresentation/Tests/DocumentPropertiesTest.php
@@ -83,7 +83,6 @@ class DocumentPropertiesTest extends TestCase
         $valueTime = time();
 
         $object = new DocumentProperties();
-        self::assertIsArray($object->getCustomProperties());
         self::assertCount(0, $object->getCustomProperties());
         self::assertFalse($object->isCustomPropertySet('pName'));
         self::assertNull($object->getCustomPropertyType('pName'));

--- a/tests/PhpPresentation/Tests/HashTableTest.php
+++ b/tests/PhpPresentation/Tests/HashTableTest.php
@@ -38,7 +38,6 @@ class HashTableTest extends TestCase
         self::assertEquals(0, $object->count());
         self::assertNull($object->getByIndex());
         self::assertNull($object->getByHashCode());
-        self::assertIsArray($object->toArray());
         self::assertEmpty($object->toArray());
     }
 
@@ -50,7 +49,6 @@ class HashTableTest extends TestCase
         ]);
 
         self::assertEquals(2, $object->count());
-        self::assertIsArray($object->toArray());
         self::assertCount(2, $object->toArray());
     }
 
@@ -63,7 +61,6 @@ class HashTableTest extends TestCase
         $object->addFromSource();
         // Add From Source : Array
         $object->addFromSource([$oSlide]);
-        self::assertIsArray($object->toArray());
         self::assertCount(1, $object->toArray());
         // Clear
         $object->clear();

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -103,7 +103,6 @@ class ODPresentationTest extends TestCase
         self::assertEquals('Sample 02 Subject', $oPhpPresentation->getDocumentProperties()->getSubject());
         self::assertEquals('Sample 02 Description', $oPhpPresentation->getDocumentProperties()->getDescription());
         self::assertEquals('office 2007 openxml libreoffice odt php', $oPhpPresentation->getDocumentProperties()->getKeywords());
-        self::assertIsArray($oPhpPresentation->getDocumentProperties()->getCustomProperties());
         self::assertCount(0, $oPhpPresentation->getDocumentProperties()->getCustomProperties());
 
         // Presentation Properties
@@ -598,7 +597,6 @@ class ODPresentationTest extends TestCase
         self::assertEquals('Sample 02 Subject', $oPhpPresentation->getDocumentProperties()->getSubject());
         self::assertEquals('Sample 02 Description', $oPhpPresentation->getDocumentProperties()->getDescription());
         self::assertEquals('office 2007 openxml libreoffice odt php', $oPhpPresentation->getDocumentProperties()->getKeywords());
-        self::assertIsArray($oPhpPresentation->getDocumentProperties()->getCustomProperties());
         self::assertCount(0, $oPhpPresentation->getDocumentProperties()->getCustomProperties());
 
         // Presentation Properties
@@ -1034,7 +1032,6 @@ class ODPresentationTest extends TestCase
         $object = new ODPresentation();
         $oPhpPresentation = $object->load($file);
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
-        self::assertIsArray($oPhpPresentation->getDocumentProperties()->getCustomProperties());
         self::assertCount(0, $oPhpPresentation->getDocumentProperties()->getCustomProperties());
 
         self::assertEquals('MaDiapo', $oPhpPresentation->getSlide(0)->getName());
@@ -1046,7 +1043,6 @@ class ODPresentationTest extends TestCase
         $object = new ODPresentation();
         $oPhpPresentation = $object->load($file);
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
-        self::assertIsArray($oPhpPresentation->getDocumentProperties()->getCustomProperties());
         self::assertCount(0, $oPhpPresentation->getDocumentProperties()->getCustomProperties());
 
         self::assertCount(3, $oPhpPresentation->getAllSlides());

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -105,7 +105,6 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals('Sample Category', $oPhpPresentation->getDocumentProperties()->getCategory());
         self::assertEquals('', $oPhpPresentation->getDocumentProperties()->getRevision());
         self::assertEquals('', $oPhpPresentation->getDocumentProperties()->getStatus());
-        self::assertIsArray($oPhpPresentation->getDocumentProperties()->getCustomProperties());
         self::assertCount(0, $oPhpPresentation->getDocumentProperties()->getCustomProperties());
 
         // Presentation Properties
@@ -630,7 +629,6 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals('Sample 02 Subject', $oPhpPresentation->getDocumentProperties()->getSubject());
         self::assertEquals('Sample 02 Description', $oPhpPresentation->getDocumentProperties()->getDescription());
         self::assertEquals('office 2007 openxml libreoffice odt php', $oPhpPresentation->getDocumentProperties()->getKeywords());
-        self::assertIsArray($oPhpPresentation->getDocumentProperties()->getCustomProperties());
         self::assertCount(0, $oPhpPresentation->getDocumentProperties()->getCustomProperties());
 
         // Presentation Properties

--- a/tests/PhpPresentation/Tests/Shape/AbstractGraphicTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AbstractGraphicTest.php
@@ -34,14 +34,8 @@ class AbstractGraphicTest extends TestCase
     {
         $min = 10;
         $max = 20;
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractGraphic $stub */
-            $stub = $this->getMockForAbstractClass(AbstractGraphic::class);
-        } else {
-            /** @var AbstractGraphic $stub */
-            $stub = new class() extends AbstractGraphic {
-            };
-        }
+        $stub = new class() extends AbstractGraphic {
+        };
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\AbstractGraphic', $stub->setResizeProportional(false));
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\AbstractGraphic', $stub->setWidth($min));
         self::assertEquals($min, $stub->getWidth());
@@ -73,14 +67,8 @@ class AbstractGraphicTest extends TestCase
     {
         $min = 10;
         $max = 20;
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractGraphic $stub */
-            $stub = $this->getMockForAbstractClass(AbstractGraphic::class);
-        } else {
-            /** @var AbstractGraphic $stub */
-            $stub = new class() extends AbstractGraphic {
-            };
-        }
+        $stub = new class() extends AbstractGraphic {
+        };
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\AbstractGraphic', $stub->setResizeProportional(false));
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\AbstractGraphic', $stub->setWidth($max));
         self::assertEquals($max, $stub->getWidth());

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -22,6 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\AutoShape;
 use PhpOffice\PhpPresentation\Style\Outline;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AutoShapeTest extends TestCase
@@ -33,12 +34,12 @@ class AutoShapeTest extends TestCase
         self::assertEquals(AutoShape::TYPE_HEART, $object->getType());
         self::assertEquals('', $object->getText());
         self::assertInstanceOf(Outline::class, $object->getOutline());
-        self::assertIsString($object->getHashCode());
+        self::assertNotEmpty($object->getHashCode());
     }
 
     public function testOutline(): void
     {
-        /** @var Outline $mock */
+        /** @var MockObject&Outline $mock */
         $mock = $this->getMockBuilder(Outline::class)->getMock();
 
         $object = new AutoShape();

--- a/tests/PhpPresentation/Tests/Shape/Chart/AxisTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/AxisTest.php
@@ -24,6 +24,7 @@ use PhpOffice\PhpPresentation\Shape\Chart\Axis;
 use PhpOffice\PhpPresentation\Shape\Chart\Gridlines;
 use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Style\Outline;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -104,7 +105,7 @@ class AxisTest extends TestCase
     {
         $object = new Axis();
 
-        /** @var Gridlines $oMock */
+        /** @var Gridlines&MockObject $oMock */
         $oMock = $this->getMockBuilder(Gridlines::class)->getMock();
 
         self::assertInstanceOf(Axis::class, $object->setMajorGridlines($oMock));
@@ -148,7 +149,7 @@ class AxisTest extends TestCase
 
     public function testOutline(): void
     {
-        /** @var Outline $oMock */
+        /** @var MockObject&Outline $oMock */
         $oMock = $this->getMockBuilder(Outline::class)->getMock();
 
         $object = new Axis();

--- a/tests/PhpPresentation/Tests/Shape/Chart/GridlinesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/GridlinesTest.php
@@ -22,6 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Gridlines;
 use PhpOffice\PhpPresentation\Style\Outline;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class GridlinesTest extends TestCase
@@ -37,7 +38,7 @@ class GridlinesTest extends TestCase
     {
         $object = new Gridlines();
 
-        /** @var Outline $oStub */
+        /** @var MockObject&Outline $oStub */
         $oStub = $this->getMockBuilder(Outline::class)->getMock();
 
         self::assertInstanceOf(Outline::class, $object->getOutline());

--- a/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
@@ -43,7 +43,6 @@ class SeriesTest extends TestCase
         self::assertEquals('Calibri', $object->getFont()->getName());
         self::assertEquals(9, $object->getFont()->getSize());
         self::assertEquals('Series Title', $object->getTitle());
-        self::assertIsArray($object->getValues());
         self::assertEmpty($object->getValues());
         self::assertInstanceOf(Marker::class, $object->getMarker());
         self::assertNull($object->getOutline());
@@ -72,7 +71,6 @@ class SeriesTest extends TestCase
     {
         $object = new Series();
 
-        self::assertIsArray($object->getDataPointFills());
         self::assertEmpty($object->getDataPointFills());
 
         self::assertInstanceOf(Fill::class, $object->getDataPointFill(0));
@@ -228,7 +226,6 @@ class SeriesTest extends TestCase
     {
         $object = new Series();
 
-        /** @var array<string, string> $array */
         $array = [
             '0' => 'a',
             '1' => 'b',
@@ -236,7 +233,6 @@ class SeriesTest extends TestCase
             '3' => 'd',
         ];
 
-        self::assertIsArray($object->getValues());
         self::assertEmpty($object->getValues());
         self::assertInstanceOf(Series::class, $object->setValues());
         self::assertEmpty($object->getValues());

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/AbstractTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/AbstractTest.php
@@ -52,27 +52,19 @@ class AbstractTest extends TestCase
 
     public function testSeries(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractType $stub */
-            $stub = $this->getMockForAbstractClass(AbstractType::class);
-        } else {
-            /** @var AbstractType $stub */
-            $stub = new class() extends AbstractType {
-                public function getHashCode(): string
-                {
-                    return '';
-                }
-            };
-        }
+        $stub = new class() extends AbstractType {
+            public function getHashCode(): string
+            {
+                return '';
+            }
+        };
         self::assertEmpty($stub->getSeries());
-        self::assertIsArray($stub->getSeries());
 
         $arraySeries = [
             new Series(),
             new Series(),
         ];
         self::assertInstanceOf(AbstractType::class, $stub->setSeries($arraySeries));
-        self::assertIsArray($stub->getSeries());
         self::assertCount(count($arraySeries), $stub->getSeries());
     }
 
@@ -85,23 +77,16 @@ class AbstractTest extends TestCase
             new Series(),
         ];
 
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractType $stub */
-            $stub = $this->getMockForAbstractClass(AbstractType::class);
-        } else {
-            /** @var AbstractType $stub */
-            $stub = new class() extends AbstractType {
-                public function getHashCode(): string
-                {
-                    return '';
-                }
-            };
-        }
+        $stub = new class() extends AbstractType {
+            public function getHashCode(): string
+            {
+                return '';
+            }
+        };
         $stub->setSeries($arraySeries);
         $clone = clone $stub;
 
         self::assertInstanceOf(AbstractType::class, $clone);
-        self::assertIsArray($stub->getSeries());
         self::assertCount(count($arraySeries), $stub->getSeries());
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/AreaTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/AreaTest.php
@@ -35,7 +35,6 @@ class AreaTest extends TestCase
     {
         $object = new Area();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/Bar3DTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/Bar3DTest.php
@@ -35,7 +35,6 @@ class Bar3DTest extends TestCase
     {
         $object = new Bar3D();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/BarTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/BarTest.php
@@ -35,7 +35,6 @@ class BarTest extends TestCase
     {
         $object = new Bar();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/DoughnutTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/DoughnutTest.php
@@ -35,7 +35,6 @@ class DoughnutTest extends TestCase
     {
         $object = new Doughnut();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/LineTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/LineTest.php
@@ -35,7 +35,6 @@ class LineTest extends TestCase
     {
         $object = new Line();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/Pie3DTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/Pie3DTest.php
@@ -35,7 +35,6 @@ class Pie3DTest extends TestCase
     {
         $object = new Pie3D();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/PieTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/PieTest.php
@@ -35,7 +35,6 @@ class PieTest extends TestCase
     {
         $object = new Pie();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/Chart/Type/ScatterTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/Type/ScatterTest.php
@@ -35,7 +35,6 @@ class ScatterTest extends TestCase
     {
         $object = new Scatter();
 
-        self::assertIsArray($object->getSeries());
         self::assertEmpty($object->getSeries());
 
         $array = [

--- a/tests/PhpPresentation/Tests/Shape/CommentTest.php
+++ b/tests/PhpPresentation/Tests/Shape/CommentTest.php
@@ -22,6 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Comment;
 use PhpOffice\PhpPresentation\Shape\Comment\Author;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,7 +47,7 @@ class CommentTest extends TestCase
     {
         $object = new Comment();
 
-        /** @var Author $oStub */
+        /** @var Author&MockObject $oStub */
         $oStub = $this->getMockBuilder(Author::class)->getMock();
 
         self::assertNull($object->getAuthor());

--- a/tests/PhpPresentation/Tests/Shape/LineTest.php
+++ b/tests/PhpPresentation/Tests/Shape/LineTest.php
@@ -44,6 +44,6 @@ class LineTest extends TestCase
         self::assertEquals($value, $object->getOffsetY());
         self::assertEquals(0, $object->getWidth());
         self::assertEquals(0, $object->getHeight());
-        self::assertIsString($object->getHashCode());
+        self::assertNotEmpty($object->getHashCode());
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/RichText/ParagraphTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichText/ParagraphTest.php
@@ -134,7 +134,6 @@ class ParagraphTest extends TestCase
     public function testRichTextElements(): void
     {
         $object = new Paragraph();
-        self::assertIsArray($object->getRichTextElements());
         self::assertEmpty($object->getRichTextElements());
         $object->createBreak();
         self::assertCount(1, $object->getRichTextElements());

--- a/tests/PhpPresentation/Tests/Slide/AbstractSlideTest.php
+++ b/tests/PhpPresentation/Tests/Slide/AbstractSlideTest.php
@@ -38,17 +38,10 @@ class AbstractSlideTest extends TestCase
 {
     public function testCollection(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractSlide $object */
-            $object = $this->getMockForAbstractClass(AbstractSlide::class);
-        } else {
-            /** @var AbstractSlide $object */
-            $object = new class() extends AbstractSlide {
-            };
-        }
+        $object = new class() extends AbstractSlide {
+        };
         $array = [];
         self::assertInstanceOf(AbstractSlide::class, $object->setShapeCollection($array));
-        self::assertIsArray($object->getShapeCollection());
         self::assertCount(count($array), $object->getShapeCollection());
 
         $array = [
@@ -57,20 +50,13 @@ class AbstractSlideTest extends TestCase
             new RichText(),
         ];
         self::assertInstanceOf(AbstractSlide::class, $object->setShapeCollection($array));
-        self::assertIsArray($object->getShapeCollection());
         self::assertCount(count($array), $object->getShapeCollection());
     }
 
     public function testAdd(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractSlide $object */
-            $object = $this->getMockForAbstractClass(AbstractSlide::class);
-        } else {
-            /** @var AbstractSlide $object */
-            $object = new class() extends AbstractSlide {
-            };
-        }
+        $object = new class() extends AbstractSlide {
+        };
 
         self::assertInstanceOf(AutoShape::class, $object->createAutoShape());
         self::assertInstanceOf(Chart::class, $object->createChartShape());
@@ -83,14 +69,8 @@ class AbstractSlideTest extends TestCase
 
     public function testSearchShapes(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractSlide $object */
-            $object = $this->getMockForAbstractClass(AbstractSlide::class);
-        } else {
-            /** @var AbstractSlide $object */
-            $object = new class() extends AbstractSlide {
-            };
-        }
+        $object = new class() extends AbstractSlide {
+        };
 
         $array = [
             (new RichText())->setName('AAA'),
@@ -101,20 +81,17 @@ class AbstractSlideTest extends TestCase
 
         // Search by Name
         $result = $object->searchShapes('AAA', null);
-        self::assertIsArray($result);
         self::assertCount(2, $result);
         self::assertInstanceOf(RichText::class, $result[0]);
         self::assertInstanceOf(Chart::class, $result[1]);
 
         // Search by Name && Type
         $result = $object->searchShapes('AAA', Chart::class);
-        self::assertIsArray($result);
         self::assertCount(1, $result);
         self::assertInstanceOf(Chart::class, $result[0]);
 
         // Search by Type
         $result = $object->searchShapes(null, Table::class);
-        self::assertIsArray($result);
         self::assertCount(1, $result);
         self::assertInstanceOf(Table::class, $result[0]);
     }

--- a/tests/PhpPresentation/Tests/Slide/AnimationTest.php
+++ b/tests/PhpPresentation/Tests/Slide/AnimationTest.php
@@ -33,27 +33,17 @@ class AnimationTest extends TestCase
 {
     public function testShape(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractShape $oStub */
-            $oStub = $this->getMockForAbstractClass(AbstractShape::class);
-        } else {
-            /** @var AbstractShape $oStub */
-            $oStub = new class() extends AbstractShape {
-            };
-        }
+        $oStub = new class() extends AbstractShape {
+        };
 
         $object = new Animation();
 
-        self::assertIsArray($object->getShapeCollection());
         self::assertCount(0, $object->getShapeCollection());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\Animation', $object->addShape($oStub));
-        self::assertIsArray($object->getShapeCollection());
         self::assertCount(1, $object->getShapeCollection());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\Animation', $object->setShapeCollection());
-        self::assertIsArray($object->getShapeCollection());
         self::assertCount(0, $object->getShapeCollection());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\Animation', $object->setShapeCollection([$oStub]));
-        self::assertIsArray($object->getShapeCollection());
         self::assertCount(1, $object->getShapeCollection());
     }
 }

--- a/tests/PhpPresentation/Tests/Slide/NoteTest.php
+++ b/tests/PhpPresentation/Tests/Slide/NoteTest.php
@@ -46,25 +46,25 @@ class NoteTest extends TestCase
     public function testExtent(): void
     {
         $object = new Note();
-        self::assertNotNull($object->getExtentX());
+        self::assertSame(0, $object->getExtentX());
 
         $object = new Note();
-        self::assertNotNull($object->getExtentY());
+        self::assertSame(0, $object->getExtentY());
     }
 
     public function testHashCode(): void
     {
         $object = new Note();
-        self::assertIsString($object->getHashCode());
+        self::assertNotEmpty($object->getHashCode());
     }
 
     public function testOffset(): void
     {
         $object = new Note();
-        self::assertNotNull($object->getOffsetX());
+        self::assertSame(0, $object->getOffsetX());
 
         $object = new Note();
-        self::assertNotNull($object->getOffsetY());
+        self::assertSame(0, $object->getOffsetY());
     }
 
     public function testShape(): void

--- a/tests/PhpPresentation/Tests/Slide/SlideLayoutTest.php
+++ b/tests/PhpPresentation/Tests/Slide/SlideLayoutTest.php
@@ -33,31 +33,18 @@ class SlideLayoutTest extends TestCase
 {
     public function testBase(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var SlideMaster $mockSlideMaster */
-            $mockSlideMaster = $this->getMockForAbstractClass(SlideMaster::class);
-        } else {
-            /** @var SlideMaster $mockSlideMaster */
-            $mockSlideMaster = new class() extends SlideMaster {
-            };
-        }
+        $mockSlideMaster = new class() extends SlideMaster {
+        };
 
         $object = new SlideLayout($mockSlideMaster);
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $object);
-        self::assertIsArray($object->getShapeCollection());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->colorMap);
     }
 
     public function testLayoutName(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var SlideMaster $mockSlideMaster */
-            $mockSlideMaster = $this->getMockForAbstractClass(SlideMaster::class);
-        } else {
-            /** @var SlideMaster $mockSlideMaster */
-            $mockSlideMaster = new class() extends SlideMaster {
-            };
-        }
+        $mockSlideMaster = new class() extends SlideMaster {
+        };
 
         // Expected
         $expectedLayoutName = 'Title' . mt_rand(1, 100);
@@ -71,14 +58,8 @@ class SlideLayoutTest extends TestCase
 
     public function testSlideMaster(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var SlideMaster $mockSlideMaster */
-            $mockSlideMaster = $this->getMockForAbstractClass(SlideMaster::class);
-        } else {
-            /** @var SlideMaster $mockSlideMaster */
-            $mockSlideMaster = new class() extends SlideMaster {
-            };
-        }
+        $mockSlideMaster = new class() extends SlideMaster {
+        };
 
         $object = new SlideLayout($mockSlideMaster);
 

--- a/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
+++ b/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
@@ -39,7 +39,6 @@ class SlideMasterTest extends TestCase
         $object = new SlideMaster();
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $object);
         self::assertNull($object->getParent());
-        self::assertIsArray($object->getShapeCollection());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->colorMap);
         /** @var Color $background */
         $background = $object->getBackground();
@@ -53,14 +52,8 @@ class SlideMasterTest extends TestCase
         $object = new SlideMaster();
 
         // Mock Post
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var SlideLayout $mockSlideLayout */
-            $mockSlideLayout = $this->getMockForAbstractClass(SlideLayout::class, [$object]);
-        } else {
-            /** @var SlideLayout $mockSlideLayout */
-            $mockSlideLayout = new class($object) extends SlideLayout {
-            };
-        }
+        $mockSlideLayout = new class($object) extends SlideLayout {
+        };
 
         self::assertEmpty($object->getAllSlideLayouts());
         self::assertInstanceOf(SlideLayout::class, $object->createSlideLayout());
@@ -71,30 +64,17 @@ class SlideMasterTest extends TestCase
     public function testSchemeColors(): void
     {
         // Mock Pre
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var SchemeColor $mockSchemeColorAccent1 */
-            $mockSchemeColorAccent1 = $this->getMockForAbstractClass(SchemeColor::class);
-        } else {
-            /** @var SchemeColor $mockSchemeColorAccent1 */
-            $mockSchemeColorAccent1 = new class() extends SchemeColor {
-            };
-        }
+        $mockSchemeColorAccent1 = new class() extends SchemeColor {
+        };
         $mockSchemeColorAccent1->setValue('accent1');
         $mockSchemeColorAccent1->setRGB('ABCDEF');
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var SchemeColor $mockSchemeColorNew */
-            $mockSchemeColorNew = $this->getMockForAbstractClass(SchemeColor::class);
-        } else {
-            /** @var SchemeColor $mockSchemeColorNew */
-            $mockSchemeColorNew = new class() extends SchemeColor {
-            };
-        }
+        $mockSchemeColorNew = new class() extends SchemeColor {
+        };
         $mockSchemeColorNew->setValue('new');
         $mockSchemeColorNew->setRGB('ABCDEF');
 
         $object = new SlideMaster();
 
-        self::assertIsArray($object->getAllSchemeColors());
         self::assertCount(12, $object->getAllSchemeColors());
         // Add idem value
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\SlideMaster', $object->addSchemeColor($mockSchemeColorAccent1));
@@ -107,14 +87,8 @@ class SlideMasterTest extends TestCase
     public function testTextStyles(): void
     {
         // Mock Pre
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var TextStyle $mockTextStyle */
-            $mockTextStyle = $this->getMockForAbstractClass(TextStyle::class);
-        } else {
-            /** @var TextStyle $mockTextStyle */
-            $mockTextStyle = new class() extends TextStyle {
-            };
-        }
+        $mockTextStyle = new class() extends TextStyle {
+        };
 
         $object = new SlideMaster();
 

--- a/tests/PhpPresentation/Tests/SlideTest.php
+++ b/tests/PhpPresentation/Tests/SlideTest.php
@@ -39,19 +39,19 @@ class SlideTest extends TestCase
     public function testExtents(): void
     {
         $object = new Slide();
-        self::assertNotNull($object->getExtentX());
+        self::assertSame(0, $object->getExtentX());
 
         $object = new Slide();
-        self::assertNotNull($object->getExtentY());
+        self::assertSame(0, $object->getExtentY());
     }
 
     public function testOffset(): void
     {
         $object = new Slide();
-        self::assertNotNull($object->getOffsetX());
+        self::assertSame(0, $object->getOffsetX());
 
         $object = new Slide();
-        self::assertNotNull($object->getOffsetY());
+        self::assertSame(0, $object->getOffsetY());
     }
 
     public function testParent(): void
@@ -77,14 +77,8 @@ class SlideTest extends TestCase
 
     public function testAnimations(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var Animation $oStub */
-            $oStub = $this->getMockForAbstractClass(Animation::class);
-        } else {
-            /** @var Animation $oStub */
-            $oStub = new class() extends Animation {
-            };
-        }
+        $oStub = new class() extends Animation {
+        };
 
         $object = new Slide();
         self::assertIsArray($object->getAnimations());
@@ -102,14 +96,8 @@ class SlideTest extends TestCase
 
     public function testBackground(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractBackground $oStub */
-            $oStub = $this->getMockForAbstractClass(AbstractBackground::class);
-        } else {
-            /** @var AbstractBackground $oStub */
-            $oStub = new class() extends AbstractBackground {
-            };
-        }
+        $oStub = new class() extends AbstractBackground {
+        };
 
         $object = new Slide();
         self::assertNull($object->getBackground());
@@ -164,7 +152,6 @@ class SlideTest extends TestCase
         self::assertInstanceOf(ShapeContainerInterface::class, $slide);
         $shape = new File();
 
-        self::assertIsArray($slide->getShapeCollection());
         self::assertCount(0, $slide->getShapeCollection());
 
         $slide->addShape($shape);
@@ -172,7 +159,6 @@ class SlideTest extends TestCase
         self::assertEquals($slide, $shape->getContainer());
         self::assertInstanceOf(Slide::class, $shape->getContainer());
 
-        self::assertIsArray($slide->getShapeCollection());
         self::assertCount(1, $slide->getShapeCollection());
         self::assertEquals([$shape], $slide->getShapeCollection());
     }
@@ -181,7 +167,6 @@ class SlideTest extends TestCase
     {
         $slide = new Slide();
 
-        self::assertIsArray($slide->getShapeCollection());
         self::assertCount(0, $slide->getShapeCollection());
 
         $shape = $slide->createDrawingShape();
@@ -189,7 +174,6 @@ class SlideTest extends TestCase
         self::assertEquals($slide, $shape->getContainer());
         self::assertInstanceOf(Slide::class, $shape->getContainer());
 
-        self::assertIsArray($slide->getShapeCollection());
         self::assertCount(1, $slide->getShapeCollection());
         self::assertEquals([$shape], $slide->getShapeCollection());
     }

--- a/tests/PhpPresentation/Tests/Style/ColorMapTest.php
+++ b/tests/PhpPresentation/Tests/Style/ColorMapTest.php
@@ -28,7 +28,6 @@ class ColorMapTest extends TestCase
     public function testConstruct(): void
     {
         $object = new ColorMap();
-        self::assertIsArray($object->getMapping());
         self::assertEquals(ColorMap::$mappingDefault, $object->getMapping());
     }
 
@@ -36,11 +35,9 @@ class ColorMapTest extends TestCase
     {
         $object = new ColorMap();
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->setMapping([]));
-        self::assertIsArray($object->getMapping());
         self::assertCount(0, $object->getMapping());
         $array = ColorMap::$mappingDefault;
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->setMapping($array));
-        self::assertIsArray($object->getMapping());
         self::assertEquals(ColorMap::$mappingDefault, $object->getMapping());
     }
 

--- a/tests/PhpPresentation/Tests/Style/TextStyleTest.php
+++ b/tests/PhpPresentation/Tests/Style/TextStyleTest.php
@@ -85,11 +85,8 @@ class TextStyleTest extends TestCase
     {
         $object = new TextStyle(false);
 
-        self::assertIsArray($object->getBodyStyle());
         self::assertCount(0, $object->getBodyStyle());
-        self::assertIsArray($object->getOtherStyle());
         self::assertCount(0, $object->getOtherStyle());
-        self::assertIsArray($object->getTitleStyle());
         self::assertCount(0, $object->getTitleStyle());
     }
 

--- a/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
+++ b/tests/PhpPresentation/Tests/Writer/AbstractWriterTest.php
@@ -34,7 +34,7 @@ require 'AbstractWriter.php';
  *
  * @coversDefaultClass \AbstractWriter
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @SuppressWarnings("PHPMD.UnusedFormalParameter")
  */
 class AbstractWriterTest extends TestCase
 {
@@ -43,14 +43,8 @@ class AbstractWriterTest extends TestCase
      */
     public function testConstruct(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractWriter $mockWriter */
-            $mockWriter = $this->getMockForAbstractClass(AbstractWriter::class);
-        } else {
-            /** @var AbstractWriter $mockWriter */
-            $mockWriter = new class() extends AbstractWriter {
-            };
-        }
+        $mockWriter = new class() extends AbstractWriter {
+        };
 
         self::assertNull($mockWriter->getPDFAdapter());
         self::assertNull($mockWriter->getZipAdapter());
@@ -58,30 +52,18 @@ class AbstractWriterTest extends TestCase
 
     public function testPDFAdapter(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractWriter $mockWriter */
-            $mockWriter = $this->getMockForAbstractClass(AbstractWriter::class);
-        } else {
-            /** @var AbstractWriter $mockWriter */
-            $mockWriter = new class() extends AbstractWriter {
-            };
-        }
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var PDFWriterInterface $mockPdfAdapter */
-            $mockPdfAdapter = $this->getMockForAbstractClass(PDFWriterInterface::class);
-        } else {
-            /** @var PDFWriterInterface $mockPdfAdapter */
-            $mockPdfAdapter = new class() implements PDFWriterInterface {
-                public function save(string $filename): void
-                {
-                }
+        $mockWriter = new class() extends AbstractWriter {
+        };
+        $mockPdfAdapter = new class() implements PDFWriterInterface {
+            public function save(string $filename): void
+            {
+            }
 
-                public function setPhpPresentation(?PhpPresentation $pPhpPresentation = null)
-                {
-                    return $this;
-                }
-            };
-        }
+            public function setPhpPresentation(?PhpPresentation $pPhpPresentation = null)
+            {
+                return $this;
+            }
+        };
 
         self::assertNull($mockWriter->getPDFAdapter());
         self::assertInstanceOf(AbstractWriter::class, $mockWriter->setPDFAdapter($mockPdfAdapter));
@@ -90,36 +72,24 @@ class AbstractWriterTest extends TestCase
 
     public function testZipAdapter(): void
     {
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractWriter $mockWriter */
-            $mockWriter = $this->getMockForAbstractClass(AbstractWriter::class);
-        } else {
-            /** @var AbstractWriter $mockWriter */
-            $mockWriter = new class() extends AbstractWriter {
-            };
-        }
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var ZipInterface $mockZip */
-            $mockZip = $this->getMockForAbstractClass(ZipInterface::class);
-        } else {
-            /** @var ZipInterface $mockZip */
-            $mockZip = new class() implements ZipInterface {
-                public function open($filename)
-                {
-                    return $this;
-                }
+        $mockWriter = new class() extends AbstractWriter {
+        };
+        $mockZip = new class() implements ZipInterface {
+            public function open($filename)
+            {
+                return $this;
+            }
 
-                public function close()
-                {
-                    return $this;
-                }
+            public function close()
+            {
+                return $this;
+            }
 
-                public function addFromString(string $localname, string $contents, bool $withCompression = true)
-                {
-                    return $this;
-                }
-            };
-        }
+            public function addFromString(string $localname, string $contents, bool $withCompression = true)
+            {
+                return $this;
+            }
+        };
 
         self::assertNull($mockWriter->getZipAdapter());
         self::assertInstanceOf(AbstractWriter::class, $mockWriter->setZipAdapter($mockZip));
@@ -140,14 +110,8 @@ class AbstractWriterTest extends TestCase
         $masterSlide = $masterSlides[0];
         $masterSlide->createDrawingShape();
 
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var TestAbstractWriter $writer */
-            $writer = $this->getMockForAbstractClass(TestAbstractWriter::class);
-        } else {
-            /** @var TestAbstractWriter $writer */
-            $writer = new class() extends TestAbstractWriter {
-            };
-        }
+        $writer = new class() extends TestAbstractWriter {
+        };
         $writer->setPhpPresentation($presentation);
 
         $drawings = $writer->allDrawings();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -272,18 +272,12 @@ class PptChartsTest extends PhpPresentationTestCase
         $oSlide = $this->oPresentation->getActiveSlide();
         $oShape = $oSlide->createChartShape();
         $oShape->setResizeProportional(false)->setHeight(550)->setWidth(700)->setOffsetX(120)->setOffsetY(80);
-        if (method_exists($this, 'getMockForAbstractClass')) {
-            /** @var AbstractType $stub */
-            $stub = $this->getMockForAbstractClass(AbstractType::class);
-        } else {
-            /** @var AbstractType $stub */
-            $stub = new class() extends AbstractType {
-                public function getHashCode(): string
-                {
-                    return '';
-                }
-            };
-        }
+        $stub = new class() extends AbstractType {
+            public function getHashCode(): string
+            {
+                return '';
+            }
+        };
         $oShape->getPlotArea()->setType($stub);
 
         $this->writePresentationFile($this->oPresentation, 'PowerPoint2007');

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlideMastersTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace PhpPresentation\Tests\Writer\PowerPoint2007;
 
-use ArrayObject;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
@@ -62,7 +61,7 @@ class PptSlideMastersTest extends TestCase
             ->method('getAllSlideLayouts')
             ->willReturn($layouts);
 
-        /** @var ArrayObject<int, ShapeDrawingFile> $collection */
+        /** @var array<int, ShapeDrawingFile> $collection */
         $collection = [];
         $collection[] = new ShapeDrawingFile();
         $collection[] = new ShapeDrawingFile();


### PR DESCRIPTION
## Problem

`PHP Static Analysis (8.4)` and `(8.5)` fail on `master` as well as on every pull request, with 3451 errors of this shape:

```
Call to an undefined static method PhpOffice\PhpPresentation\Tests\Reader\PowerPoint2007Test::assertEquals().
```

The methods are not missing: in PHPUnit 13.2.6 `TestCase` still extends `Assert` and `assertEquals()` is still `final public static`. The analyser is what cannot see them — the job installs **PHPStan 1.12.34** (the last 1.12.x release, July 2025) together with **PHPUnit 13.2.6**, which composer resolves on PHP 8.4/8.5 because `phpunit/phpunit` is constrained as `>=7.0`. PHPStan 1.x cannot discover the symbols of that PHPUnit generation, and it prints its own advice in the log:

```
Upgrade today to PHPStan 2.2 or newer by using "phpstan/phpstan": "^2.2" in your composer.json.
```

The PHP 7.4–8.3 jobs stay green because an older PHPUnit is resolved there.

## Change

- `phpstan/phpstan` is raised to `^2.2`. PHPStan 2.2.8 still requires `php: ^7.4|^8.0`, so every job in the matrix keeps resolving.
- `phpstan-baseline.neon` records the findings the newer analyser reports on the existing code, so this pull request stays a CI fix and does not mix in unrelated changes. Each PHP version resolves a different PHPUnit generation (9.6.35, 10.5.64, 11.5.56, 12.5.33, 13.2.6) and therefore reports a slightly different set — for example `getMockForAbstractClass()` only exists up to PHPUnit 9 — so the baseline is the union over all of them, 98 entries. `reportUnmatchedIgnoredErrors: false` is already set, so the entries that do not apply to a given version are simply not reported.
- `ObjectsChart` now derives the chart column name from its index instead of incrementing a string. String increment is deprecated as of PHP 8.5 and was the only new finding specific to that version (`Cannot use ++ on string`).

The findings kept in the baseline are mostly redundant PHPUnit assertions (`assertIsArray()` on a value already typed `array`), `@var` PHPDoc tags that are not a subtype of the native type, and a few always-true strict comparisons. I am happy to work through them in follow-ups if you would rather see them fixed than baselined.

## Verification

Run in a container with PHP 8.4.15 and PHP 8.5.0. Older versions were reproduced by pinning `config.platform.php` so composer resolves the same dependency set as the matrix job (that pin is not part of the diff).

| PHP | PHPUnit resolved | phpstan before | phpstan after |
| --- | --- | --- | --- |
| 7.4 | 9.6.35 | 48 errors (with PHPStan 2 and no baseline) | **No errors** |
| 8.0 | 9.6.35 | same | **No errors** |
| 8.1 | 10.5.64 | same | **No errors** |
| 8.2 | 11.5.56 | same | **No errors** |
| 8.3 | 12.5.33 | — | **No errors** |
| 8.4 | 13.2.6 | 3451 errors | **No errors** |
| 8.5 | 13.2.6 | 3451 errors + `Cannot use ++ on string` | **No errors** |

Other checks, before and after the change: `phpmd src/,tests/ text ./phpmd.xml.dist` clean, `php-cs-fixer fix --dry-run --diff` 0 of 275 files, `composer validate --strict` valid, and the ODPresentation writer test suite identical at 95 tests / 1555 assertions (the one error in both columns is `MetaInfManifestTest::testMemoryDrawing` calling `imagecreatetruecolor()`, i.e. the container missing `ext-gd`).

The column-name helper was compared against the previous behaviour for every index from 2 to 2000 (`B`, `C`, …, `Z`, `AA`, …): 1999 values, 0 mismatches, including the `Z → AA` and `ZZ → AAA` boundaries.

## Note on the PHPUnit jobs

While verifying this I saw `ObjectsChartTest::testTypeAxisUnit` fail intermittently in CI with `Element automatic-styles failed to validate content`. It is not related to this change: the same commit produced both a failing and a passing run of that job, on different PHP versions and at different lines of the test, re-running the failed job on the same commit succeeded, and running the full suite three times with and three times without this change gave an identical set of failures locally. It looks like a pre-existing non-deterministic test; I have not touched it here.
