### PR TITLE
PowerPoint2007 Writer : Keep the name of a slide

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -15,4 +15,5 @@
 - Fixed code coverage configuration for PHPUnit 10+ by [@slayerfx](http://github.com/slayerfx) in [#895](https://github.com/PHPOffice/PHPPresentation/pull/895)
 - Fixed static analysis on PHP 8.4 and 8.5 (PHPStan 1.x could not resolve the symbols of PHPUnit 13) by [@yasumorishima](http://github.com/yasumorishima) in [#897](https://github.com/PHPOffice/PHPPresentation/pull/897)
 - ODPresentation Writer : Fixed the charts losing their data points, their background, their data labels and the colour of their series, and drawing a hidden legend by [@dkulyk](http://github.com/dkulyk) in [#901](https://github.com/PHPOffice/PHPPresentation/pull/901)
+- PowerPoint2007 Writer : Fixed the name of a slide being lost on save, and read it back by [@dkulyk](http://github.com/dkulyk) in [#902](https://github.com/PHPOffice/PHPPresentation/pull/902)
 

--- a/docs/usage/slides/introduction.md
+++ b/docs/usage/slides/introduction.md
@@ -44,6 +44,9 @@ $slide = $presentation->createSlide();
 $slide->setName('Title of the slide');
 ```
 
+It is written as the `name` attribute of `p:cSld` in PowerPoint2007 files and as the
+`draw:name` attribute of `draw:page` in ODPresentation files. Both readers restore it.
+
 ### Visibility
 
 By default, a slide is visible.

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -455,6 +455,12 @@ class PowerPoint2007 implements ReaderInterface
             $this->oPhpPresentation->setActiveSlideIndex($this->oPhpPresentation->getSlideCount() - 1);
             $oSlide->setRelsIndex('ppt/slides/_rels/' . $baseFile . '.rels');
 
+            // Name
+            $oElement = $xmlReader->getElement('/p:sld/p:cSld');
+            if ($oElement instanceof DOMElement && $oElement->hasAttribute('name')) {
+                $oSlide->setName($oElement->getAttribute('name'));
+            }
+
             // Background
             $oElement = $xmlReader->getElement('/p:sld/p:cSld/p:bg/p:bgPr');
             if ($oElement instanceof DOMElement) {

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
@@ -352,6 +352,7 @@ class PptSlides extends AbstractSlide
 
         // p:sld/p:cSld
         $objWriter->startElement('p:cSld');
+        $objWriter->writeAttributeIf(null !== $pSlide->getName(), 'name', $pSlide->getName());
 
         // Background
         if ($pSlide->getBackground() instanceof Slide\AbstractBackground) {

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1160,4 +1160,19 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals('Budget spent to date: 45% of 1.2M EUR', $arrayShape[0]->getDescription());
         self::assertEquals('', $arrayShape[1]->getDescription());
     }
+
+    public function testSlideName(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oPhpPresentation->getActiveSlide()->setName('Introduction');
+        $oPhpPresentation->createSlide();
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        self::assertEquals('Introduction', $oPhpPresentationRead->getSlide(0)->getName());
+        self::assertNull($oPhpPresentationRead->getSlide(1)->getName());
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -1694,4 +1694,28 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $expectedElement, 'show', 0);
         $this->assertIsSchemaECMA376Valid();
     }
+
+    public function testSlideName(): void
+    {
+        $element = '/p:sld/p:cSld';
+
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeNotExists('ppt/slides/slide1.xml', $element, 'name');
+        $this->assertIsSchemaECMA376Valid();
+
+        $this->oPresentation->getActiveSlide()->setName('AAAA');
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $element, 'name');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'name', 'AAAA');
+        $this->assertIsSchemaECMA376Valid();
+
+        $this->oPresentation->getActiveSlide()->setName();
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeNotExists('ppt/slides/slide1.xml', $element, 'name');
+        $this->assertIsSchemaECMA376Valid();
+    }
 }


### PR DESCRIPTION
### Description

`Slide::setName()` had no effect on a PowerPoint2007 file. The ODPresentation writer writes it as `draw:name` on `draw:page` and `Reader\ODPresentation` reads it back, but `Writer\PowerPoint2007` never wrote anything, so the name was lost on save and there was nothing left for the reader to restore.

```php
$slide->setName('Introduction');
```

- **Writer**: the `name` attribute of `p:cSld`, written only when a name is set — `null` leaves the attribute out, the same condition the ODPresentation writer uses.
- **Reader**: `Reader\PowerPoint2007` reads it off `/p:sld/p:cSld`, so a load/save round trip keeps it. `Reader\ODPresentation` already did.

Fixes #882.

This supersedes #883 by @potofcoffee, which found the same gap. Two differences: that PR guards with `!empty()`, which also drops the legitimate name `'0'`, and it stops at the writer, so a name written by PowerPoint is still lost when the file is read back. Please close #883 when this one lands.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
      `PptSlidesTest::testSlideName` (schema-validated against ECMA-376, mirroring the existing `ODPresentation\ContentTest::testSlideName`) and a load/save round trip in `Reader\PowerPoint2007Test::testSlideName`.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
      The *Name* section of `docs/usage/slides/introduction.md` now says how the name is stored in each format.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
