### PR TITLE
ODPresentation Writer : Fix the chart output

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -12,4 +12,5 @@
 - Guarded `imagedestroy()` calls behind a PHP version check (no-op since PHP 8.0, deprecated in PHP 8.5) by [@slayerfx](http://github.com/slayerfx) in [#893](https://github.com/PHPOffice/PHPPresentation/pull/893)
 - Fixed code coverage configuration for PHPUnit 10+ by [@slayerfx](http://github.com/slayerfx) in [#895](https://github.com/PHPOffice/PHPPresentation/pull/895)
 - Fixed static analysis on PHP 8.4 and 8.5 (PHPStan 1.x could not resolve the symbols of PHPUnit 13) by [@yasumorishima](http://github.com/yasumorishima) in [#897](https://github.com/PHPOffice/PHPPresentation/pull/897)
+- ODPresentation Writer : Fixed the charts losing their data points, their background, their data labels and the colour of their series, and drawing a hidden legend by [@dkulyk](http://github.com/dkulyk) in [#901](https://github.com/PHPOffice/PHPPresentation/pull/901)
 

--- a/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
+++ b/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
@@ -423,6 +423,8 @@ class ObjectsChart extends AbstractDecoratorWriter
         } else {
             $this->xmlContent->writeAttribute('draw:stroke', 'solid');
         }
+        // Without draw:fill, the colour below is taken as a solid background, black by default
+        $this->xmlContent->writeAttribute('draw:fill', Fill::FILL_NONE === $chart->getFill()->getFillType() ? 'none' : 'solid');
         $this->xmlContent->writeAttribute('draw:fill-color', '#' . $chart->getFill()->getStartColor()->getRGB());
         // > style:graphic-properties
         $this->xmlContent->endElement();
@@ -460,6 +462,10 @@ class ObjectsChart extends AbstractDecoratorWriter
 
     protected function writeLegend(Chart $chart): void
     {
+        if (!$chart->getLegend()->isVisible()) {
+            return;
+        }
+
         // chart:legend
         $this->xmlContent->startElement('chart:legend');
         switch ($chart->getLegend()->getPosition()) {
@@ -626,13 +632,28 @@ class ObjectsChart extends AbstractDecoratorWriter
                 $this->xmlContent->writeAttribute('chart:percentage', 'true');
             }
         }
-        $labelFormat = 'value';
-        if ($chartType instanceof AbstractTypeBar) {
-            if (Bar::GROUPING_PERCENTSTACKED == $chartType->getBarGrouping()) {
+        // The labels the series ask for : the plot area states the default for the whole chart,
+        // so a chart whose series show nothing must not state one
+        $labelFormat = null;
+        foreach ($chartType->getSeries() as $series) {
+            if ($series->hasShowValue()) {
+                $labelFormat = $series->hasShowPercentage() ? 'value-and-percentage' : 'value';
+
+                break;
+            }
+            if ($series->hasShowPercentage()) {
                 $labelFormat = 'percentage';
+
+                break;
             }
         }
-        $this->xmlContent->writeAttribute('chart:data-label-number', $labelFormat);
+        if (null !== $labelFormat
+            && $chartType instanceof AbstractTypeBar
+            && Bar::GROUPING_PERCENTSTACKED == $chartType->getBarGrouping()
+        ) {
+            $labelFormat = 'percentage';
+        }
+        $this->xmlContent->writeAttributeIf(null !== $labelFormat, 'chart:data-label-number', $labelFormat);
 
         // > style:text-properties
         $this->xmlContent->endElement();
@@ -656,38 +677,38 @@ class ObjectsChart extends AbstractDecoratorWriter
             || $chartType instanceof Radar
             || $chartType instanceof Scatter
         ) {
-            $dataPointFills = $series->getDataPointFills();
-
-            $incRepeat = $numRange;
-            if (!empty($dataPointFills)) {
-                $inc = 0;
-                $incRepeat = 1;
-                $newFill = new Fill();
-                do {
-                    if ($series->getDataPointFill($inc)->getHashCode() !== $newFill->getHashCode()) {
-                        // chart:data-point
-                        $this->xmlContent->startElement('chart:data-point');
-                        $this->xmlContent->writeAttribute('chart:repeated', $incRepeat);
-                        // > chart:data-point
-                        $this->xmlContent->endElement();
-                        $incRepeat = 1;
-
-                        // chart:data-point
-                        $this->xmlContent->startElement('chart:data-point');
-                        $this->xmlContent->writeAttribute('chart:style-name', 'styleSeries' . $this->numSeries . '_' . $inc);
-                        // > chart:data-point
-                        $this->xmlContent->endElement();
-                    }
-                    ++$inc;
+            $newFill = new Fill();
+            $incRepeat = 0;
+            for ($inc = 0; $inc < $numRange; ++$inc) {
+                if ($series->getDataPointFill($inc)->getHashCode() === $newFill->getHashCode()) {
+                    // A data point taking the style of the serie : counted, written once the run ends
                     ++$incRepeat;
-                } while ($inc < $numRange);
-                --$incRepeat;
+
+                    continue;
+                }
+
+                if ($incRepeat > 0) {
+                    // chart:data-point
+                    $this->xmlContent->startElement('chart:data-point');
+                    $this->xmlContent->writeAttribute('chart:repeated', $incRepeat);
+                    // > chart:data-point
+                    $this->xmlContent->endElement();
+                    $incRepeat = 0;
+                }
+
+                // chart:data-point
+                $this->xmlContent->startElement('chart:data-point');
+                $this->xmlContent->writeAttribute('chart:style-name', 'styleSeries' . $this->numSeries . '_' . $inc);
+                // > chart:data-point
+                $this->xmlContent->endElement();
             }
-            // chart:data-point
-            $this->xmlContent->startElement('chart:data-point');
-            $this->xmlContent->writeAttribute('chart:repeated', $incRepeat);
-            // > chart:data-point
-            $this->xmlContent->endElement();
+            if ($incRepeat > 0) {
+                // chart:data-point
+                $this->xmlContent->startElement('chart:data-point');
+                $this->xmlContent->writeAttribute('chart:repeated', $incRepeat);
+                // > chart:data-point
+                $this->xmlContent->endElement();
+            }
         } elseif ($chartType instanceof AbstractTypePie) {
             $count = count($series->getDataPointFills());
             for ($inc = 0; $inc < $count; ++$inc) {
@@ -779,6 +800,11 @@ class ObjectsChart extends AbstractDecoratorWriter
         $this->xmlContent->endElement();
         // style:graphic-properties
         $this->xmlContent->startElement('style:graphic-properties');
+        // A serie leaving its fill untouched says nothing about its colour, the application picks one, as with the OOXML writer
+        $oSeriesFill = $series->getFill();
+        if ($oSeriesFill instanceof Fill && $oSeriesFill->getHashCode() === (new Fill())->getHashCode()) {
+            $oSeriesFill = null;
+        }
         if ($chartType instanceof Line || $chartType instanceof Radar || $chartType instanceof Scatter) {
             $outlineWidth = '';
             $outlineColor = '';
@@ -801,11 +827,13 @@ class ObjectsChart extends AbstractDecoratorWriter
             $this->xmlContent->writeAttribute('svg:stroke-color', '#' . $outlineColor);
         } else {
             $this->xmlContent->writeAttribute('draw:stroke', 'none');
-            if (!($chartType instanceof Area)) {
-                $this->xmlContent->writeAttribute('draw:fill', $series->getFill()->getFillType());
+            if (null !== $oSeriesFill && !($chartType instanceof Area)) {
+                $this->xmlContent->writeAttribute('draw:fill', $oSeriesFill->getFillType());
             }
         }
-        $this->xmlContent->writeAttribute('draw:fill-color', '#' . $series->getFill()->getStartColor()->getRGB());
+        if (null !== $oSeriesFill) {
+            $this->xmlContent->writeAttribute('draw:fill-color', '#' . $oSeriesFill->getStartColor()->getRGB());
+        }
         // > style:graphic-properties
         $this->xmlContent->endElement();
         // style:text-properties

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
@@ -285,6 +285,92 @@ class ObjectsChartTest extends PhpPresentationTestCase
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 
+    public function testLegendVisibility(): void
+    {
+        $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        $oLine = new Line();
+        $oLine->addSeries($oSeries);
+        $oChart = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oChart->getPlotArea()->setType($oLine);
+
+        $element = '/office:document-content/office:body/office:chart/chart:chart/chart:legend';
+        $this->assertZipXmlElementExists('Object 1/content.xml', $element);
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oChart->getLegend()->setVisible(false);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementNotExists('Object 1/content.xml', $element);
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testChartFill(): void
+    {
+        $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        $oLine = new Line();
+        $oLine->addSeries($oSeries);
+        $oChart = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oChart->getPlotArea()->setType($oLine);
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleChart\']/style:graphic-properties';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:fill', 'none');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oChart->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFFFFFFF'));
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:fill', 'solid');
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:fill-color', '#FFFFFF');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testSeriesFill(): void
+    {
+        $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oChart = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oChart->getPlotArea()->setType($oBar);
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleSeries0\']/style:graphic-properties';
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'draw:fill');
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'draw:fill-color');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oSeries->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FF4472C4'));
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:fill', 'solid');
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'draw:fill-color', '#4472C4');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testPlotAreaDataLabels(): void
+    {
+        $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        $oLine = new Line();
+        $oLine->addSeries($oSeries);
+        $oChart = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oChart->getPlotArea()->setType($oLine);
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'stylePlotArea\']/style:chart-properties';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:data-label-number', 'value');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        // A serie showing nothing must not leave a default label on the plot area
+        $oSeries->setShowValue(false);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'chart:data-label-number');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oSeries->setShowPercentage(true);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:data-label-number', 'percentage');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
     public function testSeriesValues(): void
     {
         $series = new Series('Series', ['Jan' => null]);
@@ -688,6 +774,28 @@ class ObjectsChartTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:overlap', '100');
         $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:percentage', 'true');
         $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:data-label-number', 'percentage');
+
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testTypeBarDataPointsRepeated(): void
+    {
+        $oSeries = new Series('Series', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2', 'Apr' => '4']);
+        $oSeries->getDataPointFill(1)->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('FFAB4744'));
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oChart = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oChart->getPlotArea()->setType($oBar);
+
+        // The data points describe the four values of the serie, no more and no less
+        $element = '/office:document-content/office:body/office:chart/chart:chart/chart:plot-area/chart:series/chart:data-point[1]';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:repeated', 1);
+        $element = '/office:document-content/office:body/office:chart/chart:chart/chart:plot-area/chart:series/chart:data-point[2]';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:style-name', 'styleSeries0_1');
+        $element = '/office:document-content/office:body/office:chart/chart:chart/chart:plot-area/chart:series/chart:data-point[3]';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:repeated', 2);
+        $element = '/office:document-content/office:body/office:chart/chart:chart/chart:plot-area/chart:series/chart:data-point[4]';
+        $this->assertZipXmlElementNotExists('Object 1/content.xml', $element);
 
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }


### PR DESCRIPTION
### Description

A chart written by the `ODPresentation` writer does not come out of LibreOffice looking like the chart it was given. The same presentation, one bar serie of four values with the second one filled red, written before and after this pull request :

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/odp-chart-before.png) | ![after](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/odp-chart-after.png) |

Five defects are at work in that picture, and this pull request fixes them one by one. The reference used throughout is a chart LibreOffice writes itself : insert a default chart, save as `.odp`, read `Object 1/content.xml`.

**1. A serie drew a single data point.** `writeSeries()` emitted one `chart:data-point chart:repeated="1"` for the whole serie, so a serie of four values was drawn as one bar, and a styled point shifted the values along. The points taking the style of the serie are now counted and their run written with the right `chart:repeated`, the styled ones written on their own — which is what LibreOffice writes :

```xml
<chart:series chart:style-name="ch7" …><chart:data-point chart:repeated="4"/></chart:series>
```

**2. Every chart came out on a black background.** `writeChartStyle()` wrote `draw:fill-color` without `draw:fill`. The ODF default for `draw:fill` is `solid`, so the colour of a `Fill` that was never asked to be painted was taken as a solid background. `draw:fill` is now written explicitly, as LibreOffice does :

```xml
<style:style style:name="ch1" …><style:graphic-properties draw:stroke="none" draw:fill="none"/></style:style>
```

**3. A hidden legend was drawn.** `writeLegend()` never looked at `Legend::isVisible()`. The element is now left out when the legend is hidden, absence of `chart:legend` being how ODF says a chart has no legend.

**4. The data labels never showed.** `chart:data-label-number` was written on the style of the serie only, where LibreOffice reads it from the style of the plot area. The format asked for by the first serie that shows something is now written there as well, `percentage` being forced for a percent-stacked bar.

**5. A serie with no fill of its own came out transparent.** `writeSeriesStyle()` wrote `draw:fill` from `$series->getFill()->getFillType()`, and the default `Fill` of a serie is `FILL_NONE` — so a serie whose colour was never set asked ODF for no fill at all. A serie leaving its fill untouched now says nothing about its colour and the application picks one, which is what the `PowerPoint2007` writer already does (`PptCharts.php`, `Fill::FILL_NONE != $series->getFill()->getFillType()`) and what LibreOffice does with its own palette :

```xml
ch7: draw:stroke="none" draw:fill-color="#004586"
ch8: draw:stroke="none" draw:fill-color="#ff420e"
```

As a side effect of the same change, `Series::setFill(null)` no longer fatals in this writer.

Nothing here touches the `PowerPoint2007` writer : its output was already correct in all five cases, and the tests cover the ODF side only.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes — no public API changes, the documented behaviour is the one that was broken
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
