### PR TITLE
An outline on the data points of a chart serie

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -8,6 +8,7 @@
 - Raised the minimum PHP version to 7.4 (dropped 7.1, 7.2 and 7.3) by [@slayerfx](http://github.com/slayerfx) in [#894](https://github.com/PHPOffice/PHPPresentation/pull/894)
 - Added an alternative text (`description`) on every shape, and not only on graphics, by [@dkulyk](http://github.com/dkulyk) in [#898](https://github.com/PHPOffice/PHPPresentation/pull/898)
 - Added the ability to mark a shape as decorative, so that assistive technologies skip it, by [@dkulyk](http://github.com/dkulyk) in [#899](https://github.com/PHPOffice/PHPPresentation/pull/899)
+- Added an outline on the data points of a chart serie, next to the fill they already had, by [@dkulyk](http://github.com/dkulyk) in [#900](https://github.com/PHPOffice/PHPPresentation/pull/900)
 
 ## Bug fixes
 - Fixed adding custom SVGs by [@seanlynchwv](http://github.com/seanlynchwv) in [#881](https://github.com/PHPOffice/PHPPresentation/pull/881)

--- a/docs/usage/shapes/chart.md
+++ b/docs/usage/shapes/chart.md
@@ -380,6 +380,27 @@ $series = new Series('Downloads', $seriesData);
 $series->setOutline($outline);
 ```
 
+#### Data points
+Each data point of a serie can carry a fill and an outline of its own, which overrides the ones of the serie.
+A data point styled this way is written whether it defines a fill, an outline, or both.
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Style\Color;
+use PhpOffice\PhpPresentation\Style\Fill;
+
+$series = new Series('Downloads', $seriesData);
+// A slice with a white border
+$series->getDataPointFill(0)->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_BLUE));
+$series->getDataPointOutline(0)->setWidth(2)->getFill()
+    ->setFillType(Fill::FILL_SOLID)
+    ->setStartColor(new Color(Color::COLOR_WHITE));
+// A slice made invisible, for the flat side of a gauge
+$series->getDataPointFill(1)->setFillType(Fill::FILL_NONE);
+$series->getDataPointOutline(1)->getFill()->setFillType(Fill::FILL_NONE);
+```
+
 ### View3D
 
 For enabling the autoscale for a shape, you must reset the height percent.

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1317,6 +1317,8 @@ class PowerPoint2007 implements ReaderInterface
                                 );
                             }
 
+                            $this->loadSeriesDataPoints($xmlReader, $elementSerie, $series);
+
                             if ($elementShowLegendKey = $xmlReader->getElement('c:dLbls/c:showLegendKey', $elementSerie)) {
                                 $series->setShowLegendKey((bool) $elementShowLegendKey->getAttribute('val'));
                             }
@@ -1679,6 +1681,39 @@ class PowerPoint2007 implements ReaderInterface
         }
 
         return $oColor;
+    }
+
+    /**
+     * Read the fill and the outline carried by the data points of a serie.
+     *
+     * @param DOMElement $oElement the `c:ser` element of the serie
+     */
+    protected function loadSeriesDataPoints(XMLReader $xmlReader, DOMElement $oElement, Chart\Series $series): void
+    {
+        foreach ($xmlReader->getElements('c:dPt', $oElement) as $oElementDataPoint) {
+            if (!$oElementDataPoint instanceof DOMElement) {
+                continue;
+            }
+            $oElementIndex = $xmlReader->getElement('c:idx', $oElementDataPoint);
+            $oElementProperties = $xmlReader->getElement('c:spPr', $oElementDataPoint);
+            if (!$oElementIndex instanceof DOMElement || !$oElementProperties instanceof DOMElement) {
+                continue;
+            }
+            $index = (int) $oElementIndex->getAttribute('val');
+
+            $oFill = $this->loadStyleFill($xmlReader, $oElementProperties);
+            if ($oFill) {
+                $series->setDataPointFill($index, $oFill);
+            } elseif ($xmlReader->getElement('a:noFill', $oElementProperties) instanceof DOMElement) {
+                // A data point stating that it has no fill of its own
+                $series->setDataPointFill($index, new Fill());
+            }
+
+            $oOutline = $this->loadStyleOutline($xmlReader, $oElementProperties);
+            if ($oOutline) {
+                $series->setDataPointOutline($index, $oOutline);
+            }
+        }
     }
 
     protected function loadStyleFill(XMLReader $xmlReader, DOMElement $oElement): ?Fill

--- a/src/PhpPresentation/Shape/Chart/Series.php
+++ b/src/PhpPresentation/Shape/Chart/Series.php
@@ -46,6 +46,13 @@ class Series implements ComparableInterface
     protected $dataPointFills = [];
 
     /**
+     * DataPointOutlines (key/value).
+     *
+     * @var array<int, Outline>
+     */
+    protected $dataPointOutlines = [];
+
+    /**
      * Data Label Number Format.
      *
      * @var string
@@ -229,11 +236,64 @@ class Series implements ComparableInterface
     }
 
     /**
+     * @param int $dataPointIndex data point index
+     */
+    public function setDataPointFill(int $dataPointIndex, Fill $fill): self
+    {
+        $this->dataPointFills[$dataPointIndex] = $fill;
+
+        return $this;
+    }
+
+    /**
      * @return Fill[]
      */
     public function getDataPointFills(): array
     {
         return $this->dataPointFills;
+    }
+
+    /**
+     * @param int $dataPointIndex data point index
+     */
+    public function getDataPointOutline(int $dataPointIndex): Outline
+    {
+        if (!isset($this->dataPointOutlines[$dataPointIndex])) {
+            $this->dataPointOutlines[$dataPointIndex] = new Outline();
+        }
+
+        return $this->dataPointOutlines[$dataPointIndex];
+    }
+
+    /**
+     * @param int $dataPointIndex data point index
+     */
+    public function setDataPointOutline(int $dataPointIndex, Outline $outline): self
+    {
+        $this->dataPointOutlines[$dataPointIndex] = $outline;
+
+        return $this;
+    }
+
+    /**
+     * @return Outline[]
+     */
+    public function getDataPointOutlines(): array
+    {
+        return $this->dataPointOutlines;
+    }
+
+    /**
+     * The indexes of the data points carrying a fill or an outline of their own.
+     *
+     * @return array<int, int>
+     */
+    public function getDataPointIndexes(): array
+    {
+        $indexes = array_keys($this->dataPointFills + $this->dataPointOutlines);
+        sort($indexes);
+
+        return $indexes;
     }
 
     /**

--- a/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
+++ b/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
@@ -677,10 +677,13 @@ class ObjectsChart extends AbstractDecoratorWriter
             || $chartType instanceof Radar
             || $chartType instanceof Scatter
         ) {
+            $dataPointOutlines = $series->getDataPointOutlines();
             $newFill = new Fill();
             $incRepeat = 0;
             for ($inc = 0; $inc < $numRange; ++$inc) {
-                if ($series->getDataPointFill($inc)->getHashCode() === $newFill->getHashCode()) {
+                if ($series->getDataPointFill($inc)->getHashCode() === $newFill->getHashCode()
+                    && !isset($dataPointOutlines[$inc])
+                ) {
                     // A data point taking the style of the serie : counted, written once the run ends
                     ++$incRepeat;
 
@@ -710,7 +713,7 @@ class ObjectsChart extends AbstractDecoratorWriter
                 $this->xmlContent->endElement();
             }
         } elseif ($chartType instanceof AbstractTypePie) {
-            $count = count($series->getDataPointFills());
+            $count = count($series->getDataPointIndexes());
             for ($inc = 0; $inc < $count; ++$inc) {
                 // chart:data-point
                 $this->xmlContent->startElement('chart:data-point');
@@ -847,20 +850,43 @@ class ObjectsChart extends AbstractDecoratorWriter
         // > style:style
         $this->xmlContent->endElement();
 
-        foreach ($series->getDataPointFills() as $idx => $oFill) {
+        $dataPointFills = $series->getDataPointFills();
+        $dataPointOutlines = $series->getDataPointOutlines();
+        foreach ($series->getDataPointIndexes() as $idx) {
             // style:style
             $this->xmlContent->startElement('style:style');
             $this->xmlContent->writeAttribute('style:name', 'styleSeries' . $this->numSeries . '_' . $idx);
             $this->xmlContent->writeAttribute('style:family', 'chart');
             // style:graphic-properties
             $this->xmlContent->startElement('style:graphic-properties');
-            $this->xmlContent->writeAttribute('draw:fill', $oFill->getFillType());
-            $this->xmlContent->writeAttribute('draw:fill-color', '#' . $oFill->getStartColor()->getRGB());
+            if (isset($dataPointFills[$idx])) {
+                $this->xmlContent->writeAttribute('draw:fill', $dataPointFills[$idx]->getFillType());
+                $this->xmlContent->writeAttribute('draw:fill-color', '#' . $dataPointFills[$idx]->getStartColor()->getRGB());
+            }
+            if (isset($dataPointOutlines[$idx])) {
+                $this->writeDataPointOutline($dataPointOutlines[$idx]);
+            }
             // > style:graphic-properties
             $this->xmlContent->endElement();
             // > style:style
             $this->xmlContent->endElement();
         }
+    }
+
+    /**
+     * Write the stroke of a data point, as attributes of the graphic properties of its style.
+     */
+    protected function writeDataPointOutline(Outline $oOutline): void
+    {
+        if (Fill::FILL_NONE == $oOutline->getFill()->getFillType()) {
+            $this->xmlContent->writeAttribute('draw:stroke', 'none');
+
+            return;
+        }
+
+        $this->xmlContent->writeAttribute('draw:stroke', 'solid');
+        $this->xmlContent->writeAttribute('svg:stroke-width', number_format(CommonDrawing::pixelsToCentimeters($oOutline->getWidth()), 3, '.', '') . 'cm');
+        $this->xmlContent->writeAttribute('svg:stroke-color', '#' . $oOutline->getFill()->getStartColor()->getRGB());
     }
 
     protected function writeTable(): void

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -836,20 +836,29 @@ class PptCharts extends AbstractDecoratorWriter
             $this->writeSingleValueOrReference($objWriter, $includeSheet, $series->getTitle(), $coords);
             $objWriter->endElement();
 
-            // Fills for points?
+            // Fills & outlines for points?
             $dataPointFills = $series->getDataPointFills();
-            foreach ($dataPointFills as $key => $value) {
+            $dataPointOutlines = $series->getDataPointOutlines();
+            foreach ($series->getDataPointIndexes() as $key) {
+                $fill = $dataPointFills[$key] ?? null;
+                $outline = $dataPointOutlines[$key] ?? null;
+                $hasFill = $fill && Fill::FILL_NONE != $fill->getFillType();
+
                 // c:dPt
                 $objWriter->startElement('c:dPt');
 
                 // c:idx
                 $this->writeElementWithValAttribute($objWriter, 'c:idx', (string) $key);
 
-                if (Fill::FILL_NONE != $value->getFillType()) {
+                if ($hasFill || $outline) {
                     // c:spPr
                     $objWriter->startElement('c:spPr');
                     // Write fill
-                    $this->writeFill($objWriter, $value);
+                    if ($hasFill) {
+                        $this->writeFill($objWriter, $fill);
+                    }
+                    // Write outline
+                    $this->writeOutline($objWriter, $outline);
                     // ## c:spPr
                     $objWriter->endElement();
                 }
@@ -1048,20 +1057,29 @@ class PptCharts extends AbstractDecoratorWriter
             $this->writeSingleValueOrReference($objWriter, $includeSheet, $series->getTitle(), $coords);
             $objWriter->endElement();
 
-            // Fills for points?
+            // Fills & outlines for points?
             $dataPointFills = $series->getDataPointFills();
-            foreach ($dataPointFills as $key => $value) {
+            $dataPointOutlines = $series->getDataPointOutlines();
+            foreach ($series->getDataPointIndexes() as $key) {
+                $fill = $dataPointFills[$key] ?? null;
+                $outline = $dataPointOutlines[$key] ?? null;
+                $hasFill = $fill && Fill::FILL_NONE != $fill->getFillType();
+
                 // c:dPt
                 $objWriter->startElement('c:dPt');
 
                 // c:idx
                 $this->writeElementWithValAttribute($objWriter, 'c:idx', (string) $key);
 
-                if (Fill::FILL_NONE != $value->getFillType()) {
+                if ($hasFill || $outline) {
                     // c:spPr
                     $objWriter->startElement('c:spPr');
                     // Write fill
-                    $this->writeFill($objWriter, $value);
+                    if ($hasFill) {
+                        $this->writeFill($objWriter, $fill);
+                    }
+                    // Write outline
+                    $this->writeOutline($objWriter, $outline);
                     // ## c:spPr
                     $objWriter->endElement();
                 }
@@ -1237,15 +1255,17 @@ class PptCharts extends AbstractDecoratorWriter
             $this->writeSingleValueOrReference($objWriter, $includeSheet, $series->getTitle(), $coords);
             $objWriter->endElement();
 
-            // Fills for points?
+            // Fills & outlines for points?
             $dataPointFills = $series->getDataPointFills();
-            foreach ($dataPointFills as $key => $value) {
+            $dataPointOutlines = $series->getDataPointOutlines();
+            foreach ($series->getDataPointIndexes() as $key) {
                 // c:dPt
                 $objWriter->startElement('c:dPt');
                 $this->writeElementWithValAttribute($objWriter, 'c:idx', (string) $key);
                 // c:dPt/c:spPr
                 $objWriter->startElement('c:spPr');
-                $this->writeFill($objWriter, $value);
+                $this->writeFill($objWriter, $dataPointFills[$key] ?? null);
+                $this->writeOutline($objWriter, $dataPointOutlines[$key] ?? null);
                 // c:dPt/##c:spPr
                 $objWriter->endElement();
                 // ##c:dPt
@@ -1398,15 +1418,17 @@ class PptCharts extends AbstractDecoratorWriter
             $this->writeSingleValueOrReference($objWriter, $includeSheet, $series->getTitle(), $coords);
             $objWriter->endElement();
 
-            // Fills for points?
+            // Fills & outlines for points?
             $dataPointFills = $series->getDataPointFills();
-            foreach ($dataPointFills as $key => $value) {
+            $dataPointOutlines = $series->getDataPointOutlines();
+            foreach ($series->getDataPointIndexes() as $key) {
                 // c:dPt
                 $objWriter->startElement('c:dPt');
                 $this->writeElementWithValAttribute($objWriter, 'c:idx', (string) $key);
                 // c:dPt/c:spPr
                 $objWriter->startElement('c:spPr');
-                $this->writeFill($objWriter, $value);
+                $this->writeFill($objWriter, $dataPointFills[$key] ?? null);
+                $this->writeOutline($objWriter, $dataPointOutlines[$key] ?? null);
                 // c:dPt/##c:spPr
                 $objWriter->endElement();
                 // ##c:dPt
@@ -1569,15 +1591,17 @@ class PptCharts extends AbstractDecoratorWriter
             $objWriter->writeAttribute('val', $subject->getExplosion());
             $objWriter->endElement();
 
-            // Fills for points?
+            // Fills & outlines for points?
             $dataPointFills = $series->getDataPointFills();
-            foreach ($dataPointFills as $key => $value) {
+            $dataPointOutlines = $series->getDataPointOutlines();
+            foreach ($series->getDataPointIndexes() as $key) {
                 // c:dPt
                 $objWriter->startElement('c:dPt');
                 $this->writeElementWithValAttribute($objWriter, 'c:idx', (string) $key);
                 // c:dPt/c:spPr
                 $objWriter->startElement('c:spPr');
-                $this->writeFill($objWriter, $value);
+                $this->writeFill($objWriter, $dataPointFills[$key] ?? null);
+                $this->writeOutline($objWriter, $dataPointOutlines[$key] ?? null);
                 // c:dPt/##c:spPr
                 $objWriter->endElement();
                 // ##c:dPt

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -27,11 +27,15 @@ use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\PresentationProperties;
 use PhpOffice\PhpPresentation\Reader\PowerPoint2007;
 use PhpOffice\PhpPresentation\Shape\Chart;
+use PhpOffice\PhpPresentation\Shape\Chart\Series;
+use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
+use PhpOffice\PhpPresentation\Style\Color;
+use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007 as PowerPoint2007Writer;
 use PHPUnit\Framework\TestCase;
@@ -615,7 +619,7 @@ class PowerPoint2007Test extends TestCase
         /** @var Chart $oShape */
         $oShape = $arrayShape[1];
         self::assertInstanceOf(Chart::class, $oShape);
-        self::assertInstanceOf(Chart\Type\Bar::class, $oShape->getPlotArea()->getType());
+        self::assertInstanceOf(Bar::class, $oShape->getPlotArea()->getType());
     }
 
     public function testLoadFileWithoutImages(): void
@@ -1111,6 +1115,38 @@ class PowerPoint2007Test extends TestCase
         $oPhpPresentation = $object->load($file);
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\PhpPresentation', $oPhpPresentation);
         self::assertEquals(1, $oPhpPresentation->getSlideCount());
+    }
+
+    public function testSeriesDataPoints(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSeries = new Series('Downloads', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        $oSeries->getDataPointFill(0)->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_BLUE));
+        $oSeries->getDataPointOutline(0)->setWidth(2)->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_WHITE));
+        $oSeries->getDataPointFill(1)->setFillType(Fill::FILL_NONE);
+        $oSeries->getDataPointOutline(1)->getFill()->setFillType(Fill::FILL_NONE);
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oPhpPresentation->getActiveSlide()->createChartShape()->getPlotArea()->setType($oBar);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(Chart::class, $arrayShape[0]);
+        $seriesRead = $arrayShape[0]->getPlotArea()->getType()->getSeries();
+        $seriesRead = reset($seriesRead);
+
+        self::assertEquals(Fill::FILL_SOLID, $seriesRead->getDataPointFill(0)->getFillType());
+        self::assertEquals('0000FF', $seriesRead->getDataPointFill(0)->getStartColor()->getRGB());
+        self::assertEquals(Fill::FILL_SOLID, $seriesRead->getDataPointOutline(0)->getFill()->getFillType());
+        self::assertEquals('FFFFFF', $seriesRead->getDataPointOutline(0)->getFill()->getStartColor()->getRGB());
+        self::assertEquals(2, $seriesRead->getDataPointOutline(0)->getWidth());
+
+        self::assertEquals(Fill::FILL_NONE, $seriesRead->getDataPointFill(1)->getFillType());
+        self::assertEquals(Fill::FILL_NONE, $seriesRead->getDataPointOutline(1)->getFill()->getFillType());
     }
 
     public function testLoadingFileWithNoteInSlide(): void

--- a/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
@@ -76,6 +76,30 @@ class SeriesTest extends TestCase
         self::assertInstanceOf(Fill::class, $object->getDataPointFill(0));
     }
 
+    public function testDataPointOutlines(): void
+    {
+        $object = new Series();
+
+        self::assertEmpty($object->getDataPointOutlines());
+
+        self::assertInstanceOf(Outline::class, $object->getDataPointOutline(0));
+        self::assertCount(1, $object->getDataPointOutlines());
+        self::assertSame($object->getDataPointOutline(0), $object->getDataPointOutline(0));
+    }
+
+    public function testDataPointIndexes(): void
+    {
+        $object = new Series();
+
+        self::assertEmpty($object->getDataPointIndexes());
+
+        $object->getDataPointFill(2);
+        $object->getDataPointOutline(0);
+        $object->getDataPointOutline(2);
+
+        self::assertSame([0, 2], $object->getDataPointIndexes());
+    }
+
     public function testFill(): void
     {
         $object = new Series();

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
@@ -800,6 +800,39 @@ class ObjectsChartTest extends PhpPresentationTestCase
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 
+    public function testDataPointOutlines(): void
+    {
+        $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        // A slice with a white border of its own
+        $oSeries->getDataPointFill(0)->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FF4672A8'));
+        $oSeries->getDataPointOutline(0)->setWidth(2)->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFFFFFFF'));
+        // A slice made invisible : no fill and no border
+        $oSeries->getDataPointFill(1)->setFillType(Fill::FILL_NONE);
+        $oSeries->getDataPointOutline(1)->getFill()->setFillType(Fill::FILL_NONE);
+        // A slice carrying an outline only
+        $oSeries->getDataPointOutline(2)->setWidth(1)->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFAB4744'));
+        $oDoughnut = new Doughnut();
+        $oDoughnut->addSeries($oSeries);
+        $oChart = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oChart->getPlotArea()->setType($oDoughnut);
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleSeries0_0\']/style:graphic-properties';
+        $this->assertZipXmlElementExists('Object 1/content.xml', $element);
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:stroke', 'solid');
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'svg:stroke-color', '#FFFFFF');
+        $this->assertZipXmlAttributeExists('Object 1/content.xml', $element, 'svg:stroke-width');
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleSeries0_1\']/style:graphic-properties';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:stroke', 'none');
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleSeries0_2\']/style:graphic-properties';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:stroke', 'solid');
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'svg:stroke-color', '#AB4744');
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'draw:fill');
+
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
     public function testTypeBarHorizontal(): void
     {
         $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -1001,6 +1001,44 @@ class PptChartsTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testDataPointOutlines(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oShape = $oSlide->createChartShape();
+        $oDoughnut = new Doughnut();
+        $oSeries = new Series('Downloads', $this->seriesData);
+        // A segment with a white border of its own
+        $oSeries->getDataPointFill(0)->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_BLUE));
+        $oSeries->getDataPointOutline(0)->setWidth(2)->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_WHITE));
+        // A segment made invisible : no fill and no border
+        $oSeries->getDataPointFill(1)->setFillType(Fill::FILL_NONE);
+        $oSeries->getDataPointOutline(1)->getFill()->setFillType(Fill::FILL_NONE);
+        // A segment carrying an outline only
+        $oSeries->getDataPointOutline(2)->setWidth(1)->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_DARKRED));
+        $oDoughnut->addSeries($oSeries);
+        $oShape->getPlotArea()->setType($oDoughnut);
+
+        $basePath = '/c:chartSpace/c:chart/c:plotArea/c:doughnutChart/c:ser';
+
+        $element = $basePath . '/c:dPt[1]/c:spPr/a:ln';
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'w', Drawing::pixelsToEmu(2));
+        $element = $basePath . '/c:dPt[1]/c:spPr/a:ln/a:solidFill/a:srgbClr';
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'val', (new Color(Color::COLOR_WHITE))->getRGB());
+
+        $element = $basePath . '/c:dPt[2]/c:spPr/a:noFill';
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+        $element = $basePath . '/c:dPt[2]/c:spPr/a:ln/a:noFill';
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+
+        $element = $basePath . '/c:dPt[3]/c:idx';
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'val', 2);
+        $element = $basePath . '/c:dPt[3]/c:spPr/a:ln/a:solidFill/a:srgbClr';
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'val', (new Color(Color::COLOR_DARKRED))->getRGB());
+
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testTypeDoughnut(): void
     {
         $randHoleSize = mt_rand(10, 90);


### PR DESCRIPTION
### Description

A data point of a serie could carry a fill of its own, but not an outline. A chart that needs a border per slice — a gauge with white gaps between its segments, a pie whose slices are separated — could not be built with the library, and had to be patched in the XML after the file was written.

`Series` gains the outline next to the fill it already had:

```php
$series = new Series('Downloads', $seriesData);
// A slice with a white border
$series->getDataPointFill(0)->setFillType(Fill::FILL_SOLID)->setStartColor(new Color(Color::COLOR_BLUE));
$series->getDataPointOutline(0)->setWidth(2)->getFill()
    ->setFillType(Fill::FILL_SOLID)
    ->setStartColor(new Color(Color::COLOR_WHITE));
// A slice made invisible, for the flat side of a gauge
$series->getDataPointFill(1)->setFillType(Fill::FILL_NONE);
$series->getDataPointOutline(1)->getFill()->setFillType(Fill::FILL_NONE);
```

- **API**: `getDataPointOutline()` / `getDataPointOutlines()` / `setDataPointOutline()`, mirroring the fills, plus `setDataPointFill()` which was missing next to its getter. `getDataPointIndexes()` returns the points carrying a fill, an outline, or both — both writers walk it, so a point defining only an outline is written as well.
- **PowerPoint2007**: `a:ln` inside `c:dPt/c:spPr`, next to the fill, for every chart type that already wrote data points (bar, bar 3D, doughnut, pie, pie 3D). An outline whose fill is `FILL_NONE` becomes `<a:ln><a:noFill/></a:ln>`, which is how a segment is made borderless.
- **ODPresentation**: `draw:stroke`, `svg:stroke-width` and `svg:stroke-color` on the style of the data point, next to `draw:fill` — `draw:stroke="none"` for an outline without a fill.
- **Reader**: `Reader\PowerPoint2007` reads `c:dPt` back. It never did, so the fills of the data points were dropped on load until now; the outlines come with them.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
      `SeriesTest::testDataPointOutlines` and `::testDataPointIndexes`, `PptChartsTest::testDataPointOutlines` (schema-validated against ECMA-376), `ObjectsChartTest::testDataPointOutlines` (schema-validated against ODF 1.2), and a load/save round trip in `Reader\PowerPoint2007Test::testSeriesDataPoints`.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
      A *Data points* section in `docs/usage/shapes/chart.md`.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
