### PR TITLE
PowerPoint2007 Writer : Keep the borders a cell asked for

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -38,6 +38,7 @@
 - ODPresentation Reader : Fixed the alignment of a paragraph being dropped on load, and its direction being read as left to right whatever the file said, by [@dkulyk](http://github.com/dkulyk) in [#927](https://github.com/PHPOffice/PHPPresentation/pull/927)
 - PowerPoint2007 Writer : Fixed `Axis::setFormatCode()` having no effect, the number format of an axis being taken from the source data instead by [@dkulyk](http://github.com/dkulyk) in [#903](https://github.com/PHPOffice/PHPPresentation/pull/903)
 - Fixed the fill of a table row never reaching the file, in both Writers, by [@dkulyk](http://github.com/dkulyk) in [#911](https://github.com/PHPOffice/PHPPresentation/pull/911)
+- PowerPoint2007 Writer : Fixed a cell losing its own right and bottom borders whenever it had a neighbour on that side by [@dkulyk](http://github.com/dkulyk) in [#906](https://github.com/PHPOffice/PHPPresentation/pull/906)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/shapes/table.md
+++ b/docs/usage/shapes/table.md
@@ -124,6 +124,25 @@ $cellA1->getActiveParagraph()->getAlignment()
     ->setMarginTop(80);
 ```
 
+### Define the borders
+For defining the borders of a cell, you can use the `getBorders` method of a Cell object.
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Style\Border;
+
+$tableShape = $slide->createTableShape($columns);
+$row = $tableShape->createRow();
+$cellA1 = $row->nextCell();
+$cellA1->getBorders()->getBottom()->setLineStyle(Border::LINE_DOUBLE);
+```
+
+Two neighbouring cells share the edge between them, and PowerPoint draws that edge once. A cell
+therefore keeps its own right and bottom borders unless the neighbour on that side asked for the
+same edge itself — the cell to the right through its **left** border, the cell below through its
+**top** border. When it did, the neighbour's rule is the one that is drawn.
+
 ### Define the text direction
 For defining the text direction of cell, you can use the `setTextDirection` method of the `getAlignment` method of a Cell object.
 The width is in pixels.

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -528,17 +528,19 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
                 $borderBottom = $currentCell->getBorders()->getBottom();
                 $borderDiagonalDown = $currentCell->getBorders()->getDiagonalDown();
                 $borderDiagonalUp = $currentCell->getBorders()->getDiagonalUp();
-                // Fix PowerPoint implementation
+                // Two cells share the edge between them, and PowerPoint draws it once. The rule is
+                // taken from the neighbour when the neighbour is the one that asked for it -- so the
+                // side that is inspected has to be the side that is copied, the one facing this cell.
                 if ($hasNextCellRight) {
                     $nextCellRight = $shape->getRow($row)->getCell($cell + 1);
-                    if ($nextCellRight->getBorders()->getRight()->getHashCode() != $defaultBorder->getHashCode()) {
+                    if ($nextCellRight->getBorders()->getLeft()->getHashCode() != $defaultBorder->getHashCode()) {
                         $borderRight = $nextCellRight->getBorders()->getLeft();
                     }
                 }
                 if ($hasNextRowBelow) {
                     $nextRowBelow = $shape->getRow($row + 1);
                     $nextCellBelow = $nextRowBelow->getCell($cell);
-                    if ($nextCellBelow->getBorders()->getBottom()->getHashCode() != $defaultBorder->getHashCode()) {
+                    if ($nextCellBelow->getBorders()->getTop()->getHashCode() != $defaultBorder->getHashCode()) {
                         $borderBottom = $nextCellBelow->getBorders()->getTop();
                     }
                 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -1480,6 +1480,50 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testTableWithBorderOnEveryCell(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oShape = $oSlide->createTableShape(2);
+        $oShape->setHeight(200)->setWidth(600)->setOffsetX(150)->setOffsetY(300);
+        for ($row = 0; $row < 2; ++$row) {
+            $oRow = $oShape->createRow();
+            for ($cell = 0; $cell < 2; ++$cell) {
+                $oCell = $oRow->getCell($cell);
+                $oCell->createTextRun('AAA');
+                $oCell->getBorders()->getRight()->setLineStyle(Border::LINE_THICKTHIN);
+                $oCell->getBorders()->getBottom()->setLineStyle(Border::LINE_DOUBLE);
+            }
+        }
+
+        // The top left cell is the one with both a neighbour to its right and a row below it
+        $element = '/p:sld/p:cSld/p:spTree/p:graphicFrame/a:graphic/a:graphicData/a:tbl/a:tr[1]/a:tc[1]/a:tcPr';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element . '/a:lnR[@cmpd="' . Border::LINE_THICKTHIN . '"]');
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element . '/a:lnB[@cmpd="' . Border::LINE_DOUBLE . '"]');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    public function testTableWithBorderOwnedByTheNeighbour(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oShape = $oSlide->createTableShape(2);
+        $oShape->setHeight(200)->setWidth(600)->setOffsetX(150)->setOffsetY(300);
+
+        // Only the neighbours declare the edges they share with the top left cell
+        $oRow = $oShape->createRow();
+        $oRow->getCell(0)->createTextRun('AAA');
+        $oRow->getCell(1)->createTextRun('BBB');
+        $oRow->getCell(1)->getBorders()->getLeft()->setLineStyle(Border::LINE_TRI);
+        $oRow = $oShape->createRow();
+        $oRow->getCell(0)->createTextRun('CCC');
+        $oRow->getCell(0)->getBorders()->getTop()->setLineStyle(Border::LINE_THICKTHIN);
+        $oRow->getCell(1)->createTextRun('DDD');
+
+        $element = '/p:sld/p:cSld/p:spTree/p:graphicFrame/a:graphic/a:graphicData/a:tbl/a:tr[1]/a:tc[1]/a:tcPr';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element . '/a:lnR[@cmpd="' . Border::LINE_TRI . '"]');
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element . '/a:lnB[@cmpd="' . Border::LINE_THICKTHIN . '"]');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testTableWithCellMargin(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();


### PR DESCRIPTION
### Description

Fixes #808

`AbstractSlide::writeShapeTable()` hands the edge shared by two neighbouring cells to one of them, which is sound. But it inspects the **opposite side of the neighbour** from the one it then copies:

```php
// src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php:530
if ($hasNextCellRight) {
    $nextCellRight = $shape->getRow($row)->getCell($cell + 1);
    if ($nextCellRight->getBorders()->getRight()->getHashCode() != $defaultBorder->getHashCode()) {
        $borderRight = $nextCellRight->getBorders()->getLeft();   // guard tested RIGHT, copies LEFT
    }
}
if ($hasNextRowBelow) {
    $nextCellBelow = $shape->getRow($row + 1)->getCell($cell);
    if ($nextCellBelow->getBorders()->getBottom()->getHashCode() != $defaultBorder->getHashCode()) {
        $borderBottom = $nextCellBelow->getBorders()->getTop();   // guard tested BOTTOM, copies TOP
    }
}
```

So a cell loses the borders it owns as soon as it has a neighbour on that side, and the rule that replaces them is whatever the neighbour has on the facing side — usually the default. Left and top are never overridden, which is exactly the "left works, bottom does not" shape of the report.

### Measured

A two-column, three-row table where **every** cell sets its own right and bottom rule (`LINE_THICKTHIN` / `LINE_DOUBLE`):

| cell | `a:lnR` before | `a:lnB` before | after |
| --- | --- | --- | --- |
| r0c0 | `sng` | `sng` | `thickThin` / `dbl` |
| r0c1 | `thickThin` | `sng` | `thickThin` / `dbl` |
| r1c0 | `sng` | `sng` | `thickThin` / `dbl` |
| r1c1 | `thickThin` | `sng` | `thickThin` / `dbl` |
| r2c0 | `sng` | `dbl` | `thickThin` / `dbl` |
| r2c1 | `thickThin` | `dbl` | `thickThin` / `dbl` |

Eight of the twelve rules were dropped. Only the last column kept its right border and only the last row its bottom one — the two positions with no neighbour to be overridden by.

### The fix

Inspect the side that is copied, the one facing this cell. The neighbour still wins the shared edge, but only when the neighbour is the one that asked for it — verified separately: a right neighbour that sets only its **left** border, and a cell below that sets only its **top**, both land on the top left cell as before.

Worth noting for anyone who worked around this: the old code required setting *both* sides of the neighbour — its right (to trip the guard) and its left (to supply the value). Setting just the facing side now works, and setting the border on the cell that owns it works too.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
      The existing `testTableWithBorder` passes unchanged, which is the problem — its XPath `.../a:tr/a:tc/a:tcPr` matches any cell in any row, so default borders satisfied it. `PptSlidesTest::testTableWithBorderOnEveryCell` and `testTableWithBorderOwnedByTheNeighbour` anchor on `a:tr[1]/a:tc[1]`, the one cell that has both a neighbour to its right and a row below. Both fail on the current code and pass on the fix, and both are schema-validated.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
      `docs/usage/shapes/table.md` said nothing about borders at all. New *Define the borders* section, including the sharing rule — which is what tells a caller which cell to set.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)