### PR TITLE
Mark a shape as decorative

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -7,6 +7,7 @@
 - Added ability to set rounded corner radius by [@seanlynchwv](http://github.com/seanlynchwv) in [#880](https://github.com/PHPOffice/PHPPresentation/pull/880)
 - Raised the minimum PHP version to 7.4 (dropped 7.1, 7.2 and 7.3) by [@slayerfx](http://github.com/slayerfx) in [#894](https://github.com/PHPOffice/PHPPresentation/pull/894)
 - Added an alternative text (`description`) on every shape, and not only on graphics, by [@dkulyk](http://github.com/dkulyk) in [#898](https://github.com/PHPOffice/PHPPresentation/pull/898)
+- Added the ability to mark a shape as decorative, so that assistive technologies skip it, by [@dkulyk](http://github.com/dkulyk) in [#899](https://github.com/PHPOffice/PHPPresentation/pull/899)
 
 ## Bug fixes
 - Fixed adding custom SVGs by [@seanlynchwv](http://github.com/seanlynchwv) in [#881](https://github.com/PHPOffice/PHPPresentation/pull/881)

--- a/docs/usage/shapes/introduction.md
+++ b/docs/usage/shapes/introduction.md
@@ -15,6 +15,7 @@ Every shapes have common properties that you can set by using fluent interface.
 - ``hyperlink``
 - ``name``
 - ``description`` see *[Alternative text](#alternative-text)*
+- ``decorative`` see *[Decorative shapes](#decorative-shapes)*
 
 Example:
 
@@ -42,6 +43,22 @@ $richtext = $slide->createRichTextShape()
 
 It is written as the `descr` attribute of `p:cNvPr` in PowerPoint2007 files and as the
 `svg:desc` element of the shape in ODPresentation files.
+
+## Decorative shapes
+
+A shape that carries no information — a coloured band, a rule, a background image — can be
+marked as decorative, so that assistive technologies skip it instead of announcing it.
+
+``` php
+<?php
+$slide->createLineShape(10, 10, 100, 10)
+		->setDecorative();      // setDecorative(false) states the opposite explicitly
+```
+
+The flag is unset by default (`isDecorative()` returns `null`), and nothing is then written to
+the document. It is written as the `{C183D7F6-B498-43B3-948B-1728B52AA6E4}` extension of
+`p:cNvPr` in PowerPoint2007 files, and as the `loext:decorative` attribute of the shape in
+ODPresentation files.
 
 ## Line
 

--- a/docs/usage/shapes/introduction.md
+++ b/docs/usage/shapes/introduction.md
@@ -58,7 +58,7 @@ $slide->createLineShape(10, 10, 100, 10)
 The flag is unset by default (`isDecorative()` returns `null`), and nothing is then written to
 the document. It is written as the `{C183D7F6-B498-43B3-948B-1728B52AA6E4}` extension of
 `p:cNvPr` in PowerPoint2007 files, and as the `loext:decorative` attribute of the shape in
-ODPresentation files.
+ODPresentation files. Both readers restore the flag when the document carries it.
 
 ## Line
 

--- a/docs/usage/shapes/introduction.md
+++ b/docs/usage/shapes/introduction.md
@@ -52,13 +52,13 @@ marked as decorative, so that assistive technologies skip it instead of announci
 ``` php
 <?php
 $slide->createLineShape(10, 10, 100, 10)
-		->setDecorative();      // setDecorative(false) states the opposite explicitly
+		->setDecorative();      // setDecorative(false) takes it back
 ```
 
-The flag is unset by default (`isDecorative()` returns `null`), and nothing is then written to
-the document. It is written as the `{C183D7F6-B498-43B3-948B-1728B52AA6E4}` extension of
-`p:cNvPr` in PowerPoint2007 files, and as the `loext:decorative` attribute of the shape in
-ODPresentation files. Both readers restore the flag when the document carries it.
+A shape is not decorative by default, and nothing is then written to the document. The flag is
+written as the `{C183D7F6-B498-43B3-948B-1728B52AA6E4}` extension of `p:cNvPr` in PowerPoint2007
+files, and as the `loext:decorative` attribute of the shape in ODPresentation files. Both readers
+restore the flag when the document carries it.
 
 ## Line
 

--- a/src/PhpPresentation/AbstractShape.php
+++ b/src/PhpPresentation/AbstractShape.php
@@ -126,6 +126,14 @@ abstract class AbstractShape implements ComparableInterface
     protected $description = '';
 
     /**
+     * Decorative, ie the shape is ignored by assistive technologies.
+     * Null when the document says nothing about it.
+     *
+     * @var null|bool
+     */
+    protected $decorative;
+
+    /**
      * Create a new self.
      */
     public function __construct()
@@ -241,6 +249,28 @@ abstract class AbstractShape implements ComparableInterface
     public function setDescription(string $pValue = ''): self
     {
         $this->description = $pValue;
+
+        return $this;
+    }
+
+    /**
+     * Is the shape decorative, ie ignored by assistive technologies?
+     * Null when the document says nothing about it.
+     */
+    public function isDecorative(): ?bool
+    {
+        return $this->decorative;
+    }
+
+    /**
+     * Set the shape as decorative, ie ignored by assistive technologies.
+     * Null removes the information from the document.
+     *
+     * @return static
+     */
+    public function setDecorative(?bool $pValue = true): self
+    {
+        $this->decorative = $pValue;
 
         return $this;
     }

--- a/src/PhpPresentation/AbstractShape.php
+++ b/src/PhpPresentation/AbstractShape.php
@@ -127,11 +127,10 @@ abstract class AbstractShape implements ComparableInterface
 
     /**
      * Decorative, ie the shape is ignored by assistive technologies.
-     * Null when the document says nothing about it.
      *
-     * @var null|bool
+     * @var bool
      */
-    protected $decorative;
+    protected $decorative = false;
 
     /**
      * Create a new self.
@@ -255,20 +254,18 @@ abstract class AbstractShape implements ComparableInterface
 
     /**
      * Is the shape decorative, ie ignored by assistive technologies?
-     * Null when the document says nothing about it.
      */
-    public function isDecorative(): ?bool
+    public function isDecorative(): bool
     {
         return $this->decorative;
     }
 
     /**
      * Set the shape as decorative, ie ignored by assistive technologies.
-     * Null removes the information from the document.
      *
      * @return static
      */
-    public function setDecorative(?bool $pValue = true): self
+    public function setDecorative(bool $pValue = true): self
     {
         $this->decorative = $pValue;
 

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -24,7 +24,6 @@ use DateTime;
 use DOMElement;
 use PhpOffice\Common\Drawing as CommonDrawing;
 use PhpOffice\Common\XMLReader;
-use PhpOffice\PhpPresentation\AbstractShape;
 use PhpOffice\PhpPresentation\DocumentProperties;
 use PhpOffice\PhpPresentation\Exception\FileNotFoundException;
 use PhpOffice\PhpPresentation\Exception\InvalidFileFormatException;
@@ -572,12 +571,16 @@ class ODPresentation implements ReaderInterface
 
     /**
      * Read the decorative flag of a shape.
+     *
+     * @return null|bool null when the shape says nothing about it
      */
-    protected function loadShapeDecorative(DOMElement $oNodeFrame, AbstractShape $shape): void
+    protected function loadShapeDecorative(DOMElement $oNodeFrame): ?bool
     {
-        if ($oNodeFrame->hasAttribute('loext:decorative')) {
-            $shape->setDecorative('true' === $oNodeFrame->getAttribute('loext:decorative'));
+        if (!$oNodeFrame->hasAttribute('loext:decorative')) {
+            return null;
         }
+
+        return 'true' === $oNodeFrame->getAttribute('loext:decorative');
     }
 
     /**
@@ -619,7 +622,7 @@ class ODPresentation implements ReaderInterface
         $shape->getShadow()->setVisible(false);
         $shape->setName($oNodeFrame->hasAttribute('draw:name') ? $oNodeFrame->getAttribute('draw:name') : '');
         $shape->setDescription($this->loadShapeDescription($oNodeFrame));
-        $this->loadShapeDecorative($oNodeFrame, $shape);
+        $shape->setDecorative($this->loadShapeDecorative($oNodeFrame));
         $shape->setResizeProportional(false);
         $shape->setWidth($oNodeFrame->hasAttribute('svg:width') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:width'), 0, -2)) : 0);
         $shape->setHeight($oNodeFrame->hasAttribute('svg:height') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:height'), 0, -2)) : 0);
@@ -648,7 +651,7 @@ class ODPresentation implements ReaderInterface
         $oShape->setParagraphs([]);
 
         $oShape->setDescription($this->loadShapeDescription($oNodeFrame));
-        $this->loadShapeDecorative($oNodeFrame, $oShape);
+        $oShape->setDecorative($this->loadShapeDecorative($oNodeFrame));
         $oShape->setWidth($oNodeFrame->hasAttribute('svg:width') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:width'), 0, -2)) : 0);
         $oShape->setHeight($oNodeFrame->hasAttribute('svg:height') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:height'), 0, -2)) : 0);
         $oShape->setOffsetX($oNodeFrame->hasAttribute('svg:x') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:x'), 0, -2)) : 0);

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -572,12 +572,12 @@ class ODPresentation implements ReaderInterface
     /**
      * Read the decorative flag of a shape.
      *
-     * @return null|bool null when the shape says nothing about it
+     * @return bool false when the shape says nothing about it
      */
-    protected function loadShapeDecorative(DOMElement $oNodeFrame): ?bool
+    protected function loadShapeDecorative(DOMElement $oNodeFrame): bool
     {
         if (!$oNodeFrame->hasAttribute('loext:decorative')) {
-            return null;
+            return false;
         }
 
         return 'true' === $oNodeFrame->getAttribute('loext:decorative');

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -24,6 +24,7 @@ use DateTime;
 use DOMElement;
 use PhpOffice\Common\Drawing as CommonDrawing;
 use PhpOffice\Common\XMLReader;
+use PhpOffice\PhpPresentation\AbstractShape;
 use PhpOffice\PhpPresentation\DocumentProperties;
 use PhpOffice\PhpPresentation\Exception\FileNotFoundException;
 use PhpOffice\PhpPresentation\Exception\InvalidFileFormatException;
@@ -570,6 +571,16 @@ class ODPresentation implements ReaderInterface
     }
 
     /**
+     * Read the decorative flag of a shape.
+     */
+    protected function loadShapeDecorative(DOMElement $oNodeFrame, AbstractShape $shape): void
+    {
+        if ($oNodeFrame->hasAttribute('loext:decorative')) {
+            $shape->setDecorative('true' === $oNodeFrame->getAttribute('loext:decorative'));
+        }
+    }
+
+    /**
      * Read Shape Drawing.
      */
     protected function loadShapeDrawing(DOMElement $oNodeFrame): void
@@ -608,6 +619,7 @@ class ODPresentation implements ReaderInterface
         $shape->getShadow()->setVisible(false);
         $shape->setName($oNodeFrame->hasAttribute('draw:name') ? $oNodeFrame->getAttribute('draw:name') : '');
         $shape->setDescription($this->loadShapeDescription($oNodeFrame));
+        $this->loadShapeDecorative($oNodeFrame, $shape);
         $shape->setResizeProportional(false);
         $shape->setWidth($oNodeFrame->hasAttribute('svg:width') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:width'), 0, -2)) : 0);
         $shape->setHeight($oNodeFrame->hasAttribute('svg:height') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:height'), 0, -2)) : 0);
@@ -636,6 +648,7 @@ class ODPresentation implements ReaderInterface
         $oShape->setParagraphs([]);
 
         $oShape->setDescription($this->loadShapeDescription($oNodeFrame));
+        $this->loadShapeDecorative($oNodeFrame, $oShape);
         $oShape->setWidth($oNodeFrame->hasAttribute('svg:width') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:width'), 0, -2)) : 0);
         $oShape->setHeight($oNodeFrame->hasAttribute('svg:height') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:height'), 0, -2)) : 0);
         $oShape->setOffsetX($oNodeFrame->hasAttribute('svg:x') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:x'), 0, -2)) : 0);

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -26,6 +26,7 @@ use DOMNode;
 use DOMNodeList;
 use PhpOffice\Common\Drawing as CommonDrawing;
 use PhpOffice\Common\XMLReader;
+use PhpOffice\PhpPresentation\AbstractShape;
 use PhpOffice\PhpPresentation\DocumentLayout;
 use PhpOffice\PhpPresentation\DocumentProperties;
 use PhpOffice\PhpPresentation\Exception\FeatureNotImplementedException;
@@ -805,6 +806,20 @@ class PowerPoint2007 implements ReaderInterface
         }
     }
 
+    /**
+     * Read the decorative flag, stored as an extension of the non-visual properties of the shape.
+     *
+     * @param DOMElement $node the `p:cNvPr` element of the shape
+     */
+    protected function loadShapeDecorative(XMLReader $document, DOMElement $node, AbstractShape $oShape): void
+    {
+        $document->registerNamespace('adec', 'http://schemas.microsoft.com/office/drawing/2017/decorative');
+        $oElement = $document->getElement('a:extLst/a:ext[@uri="{C183D7F6-B498-43B3-948B-1728B52AA6E4}"]/adec:decorative', $node);
+        if ($oElement instanceof DOMElement) {
+            $oShape->setDecorative(in_array($oElement->getAttribute('val'), ['1', 'true'], true));
+        }
+    }
+
     protected function loadShapeDrawing(XMLReader $document, DOMElement $node, AbstractSlide $oSlide): void
     {
         // Core
@@ -822,6 +837,7 @@ class PowerPoint2007 implements ReaderInterface
         if ($oElement instanceof DOMElement) {
             $oShape->setName($oElement->hasAttribute('name') ? $oElement->getAttribute('name') : '');
             $oShape->setDescription($oElement->hasAttribute('descr') ? $oElement->getAttribute('descr') : '');
+            $this->loadShapeDecorative($document, $oElement, $oShape);
 
             // Hyperlink
             $oElementHlinkClick = $document->getElement('a:hlinkClick', $oElement);
@@ -970,6 +986,7 @@ class PowerPoint2007 implements ReaderInterface
         if ($oElement instanceof DOMElement) {
             $oShape->setName($oElement->hasAttribute('name') ? $oElement->getAttribute('name') : '');
             $oShape->setDescription($oElement->hasAttribute('descr') ? $oElement->getAttribute('descr') : '');
+            $this->loadShapeDecorative($document, $oElement, $oShape);
         }
 
         $oElement = $document->getElement('p:spPr/a:xfrm', $node);
@@ -1066,6 +1083,7 @@ class PowerPoint2007 implements ReaderInterface
             if ($oElement->hasAttribute('descr')) {
                 $oShape->setDescription($oElement->getAttribute('descr'));
             }
+            $this->loadShapeDecorative($document, $oElement, $oShape);
         }
 
         $oElement = $document->getElement('p:xfrm/a:off', $node);
@@ -1204,6 +1222,7 @@ class PowerPoint2007 implements ReaderInterface
             if ($oElement->hasAttribute('descr')) {
                 $oShape->setDescription($oElement->getAttribute('descr'));
             }
+            $this->loadShapeDecorative($document, $oElement, $oShape);
         }
 
         $oElement = $document->getElement('p:xfrm/a:off', $node);

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -26,7 +26,6 @@ use DOMNode;
 use DOMNodeList;
 use PhpOffice\Common\Drawing as CommonDrawing;
 use PhpOffice\Common\XMLReader;
-use PhpOffice\PhpPresentation\AbstractShape;
 use PhpOffice\PhpPresentation\DocumentLayout;
 use PhpOffice\PhpPresentation\DocumentProperties;
 use PhpOffice\PhpPresentation\Exception\FeatureNotImplementedException;
@@ -810,14 +809,18 @@ class PowerPoint2007 implements ReaderInterface
      * Read the decorative flag, stored as an extension of the non-visual properties of the shape.
      *
      * @param DOMElement $node the `p:cNvPr` element of the shape
+     *
+     * @return null|bool null when the shape says nothing about it
      */
-    protected function loadShapeDecorative(XMLReader $document, DOMElement $node, AbstractShape $oShape): void
+    protected function loadShapeDecorative(XMLReader $document, DOMElement $node): ?bool
     {
         $document->registerNamespace('adec', 'http://schemas.microsoft.com/office/drawing/2017/decorative');
         $oElement = $document->getElement('a:extLst/a:ext[@uri="{C183D7F6-B498-43B3-948B-1728B52AA6E4}"]/adec:decorative', $node);
-        if ($oElement instanceof DOMElement) {
-            $oShape->setDecorative(in_array($oElement->getAttribute('val'), ['1', 'true'], true));
+        if (!$oElement instanceof DOMElement) {
+            return null;
         }
+
+        return in_array($oElement->getAttribute('val'), ['1', 'true'], true);
     }
 
     protected function loadShapeDrawing(XMLReader $document, DOMElement $node, AbstractSlide $oSlide): void
@@ -837,7 +840,7 @@ class PowerPoint2007 implements ReaderInterface
         if ($oElement instanceof DOMElement) {
             $oShape->setName($oElement->hasAttribute('name') ? $oElement->getAttribute('name') : '');
             $oShape->setDescription($oElement->hasAttribute('descr') ? $oElement->getAttribute('descr') : '');
-            $this->loadShapeDecorative($document, $oElement, $oShape);
+            $oShape->setDecorative($this->loadShapeDecorative($document, $oElement));
 
             // Hyperlink
             $oElementHlinkClick = $document->getElement('a:hlinkClick', $oElement);
@@ -986,7 +989,7 @@ class PowerPoint2007 implements ReaderInterface
         if ($oElement instanceof DOMElement) {
             $oShape->setName($oElement->hasAttribute('name') ? $oElement->getAttribute('name') : '');
             $oShape->setDescription($oElement->hasAttribute('descr') ? $oElement->getAttribute('descr') : '');
-            $this->loadShapeDecorative($document, $oElement, $oShape);
+            $oShape->setDecorative($this->loadShapeDecorative($document, $oElement));
         }
 
         $oElement = $document->getElement('p:spPr/a:xfrm', $node);
@@ -1083,7 +1086,7 @@ class PowerPoint2007 implements ReaderInterface
             if ($oElement->hasAttribute('descr')) {
                 $oShape->setDescription($oElement->getAttribute('descr'));
             }
-            $this->loadShapeDecorative($document, $oElement, $oShape);
+            $oShape->setDecorative($this->loadShapeDecorative($document, $oElement));
         }
 
         $oElement = $document->getElement('p:xfrm/a:off', $node);
@@ -1222,7 +1225,7 @@ class PowerPoint2007 implements ReaderInterface
             if ($oElement->hasAttribute('descr')) {
                 $oShape->setDescription($oElement->getAttribute('descr'));
             }
-            $this->loadShapeDecorative($document, $oElement, $oShape);
+            $oShape->setDecorative($this->loadShapeDecorative($document, $oElement));
         }
 
         $oElement = $document->getElement('p:xfrm/a:off', $node);

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -810,14 +810,14 @@ class PowerPoint2007 implements ReaderInterface
      *
      * @param DOMElement $node the `p:cNvPr` element of the shape
      *
-     * @return null|bool null when the shape says nothing about it
+     * @return bool false when the shape says nothing about it
      */
-    protected function loadShapeDecorative(XMLReader $document, DOMElement $node): ?bool
+    protected function loadShapeDecorative(XMLReader $document, DOMElement $node): bool
     {
         $document->registerNamespace('adec', 'http://schemas.microsoft.com/office/drawing/2017/decorative');
         $oElement = $document->getElement('a:extLst/a:ext[@uri="{C183D7F6-B498-43B3-948B-1728B52AA6E4}"]/adec:decorative', $node);
         if (!$oElement instanceof DOMElement) {
-            return null;
+            return false;
         }
 
         return in_array($oElement->getAttribute('val'), ['1', 'true'], true);

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -418,6 +418,21 @@ class Content extends AbstractDecoratorWriter
     /**
      * Write picture.
      */
+    /**
+     * Write the decorative flag of a shape, ie the shape is ignored by assistive
+     * technologies. It has to be written before any child of the shape element.
+     *
+     * ODF has no such attribute before version 1.4, so the LibreOffice extension is used.
+     */
+    protected function writeShapeDecorative(XMLWriter $objWriter, AbstractShape $shape): void
+    {
+        if (null === $shape->isDecorative()) {
+            return;
+        }
+
+        $objWriter->writeAttribute('loext:decorative', $shape->isDecorative() ? 'true' : 'false');
+    }
+
     protected function writeShapeMedia(XMLWriter $objWriter, Media $shape): void
     {
         // draw:frame
@@ -428,6 +443,7 @@ class Content extends AbstractDecoratorWriter
         $objWriter->writeAttribute('svg:x', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetX()), 3) . 'cm');
         $objWriter->writeAttribute('svg:y', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetY()), 3) . 'cm');
         $objWriter->writeAttribute('draw:style-name', 'gr' . $this->shapeId);
+        $this->writeShapeDecorative($objWriter, $shape);
         // draw:frame > draw:plugin
         $objWriter->startElement('draw:plugin');
         $objWriter->writeAttribute('xlink:href', 'Pictures/' . $shape->getIndexedFilename());
@@ -475,6 +491,7 @@ class Content extends AbstractDecoratorWriter
         $objWriter->writeAttribute('svg:x', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetX()), 3) . 'cm');
         $objWriter->writeAttribute('svg:y', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetY()), 3) . 'cm');
         $objWriter->writeAttribute('draw:style-name', 'gr' . $this->shapeId);
+        $this->writeShapeDecorative($objWriter, $shape);
         // draw:image
         $objWriter->startElement('draw:image');
         $objWriter->writeAttribute('xlink:href', 'Pictures/' . $shape->getIndexedFilename());
@@ -530,6 +547,7 @@ class Content extends AbstractDecoratorWriter
             $objWriter->writeAttribute('svg:x', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetX()), 3) . 'cm');
             $objWriter->writeAttribute('svg:y', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetY()), 3) . 'cm');
         }
+        $this->writeShapeDecorative($objWriter, $shape);
         // draw:text-box
         $objWriter->startElement('draw:text-box');
 
@@ -709,6 +727,7 @@ class Content extends AbstractDecoratorWriter
         $objWriter->writeAttribute('svg:x2', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetX() + $shape->getWidth()), 3) . 'cm');
         $objWriter->writeAttribute('svg:y2', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetY() + $shape->getHeight()), 3) . 'cm');
 
+        $this->writeShapeDecorative($objWriter, $shape);
         $this->writeShapeDescription($objWriter, $shape);
 
         // text:p
@@ -728,6 +747,8 @@ class Content extends AbstractDecoratorWriter
         $objWriter->writeAttribute('svg:y', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getOffsetY()), 3) . 'cm');
         $objWriter->writeAttribute('svg:height', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getHeight()), 3) . 'cm');
         $objWriter->writeAttribute('svg:width', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getWidth()), 3) . 'cm');
+
+        $this->writeShapeDecorative($objWriter, $shape);
 
         $arrayRows = $shape->getRows();
         if (!empty($arrayRows)) {
@@ -831,6 +852,8 @@ class Content extends AbstractDecoratorWriter
         $objWriter->writeAttribute('svg:height', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getHeight()), 3) . 'cm');
         $objWriter->writeAttribute('svg:width', Text::numberFormat(CommonDrawing::pixelsToCentimeters((int) $shape->getWidth()), 3) . 'cm');
 
+        $this->writeShapeDecorative($objWriter, $shape);
+
         // draw:object
         $objWriter->startElement('draw:object');
         $objWriter->writeAttribute('xlink:href', './Object ' . $this->shapeId);
@@ -854,6 +877,7 @@ class Content extends AbstractDecoratorWriter
         // draw:g
         $objWriter->startElement('draw:g');
 
+        $this->writeShapeDecorative($objWriter, $group);
         $this->writeShapeDescription($objWriter, $group);
 
         $shapes = $group->getShapeCollection();

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -403,6 +403,21 @@ class Content extends AbstractDecoratorWriter
     }
 
     /**
+     * Write the decorative flag of a shape, ie the shape is ignored by assistive
+     * technologies. It has to be written before any child of the shape element.
+     *
+     * ODF has no such attribute before version 1.4, so the LibreOffice extension is used.
+     */
+    protected function writeShapeDecorative(XMLWriter $objWriter, AbstractShape $shape): void
+    {
+        if (!$shape->isDecorative()) {
+            return;
+        }
+
+        $objWriter->writeAttribute('loext:decorative', 'true');
+    }
+
+    /**
      * Write the description of a shape, exposed to assistive technologies as the
      * alternative text. It has to be the first child of the shape element.
      */
@@ -418,21 +433,6 @@ class Content extends AbstractDecoratorWriter
     /**
      * Write picture.
      */
-    /**
-     * Write the decorative flag of a shape, ie the shape is ignored by assistive
-     * technologies. It has to be written before any child of the shape element.
-     *
-     * ODF has no such attribute before version 1.4, so the LibreOffice extension is used.
-     */
-    protected function writeShapeDecorative(XMLWriter $objWriter, AbstractShape $shape): void
-    {
-        if (null === $shape->isDecorative()) {
-            return;
-        }
-
-        $objWriter->writeAttribute('loext:decorative', $shape->isDecorative() ? 'true' : 'false');
-    }
-
     protected function writeShapeMedia(XMLWriter $objWriter, Media $shape): void
     {
         // draw:frame

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -154,6 +154,48 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
     }
 
     /**
+     * Write the decorative flag of a shape. It is an extension of `p:cNvPr`, so it has to be
+     * written as its last child.
+     *
+     * @param XMLWriter $objWriter XML Writer
+     */
+    protected function writeShapeDecorative(XMLWriter $objWriter, AbstractShape $shape): void
+    {
+        if (null === $shape->isDecorative()) {
+            return;
+        }
+
+        // a:extLst
+        $objWriter->startElement('a:extLst');
+        $this->writeShapeDecorativeExtension($objWriter, $shape);
+        // > a:extLst
+        $objWriter->endElement();
+    }
+
+    /**
+     * Write the decorative extension of a shape, for callers writing their own `a:extLst`.
+     *
+     * @param XMLWriter $objWriter XML Writer
+     */
+    protected function writeShapeDecorativeExtension(XMLWriter $objWriter, AbstractShape $shape): void
+    {
+        if (null === $shape->isDecorative()) {
+            return;
+        }
+
+        // a:ext
+        $objWriter->startElement('a:ext');
+        $objWriter->writeAttribute('uri', '{C183D7F6-B498-43B3-948B-1728B52AA6E4}');
+        // a:ext\adec:decorative
+        $objWriter->startElement('adec:decorative');
+        $objWriter->writeAttribute('xmlns:adec', 'http://schemas.microsoft.com/office/drawing/2017/decorative');
+        $objWriter->writeAttribute('val', $shape->isDecorative() ? '1' : '0');
+        $objWriter->endElement();
+        // > a:ext
+        $objWriter->endElement();
+    }
+
+    /**
      * Write txt.
      *
      * @param XMLWriter $objWriter XML Writer
@@ -177,6 +219,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         if ($shape->hasHyperlink()) {
             $this->writeHyperlink($objWriter, $shape);
         }
+        $this->writeShapeDecorative($objWriter, $shape);
         // > p:sp\p:nvSpPr
         $objWriter->endElement();
         // p:sp\p:nvSpPr\p:cNvSpPr
@@ -338,6 +381,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('id', $shapeId);
         $objWriter->writeAttribute('name', $shape->getName());
         $objWriter->writeAttribute('descr', $shape->getDescription());
+        $this->writeShapeDecorative($objWriter, $shape);
         $objWriter->endElement();
         // p:graphicFrame/p:nvGraphicFramePr/p:cNvGraphicFramePr
         $objWriter->startElement('p:cNvGraphicFramePr');
@@ -719,6 +763,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('id', $shapeId);
         $objWriter->writeAttribute('name', '');
         $objWriter->writeAttribute('descr', $shape->getDescription());
+        $this->writeShapeDecorative($objWriter, $shape);
         $objWriter->endElement();
         // p:cNvCxnSpPr
         $objWriter->writeElement('p:cNvCxnSpPr', null);
@@ -1158,6 +1203,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('id', $shapeId);
         $objWriter->writeAttribute('name', $shape->getName());
         $objWriter->writeAttribute('descr', $shape->getDescription());
+        $this->writeShapeDecorative($objWriter, $shape);
         // p:sp\p:nvSpPr\p:cNvPr\
         $objWriter->endElement();
         // p:sp\p:nvSpPr\p:cNvSpPr
@@ -1274,6 +1320,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('id', $shapeId);
         $objWriter->writeAttribute('name', $shape->getName());
         $objWriter->writeAttribute('descr', $shape->getDescription());
+        $this->writeShapeDecorative($objWriter, $shape);
         $objWriter->endElement();
         // p:cNvGraphicFramePr
         $objWriter->writeElement('p:cNvGraphicFramePr', null);
@@ -1340,15 +1387,19 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
             $this->writeHyperlink($objWriter, $shape);
         }
 
-        if ($shape instanceof AbstractDrawingAdapter && $shape->getExtension() == 'svg') {
+        $hasCreationId = $shape instanceof AbstractDrawingAdapter && $shape->getExtension() == 'svg';
+        if ($hasCreationId || null !== $shape->isDecorative()) {
             $objWriter->startElement('a:extLst');
-            $objWriter->startElement('a:ext');
-            $objWriter->writeAttribute('uri', '{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}');
-            $objWriter->startElement('a16:creationId');
-            $objWriter->writeAttribute('xmlns:a16', 'http://schemas.microsoft.com/office/drawing/2014/main');
-            $objWriter->writeAttribute('id', '{F8CFD691-5332-EB49-9B42-7D7B3DB9185D}');
-            $objWriter->endElement();
-            $objWriter->endElement();
+            if ($hasCreationId) {
+                $objWriter->startElement('a:ext');
+                $objWriter->writeAttribute('uri', '{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}');
+                $objWriter->startElement('a16:creationId');
+                $objWriter->writeAttribute('xmlns:a16', 'http://schemas.microsoft.com/office/drawing/2014/main');
+                $objWriter->writeAttribute('id', '{F8CFD691-5332-EB49-9B42-7D7B3DB9185D}');
+                $objWriter->endElement();
+                $objWriter->endElement();
+            }
+            $this->writeShapeDecorativeExtension($objWriter, $shape);
             $objWriter->endElement();
         }
 
@@ -1500,6 +1551,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('name', 'Group ' . $shapeId++);
         $objWriter->writeAttribute('id', $shapeId);
         $objWriter->writeAttribute('descr', $group->getDescription());
+        $this->writeShapeDecorative($objWriter, $group);
         $objWriter->endElement(); // p:cNvPr
         // NOTE: Re: $shapeId This seems to be how PowerPoint 2010 does business.
         // p:cNvGrpSpPr

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -161,7 +161,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
      */
     protected function writeShapeDecorative(XMLWriter $objWriter, AbstractShape $shape): void
     {
-        if (null === $shape->isDecorative()) {
+        if (!$shape->isDecorative()) {
             return;
         }
 
@@ -179,7 +179,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
      */
     protected function writeShapeDecorativeExtension(XMLWriter $objWriter, AbstractShape $shape): void
     {
-        if (null === $shape->isDecorative()) {
+        if (!$shape->isDecorative()) {
             return;
         }
 
@@ -189,7 +189,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         // a:ext\adec:decorative
         $objWriter->startElement('adec:decorative');
         $objWriter->writeAttribute('xmlns:adec', 'http://schemas.microsoft.com/office/drawing/2017/decorative');
-        $objWriter->writeAttribute('val', $shape->isDecorative() ? '1' : '0');
+        $objWriter->writeAttribute('val', '1');
         $objWriter->endElement();
         // > a:ext
         $objWriter->endElement();
@@ -1388,7 +1388,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         }
 
         $hasCreationId = $shape instanceof AbstractDrawingAdapter && $shape->getExtension() == 'svg';
-        if ($hasCreationId || null !== $shape->isDecorative()) {
+        if ($hasCreationId || $shape->isDecorative()) {
             $objWriter->startElement('a:extLst');
             if ($hasCreationId) {
                 $objWriter->startElement('a:ext');

--- a/tests/PhpPresentation/Tests/AbstractShapeTest.php
+++ b/tests/PhpPresentation/Tests/AbstractShapeTest.php
@@ -54,6 +54,19 @@ class AbstractShapeTest extends TestCase
         self::assertInstanceOf(Shadow::class, $object->getShadow());
     }
 
+    public function testDecorative(): void
+    {
+        $object = new RichText();
+
+        self::assertNull($object->isDecorative());
+        self::assertInstanceOf(AbstractShape::class, $object->setDecorative());
+        self::assertTrue($object->isDecorative());
+        self::assertInstanceOf(AbstractShape::class, $object->setDecorative(false));
+        self::assertFalse($object->isDecorative());
+        self::assertInstanceOf(AbstractShape::class, $object->setDecorative(null));
+        self::assertNull($object->isDecorative());
+    }
+
     public function testDescription(): void
     {
         $object = new RichText();

--- a/tests/PhpPresentation/Tests/AbstractShapeTest.php
+++ b/tests/PhpPresentation/Tests/AbstractShapeTest.php
@@ -58,13 +58,11 @@ class AbstractShapeTest extends TestCase
     {
         $object = new RichText();
 
-        self::assertNull($object->isDecorative());
+        self::assertFalse($object->isDecorative());
         self::assertInstanceOf(AbstractShape::class, $object->setDecorative());
         self::assertTrue($object->isDecorative());
         self::assertInstanceOf(AbstractShape::class, $object->setDecorative(false));
         self::assertFalse($object->isDecorative());
-        self::assertInstanceOf(AbstractShape::class, $object->setDecorative(null));
-        self::assertNull($object->isDecorative());
     }
 
     public function testDescription(): void

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1073,8 +1073,7 @@ class ODPresentationTest extends TestCase
         $oPhpPresentation = new PhpPresentation();
         $oSlide = $oPhpPresentation->getActiveSlide();
         $oSlide->createRichTextShape()->setDecorative()->createTextRun('Decorative');
-        $oSlide->createRichTextShape()->setDecorative(false)->createTextRun('Meaningful');
-        $oSlide->createRichTextShape()->createTextRun('Unspecified');
+        $oSlide->createRichTextShape()->createTextRun('Meaningful');
 
         $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
         (new ODPresentationWriter($oPhpPresentation))->save($file);
@@ -1082,10 +1081,9 @@ class ODPresentationTest extends TestCase
         unlink($file);
 
         $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
-        self::assertCount(3, $arrayShape);
+        self::assertCount(2, $arrayShape);
         self::assertTrue($arrayShape[0]->isDecorative());
         self::assertFalse($arrayShape[1]->isDecorative());
-        self::assertNull($arrayShape[2]->isDecorative());
     }
 
     public function testShapeDescription(): void

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1068,6 +1068,26 @@ class ODPresentationTest extends TestCase
         self::assertEquals('TEST IMAGE', $oElement->getText());
     }
 
+    public function testShapeDecorative(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSlide = $oPhpPresentation->getActiveSlide();
+        $oSlide->createRichTextShape()->setDecorative()->createTextRun('Decorative');
+        $oSlide->createRichTextShape()->setDecorative(false)->createTextRun('Meaningful');
+        $oSlide->createRichTextShape()->createTextRun('Unspecified');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertCount(3, $arrayShape);
+        self::assertTrue($arrayShape[0]->isDecorative());
+        self::assertFalse($arrayShape[1]->isDecorative());
+        self::assertNull($arrayShape[2]->isDecorative());
+    }
+
     public function testShapeDescription(): void
     {
         $oPhpPresentation = new PhpPresentation();

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1126,8 +1126,7 @@ class PowerPoint2007Test extends TestCase
         $oPhpPresentation = new PhpPresentation();
         $oSlide = $oPhpPresentation->getActiveSlide();
         $oSlide->createRichTextShape()->setDecorative()->createTextRun('Decorative');
-        $oSlide->createRichTextShape()->setDecorative(false)->createTextRun('Meaningful');
-        $oSlide->createRichTextShape()->createTextRun('Unspecified');
+        $oSlide->createRichTextShape()->createTextRun('Meaningful');
 
         $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
         (new PowerPoint2007Writer($oPhpPresentation))->save($file);
@@ -1135,10 +1134,9 @@ class PowerPoint2007Test extends TestCase
         unlink($file);
 
         $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
-        self::assertCount(3, $arrayShape);
+        self::assertCount(2, $arrayShape);
         self::assertTrue($arrayShape[0]->isDecorative());
         self::assertFalse($arrayShape[1]->isDecorative());
-        self::assertNull($arrayShape[2]->isDecorative());
     }
 
     public function testShapeDescription(): void

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1121,6 +1121,26 @@ class PowerPoint2007Test extends TestCase
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
     }
 
+    public function testShapeDecorative(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSlide = $oPhpPresentation->getActiveSlide();
+        $oSlide->createRichTextShape()->setDecorative()->createTextRun('Decorative');
+        $oSlide->createRichTextShape()->setDecorative(false)->createTextRun('Meaningful');
+        $oSlide->createRichTextShape()->createTextRun('Unspecified');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertCount(3, $arrayShape);
+        self::assertTrue($arrayShape[0]->isDecorative());
+        self::assertFalse($arrayShape[1]->isDecorative());
+        self::assertNull($arrayShape[2]->isDecorative());
+    }
+
     public function testShapeDescription(): void
     {
         $oPhpPresentation = new PhpPresentation();

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -86,6 +86,23 @@ class ContentTest extends PhpPresentationTestCase
         $this->assertIsSchemaOpenDocumentNotValid('1.2');
     }
 
+    public function testShapeDecorative(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+
+        $oRichText = $oSlide->createRichTextShape();
+        $oRichText->createTextRun('AAA');
+
+        $oLine = $oSlide->createLineShape(10, 10, 100, 100);
+        $oLine->setDecorative();
+
+        $basePath = '/office:document-content/office:body/office:presentation/draw:page';
+        $this->assertZipXmlAttributeNotExists('content.xml', $basePath . '/draw:frame', 'loext:decorative');
+        $this->assertZipXmlAttributeEquals('content.xml', $basePath . '/draw:line', 'loext:decorative', 'true');
+        // Invalid because `loext:decorative` is a LibreOffice extension, standardized in ODF 1.4
+        $this->assertIsSchemaOpenDocumentNotValid('1.2');
+    }
+
     public function testShapeDescription(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -174,7 +174,7 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
 
         $this->resetPresentationFile();
-        $oRichText->setDecorative(false);
+        $oRichText->setDecorative();
 
         $expectedElement = '/p:sld/p:cSld/p:spTree/p:sp/p:nvSpPr/p:cNvPr/a:extLst/a:ext';
         $this->assertZipXmlAttributeEquals(
@@ -183,7 +183,7 @@ class PptSlidesTest extends PhpPresentationTestCase
             'uri',
             '{C183D7F6-B498-43B3-948B-1728B52AA6E4}'
         );
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $expectedElement . '/adec:decorative', 'val', '0');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $expectedElement . '/adec:decorative', 'val', '1');
         $this->assertIsSchemaECMA376Valid();
     }
 

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -153,6 +153,40 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testShapeDecorative(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+
+        $oRichText = $oSlide->createRichTextShape();
+        $oRichText->createTextRun('AAA');
+
+        $oGroup = new Group();
+        $oGroup->setDecorative();
+        $oGroup->addShape(new AutoShape());
+        $oSlide->addShape($oGroup);
+
+        $expectedElement = '/p:sld/p:cSld/p:spTree/p:sp/p:nvSpPr/p:cNvPr/a:extLst/a:ext/adec:decorative';
+        $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $expectedElement);
+
+        $expectedElement = '/p:sld/p:cSld/p:spTree/p:grpSp/p:nvGrpSpPr/p:cNvPr/a:extLst/a:ext/adec:decorative';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $expectedElement);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $expectedElement, 'val', '1');
+        $this->assertIsSchemaECMA376Valid();
+
+        $this->resetPresentationFile();
+        $oRichText->setDecorative(false);
+
+        $expectedElement = '/p:sld/p:cSld/p:spTree/p:sp/p:nvSpPr/p:cNvPr/a:extLst/a:ext';
+        $this->assertZipXmlAttributeEquals(
+            'ppt/slides/slide1.xml',
+            $expectedElement,
+            'uri',
+            '{C183D7F6-B498-43B3-948B-1728B52AA6E4}'
+        );
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $expectedElement . '/adec:decorative', 'val', '0');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testShapeDescription(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();

--- a/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
+++ b/tests/PhpPresentation/Tests/_includes/PhpPresentationTestCase.php
@@ -196,6 +196,7 @@ class PhpPresentationTestCase extends TestCase
         if (null === $this->xmlXPath) {
             $this->xmlXPath = new DOMXPath($this->xmlDom);
             $this->xmlXPath->registerNamespace('p14', 'http://schemas.microsoft.com/office/powerpoint/2010/main');
+            $this->xmlXPath->registerNamespace('adec', 'http://schemas.microsoft.com/office/drawing/2017/decorative');
         }
 
         return $this->xmlXPath->query($xpath);


### PR DESCRIPTION
### Description

A shape that carries no information — a coloured band, a rule, a background image — is announced by assistive technologies like any other, which walks blind users through content that means nothing. Both formats can say otherwise, and the library could not.

`AbstractShape` gains a `decorative` flag, false by default. Only a decorative shape writes anything: false and absent mean the same thing to both formats.

```php
$slide->createLineShape(10, 10, 100, 10)->setDecorative();
```

- **PowerPoint2007**: the `{C183D7F6-B498-43B3-948B-1728B52AA6E4}` extension of `p:cNvPr`, written for every shape kind. Pictures may already write an `a:extLst` for the SVG creation id, so the two extensions share one list rather than emitting a second one.
- **ODPresentation**: the `loext:decorative` attribute of the shape element. ODF has no such attribute before 1.4, so this is the LibreOffice extension — which is why `ContentTest::testShapeDecorative` asserts `assertIsSchemaOpenDocumentNotValid('1.2')`, the same way the existing `loext:mime-type` test does.
- **Readers**: both restore the flag, so a load/save round trip keeps it. `Reader\PowerPoint2007` reads the extension of `p:cNvPr` for rich text, pictures, tables and charts (the shape kinds it loads), `Reader\ODPresentation` reads `loext:decorative` off the frame.

Fixes #705.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
      `AbstractShapeTest::testDecorative`, `PptSlidesTest::testShapeDecorative` (schema-validated against ECMA-376), `ContentTest::testShapeDecorative`, and a load/save round trip in `Reader\PowerPoint2007Test::testShapeDecorative` and `Reader\ODPresentationTest::testShapeDecorative`. The `adec` prefix is registered in `PhpPresentationTestCase` so it can be reached by XPath.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
      A *Decorative shapes* section in `docs/usage/shapes/introduction.md`.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)

