### PR TITLE
Let a table say whether its first row is a header row

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -10,6 +10,7 @@
 - Added the ability to mark a shape as decorative, so that assistive technologies skip it, by [@dkulyk](http://github.com/dkulyk) in [#899](https://github.com/PHPOffice/PHPPresentation/pull/899)
 - Added an outline on the data points of a chart serie, next to the fill they already had, by [@dkulyk](http://github.com/dkulyk) in [#900](https://github.com/PHPOffice/PHPPresentation/pull/900)
 - `DocumentLayout::convertUnit()` is public and static, so a value that belongs to no layout can be converted too, by [@dkulyk](http://github.com/dkulyk) in [#921](https://github.com/PHPOffice/PHPPresentation/pull/921)
+- Added `Table::setFirstRow()` and `Table::setBandRow()`, so that a table can say whether its first row is a header row, by [@dkulyk](http://github.com/dkulyk) in [#904](https://github.com/PHPOffice/PHPPresentation/pull/904)
 
 ## Bug fixes
 - Fixed adding custom SVGs by [@seanlynchwv](http://github.com/seanlynchwv) in [#881](https://github.com/PHPOffice/PHPPresentation/pull/881)

--- a/docs/usage/shapes/table.md
+++ b/docs/usage/shapes/table.md
@@ -9,6 +9,26 @@ Example:
 $tableShape = $slide->createTableShape($columns);
 ```
 
+## Header row and banded rows
+
+!!! warning
+    Available only on the PowerPoint2007 Writer
+
+A table is written with its first row styled as a header row and with alternating row bands.
+Both can be turned off with `setFirstRow` and `setBandRow`.
+
+A header row is announced as a header by assistive technologies, so a table whose first row holds
+data rather than column labels — a single-column list, for instance — should turn it off, or its
+first entry is read out as the heading of the column.
+
+``` php
+<?php
+
+$tableShape = $slide->createTableShape($columns);
+$tableShape->setFirstRow(false);
+$tableShape->setBandRow(false);
+```
+
 ## Rows
 A row is a child of a table. For creating a row, use `createRow` method of a Table shape.
 

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1116,6 +1116,11 @@ class PowerPoint2007 implements ReaderInterface
             }
         }
 
+        $oElement = $document->getElement('a:graphic/a:graphicData/a:tbl/a:tblPr', $node);
+        // Both attributes default to false when the element or the attribute is absent
+        $oShape->setFirstRow($oElement instanceof DOMElement && in_array($oElement->getAttribute('firstRow'), ['1', 'true'], true));
+        $oShape->setBandRow($oElement instanceof DOMElement && in_array($oElement->getAttribute('bandRow'), ['1', 'true'], true));
+
         $arrayElements = $document->getElements('a:graphic/a:graphicData/a:tbl/a:tblGrid/a:gridCol', $node);
         $oShape->setNumColumns($arrayElements->length);
         $oShape->createRow();

--- a/src/PhpPresentation/Shape/Table.php
+++ b/src/PhpPresentation/Shape/Table.php
@@ -44,6 +44,20 @@ class Table extends AbstractGraphic implements ComparableInterface
     private $columnCount = 1;
 
     /**
+     * Is the first row of the table styled as a header row?
+     *
+     * @var bool
+     */
+    protected $firstRow = true;
+
+    /**
+     * Are the rows of the table styled with alternating bands?
+     *
+     * @var bool
+     */
+    protected $bandRow = true;
+
+    /**
      * Create a new \PhpOffice\PhpPresentation\Shape\Table instance.
      *
      * @param int $columns Number of columns
@@ -101,6 +115,39 @@ class Table extends AbstractGraphic implements ComparableInterface
         $this->rows[] = $row;
 
         return $row;
+    }
+
+    /**
+     * Is the first row of the table styled as a header row?
+     *
+     * A header row is announced as such by assistive technologies, so a table whose first row
+     * holds data rather than column labels should turn it off.
+     */
+    public function isFirstRow(): bool
+    {
+        return $this->firstRow;
+    }
+
+    public function setFirstRow(bool $value = true): self
+    {
+        $this->firstRow = $value;
+
+        return $this;
+    }
+
+    /**
+     * Are the rows of the table styled with alternating bands?
+     */
+    public function isBandRow(): bool
+    {
+        return $this->bandRow;
+    }
+
+    public function setBandRow(bool $value = true): self
+    {
+        $this->bandRow = $value;
+
+        return $this;
     }
 
     public function getNumColumns(): int

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -424,8 +424,8 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->startElement('a:tbl');
         // p:graphicFrame/a:graphic/a:graphicData/a:tbl/a:tblPr
         $objWriter->startElement('a:tblPr');
-        $objWriter->writeAttribute('firstRow', '1');
-        $objWriter->writeAttribute('bandRow', '1');
+        $objWriter->writeAttributeIf($shape->isFirstRow(), 'firstRow', '1');
+        $objWriter->writeAttributeIf($shape->isBandRow(), 'bandRow', '1');
         $objWriter->endElement();
         // p:graphicFrame/a:graphic/a:graphicData/a:tbl/a:tblGrid
         $objWriter->startElement('a:tblGrid');

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -34,6 +34,7 @@ use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
+use PhpOffice\PhpPresentation\Shape\Table;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
 use PhpOffice\PhpPresentation\Style\Color;
@@ -1463,5 +1464,26 @@ class PowerPoint2007Test extends TestCase
         // Without the slide number this comes back as the raw part name, `slide2.xml`
         self::assertTrue($oHyperlink->isInternal());
         self::assertEquals(2, $oHyperlink->getSlideNumber());
+    }
+
+    public function testTableFirstRowAndBandRow(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSlide = $oPhpPresentation->getActiveSlide();
+        $oSlide->createTableShape(1)->setFirstRow(false)->setBandRow(false)->createRow();
+        $oSlide->createTableShape(1)->createRow();
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = $oPhpPresentationRead->getSlide(0)->getShapeCollection();
+        self::assertInstanceOf(Table::class, $arrayShape[0]);
+        self::assertFalse($arrayShape[0]->isFirstRow());
+        self::assertFalse($arrayShape[0]->isBandRow());
+        self::assertInstanceOf(Table::class, $arrayShape[1]);
+        self::assertTrue($arrayShape[1]->isFirstRow());
+        self::assertTrue($arrayShape[1]->isBandRow());
     }
 }

--- a/tests/PhpPresentation/Tests/Shape/TableTest.php
+++ b/tests/PhpPresentation/Tests/Shape/TableTest.php
@@ -68,6 +68,28 @@ class TableTest extends TestCase
         $object->getRow(1);
     }
 
+    public function testFirstRow(): void
+    {
+        $object = new Table();
+
+        self::assertTrue($object->isFirstRow());
+        self::assertInstanceOf(Table::class, $object->setFirstRow(false));
+        self::assertFalse($object->isFirstRow());
+        self::assertInstanceOf(Table::class, $object->setFirstRow());
+        self::assertTrue($object->isFirstRow());
+    }
+
+    public function testBandRow(): void
+    {
+        $object = new Table();
+
+        self::assertTrue($object->isBandRow());
+        self::assertInstanceOf(Table::class, $object->setBandRow(false));
+        self::assertFalse($object->isBandRow());
+        self::assertInstanceOf(Table::class, $object->setBandRow());
+        self::assertTrue($object->isBandRow());
+    }
+
     public function testHashCode(): void
     {
         $object = new Table();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -1351,6 +1351,31 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testTableWithFirstRowAndBandRow(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oShape = $oSlide->createTableShape(4);
+        $oShape->setHeight(200)->setWidth(600)->setOffsetX(150)->setOffsetY(300);
+        $oShape->createRow()->getCell()->createTextRun('AAA');
+
+        $element = '/p:sld/p:cSld/p:spTree/p:graphicFrame/a:graphic/a:graphicData/a:tbl/a:tblPr';
+
+        // Both are on by default, as they have always been written
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'firstRow', '1');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'bandRow', '1');
+        $this->assertIsSchemaECMA376Valid();
+
+        // A table whose first row holds data, not column labels
+        $this->resetPresentationFile();
+        $oShape->setFirstRow(false)->setBandRow(false);
+
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertZipXmlAttributeNotExists('ppt/slides/slide1.xml', $element, 'firstRow');
+        $this->assertZipXmlAttributeNotExists('ppt/slides/slide1.xml', $element, 'bandRow');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testTableWithBorder(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();


### PR DESCRIPTION
### Description

`AbstractSlide::writeShapeTable()` stamps both table-property flags on every table it writes, unconditionally:

```php
// src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php:427
$objWriter->startElement('a:tblPr');
$objWriter->writeAttribute('firstRow', '1');
$objWriter->writeAttribute('bandRow', '1');
$objWriter->endElement();
```

A table has no say in it. For a grid with column labels that is a gift — the labels become a header row for free. For a single-column list it is wrong: the first item is announced as the heading of its column, and there is no way to turn it off short of not using a table at all.

`Table::setFirstRow()` and `Table::setBandRow()` expose both. They default to `true`, which is the behaviour the writer has always had, so a table nobody configures produces a byte-identical file.

```php
$tableShape = $slide->createTableShape($columns);
$tableShape->setFirstRow(false);   // the first row holds data, not column labels
$tableShape->setBandRow(false);
```

The reader picks the two attributes up as well (accepting `1` and `true`, matching the idiom already used at `Reader/PowerPoint2007.php:829`), so the choice survives a load/save round trip.

**One behaviour change worth naming.** A deck read from a file that carries no `a:tblPr` used to be written back with both flags on; it is now written back the way the source had it. That makes the round trip faithful, but it is a change, not just an addition.

**Deliberately out of scope.** `bandRow` stays PowerPoint2007-only — ODF expresses banding by styling each row, not as a property of the table. `firstRow` does have an ODF counterpart (`table:table-header-rows`, which the ODPresentation writer does not emit today); that is a change to the structure of every table it writes and belongs in its own PR rather than riding along here. The other four `CT_TableProperties` flags (`firstCol`, `lastRow`, `lastCol`, `bandCol`) are left alone — this PR only makes configurable what the writer already writes.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
      `TableTest::testFirstRow` and `TableTest::testBandRow` for the shape, `PptSlidesTest::testTableWithFirstRowAndBandRow` for the writer (both branches, each validated against the ECMA-376 schema), and `Reader\PowerPoint2007Test::testTableFirstRowAndBandRow` for a load/save round trip.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
      New *Header row and banded rows* section in `docs/usage/shapes/table.md`.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)