### PR TITLE
PowerPoint2007 Writer : Honour the format code of an axis

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -34,6 +34,7 @@
 - `Style\Color` : Fixed a colour written as a plain RGB being given an alpha it never asked for by [@dkulyk](http://github.com/dkulyk) in [#910](https://github.com/PHPOffice/PHPPresentation/pull/910)
 - PowerPoint2007 Reader : Fixed a slide size written with an explicit `type="custom"` crashing the reader instead of being read with its own dimensions by [@SAY-5](http://github.com/SAY-5) in [#929](https://github.com/PHPOffice/PHPPresentation/pull/929)
 - ODPresentation Reader : Fixed the alignment of a paragraph being dropped on load, and its direction being read as left to right whatever the file said, by [@dkulyk](http://github.com/dkulyk) in [#927](https://github.com/PHPOffice/PHPPresentation/pull/927)
+- PowerPoint2007 Writer : Fixed `Axis::setFormatCode()` having no effect, the number format of an axis being taken from the source data instead by [@dkulyk](http://github.com/dkulyk) in [#903](https://github.com/PHPOffice/PHPPresentation/pull/903)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/shapes/chart.md
+++ b/docs/usage/shapes/chart.md
@@ -95,6 +95,27 @@ $shape->getPlotArea()->getAxisX()->setMinBounds(0);
 $shape->getPlotArea()->getAxisX()->setMaxBounds(200);
 ```
 
+#### Number format
+
+!!! warning
+    Available only on the PowerPoint2007 Writer
+
+For Axis, `setFormatCode` defines the number format of the tick labels, as an
+[OOXML format code](https://support.microsoft.com/en-us/office/number-format-codes-5026bbd6-04bc-48cd-bf33-80f18b4eae68).
+The default is `Axis::DEFAULT_FORMAT_CODE` (`general`), which leaves the labels formatted as the source data is.
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\Chart\Type\Line;
+
+$line = new Line();
+
+$shape = $slide->createChartShape();
+$shape->getPlotArea()->setType($line);
+$shape->getPlotArea()->getAxisY()->setFormatCode('#,##0.00');
+```
+
 #### Crossing
 
 !!! warning

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -2465,7 +2465,10 @@ class PptCharts extends AbstractDecoratorWriter
         // c:numFmt
         $objWriter->startElement('c:numFmt');
         $objWriter->writeAttribute('formatCode', $oAxis->getFormatCode());
-        $objWriter->writeAttribute('sourceLinked', '1');
+        // sourceLinked="1" tells the renderer to take the number format from the source data,
+        // which discards the formatCode written next to it. Only link it when no format code
+        // was asked for, so that a default axis keeps inheriting the format of its data.
+        $objWriter->writeAttribute('sourceLinked', Chart\Axis::DEFAULT_FORMAT_CODE === $oAxis->getFormatCode() ? '1' : '0');
         $objWriter->endElement();
 
         // c:majorTickMark

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -60,6 +60,34 @@ class PptChartsTest extends PhpPresentationTestCase
         'E' => '2',
     ];
 
+    public function testAxisFormatCode(): void
+    {
+        $oSeries = new Series('Downloads', $this->seriesData);
+
+        $oLine = new Line();
+        $oLine->addSeries($oSeries);
+
+        $oShape = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oShape->getPlotArea()->setType($oLine);
+
+        $element = '/c:chartSpace/c:chart/c:plotArea/c:valAx/c:numFmt';
+
+        // A default axis links its format to the source data, as it always has.
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'formatCode', Axis::DEFAULT_FORMAT_CODE);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'sourceLinked', '1');
+        $this->assertIsSchemaECMA376Valid();
+
+        // An explicit format code unlinks it, or the renderer would discard the format code.
+        $this->resetPresentationFile();
+        $oShape->getPlotArea()->getAxisY()->setFormatCode('#,##0.00');
+
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'formatCode', '#,##0.00');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'sourceLinked', '0');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testChartDisplayBlankAs(): void
     {
         $oSeries = new Series('Downloads', $this->seriesData);


### PR DESCRIPTION
### Description

`writeAxis()` writes the axis' format code and then immediately tells the renderer to ignore it:

```php
// src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php:2466
$objWriter->startElement('c:numFmt');
$objWriter->writeAttribute('formatCode', $oAxis->getFormatCode());
$objWriter->writeAttribute('sourceLinked', '1');   // ← take the format from the source data
$objWriter->endElement();
```

`sourceLinked="1"` means "the number format comes from the source data", so the `formatCode` sitting next to it is discarded by PowerPoint. The attribute *is* in the file, which is why the issue reads as "it still doesn't work" rather than "nothing is written".

**Why `'0'` is the right value.** The library already writes it correctly everywhere else — in the same file, all three data-label sites use `sourceLinked="0"`:

| line | what | `sourceLinked` |
|------|------|----------------|
| 877 | data labels (`getDlblNumFormat()`) | `0` |
| 1305 | data labels | `0` |
| 1445 | data labels | `0` |
| **2468** | **axis** (`getFormatCode()`) | **`1`** |

The axis is the only one out of line. It has been hardcoded to `'1'` since b957fb9df (2016-03-02, the Gridlines implementation) and was never revisited.

**The fix** is not an unconditional `'0'` — that would take the inherited format away from every deck that never called the setter. `Axis::DEFAULT_FORMAT_CODE` is `'general'`, so:

```php
$objWriter->writeAttribute('sourceLinked', Chart\Axis::DEFAULT_FORMAT_CODE === $oAxis->getFormatCode() ? '1' : '0');
```

- an axis nobody configured → byte-identical output to before;
- an axis with an explicit format code → the format code is finally honoured.

Fixes #632

**Possibly related, deliberately not claimed here.** #610 and #420 report chart *series* data not being formatted as numbers. They may share this cause, but I have not measured them.

The ODPresentation writer never reads `getFormatCode()` at all. ODF expresses a number format as a `<number:number-style>` element referenced through `style:data-style-name`, not as an attribute, and there is no such machinery in that writer today — that is separate work, not a matter of copying this line across. Hence the `Available only on the PowerPoint2007 Writer` note in the documentation, matching the existing one on *Crossing*.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
      `Axis::setFormatCode()` had no writer-side coverage at all — `AxisTest` only exercises the getter/setter, and `numFmt` appeared nowhere in the writer tests. `PptChartsTest::testAxisFormatCode` now covers both branches (default and explicit format code) and validates each against the ECMA-376 schema.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
      `setFormatCode` was not mentioned anywhere in `docs/`. Added a *Number format* section to `docs/usage/shapes/chart.md`, next to *Bounds* and *Crossing*.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)