### PR TITLE
ODPresentation Writer : Fixed a link to another slide

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -16,6 +16,7 @@
 - Fixed code coverage configuration for PHPUnit 10+ by [@slayerfx](http://github.com/slayerfx) in [#895](https://github.com/PHPOffice/PHPPresentation/pull/895)
 - Fixed static analysis on PHP 8.4 and 8.5 (PHPStan 1.x could not resolve the symbols of PHPUnit 13) by [@yasumorishima](http://github.com/yasumorishima) in [#897](https://github.com/PHPOffice/PHPPresentation/pull/897)
 - ODPresentation Writer : Fixed the charts losing their data points, their background, their data labels and the colour of their series, and drawing a hidden legend by [@dkulyk](http://github.com/dkulyk) in [#901](https://github.com/PHPOffice/PHPPresentation/pull/901)
+- Fixed a hyperlink to another slide being written by the ODPresentation Writer as a PowerPoint action string, and read back by neither reader, by [@dkulyk](http://github.com/dkulyk) in [#908](https://github.com/PHPOffice/PHPPresentation/pull/908)
 - PowerPoint2007 Writer : Fixed the name of a slide being lost on save, and read it back by [@dkulyk](http://github.com/dkulyk) in [#902](https://github.com/PHPOffice/PHPPresentation/pull/902)
 - ODPresentation Writer : Fixed the number of a slide and its date being written as dead text instead of the fields they are by [@dkulyk](http://github.com/dkulyk) in [#913](https://github.com/PHPOffice/PHPPresentation/pull/913)
 - A master slide is no longer born with a white background nobody asked for by [@dkulyk](http://github.com/dkulyk) in [#909](https://github.com/PHPOffice/PHPPresentation/pull/909)

--- a/docs/usage/shapes/richtext.md
+++ b/docs/usage/shapes/richtext.md
@@ -66,6 +66,27 @@ $richText->getHyperlink()->setUrl('https://phpoffice.github.io/PHPPresentation/'
 
 ```
 
+### Link to another slide
+
+A hyperlink can point at another slide of the same deck rather than at a URL.
+
+Example:
+
+```php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\RichText;
+
+$richText = new RichText();
+$richText->getHyperlink()->setSlideNumber(3);
+
+```
+
+Each format addresses the slide in its own way. The PowerPoint2007 Writer writes a relationship to
+the slide part; the ODPresentation Writer writes the name of the page, because that is how ODF
+addresses a slide. Every page therefore carries a `draw:name`, and a slide with no name of its own
+is named after its position, the way LibreOffice names the pages of a deck.
+
 ### Use of Text Color
 
 !!! warning

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -98,6 +98,13 @@ class ODPresentation implements ReaderInterface
     protected $arrayCommonStyles = [];
 
     /**
+     * The number of every named slide, so that a link can be resolved back to it.
+     *
+     * @var array<string, int>
+     */
+    protected $arraySlideNumbers = [];
+
+    /**
      * @var XMLReader
      */
     protected $oXMLReader;
@@ -262,6 +269,18 @@ class ODPresentation implements ReaderInterface
         foreach ($this->oXMLReader->getElements('/office:document-content/office:automatic-styles/*') as $oElement) {
             if ($oElement instanceof DOMElement && $oElement->hasAttribute('style:name')) {
                 $this->loadStyle($oElement);
+            }
+        }
+        // A link to another slide addresses it by name and can point forwards, so the names are
+        // collected before any slide is read
+        $this->arraySlideNumbers = [];
+        $slideNumber = 0;
+        foreach ($this->oXMLReader->getElements('/office:document-content/office:body/office:presentation/draw:page') as $oElement) {
+            if ($oElement instanceof DOMElement && 'draw:page' == $oElement->nodeName) {
+                ++$slideNumber;
+                if ($oElement->hasAttribute('draw:name')) {
+                    $this->arraySlideNumbers[$oElement->getAttribute('draw:name')] = $slideNumber;
+                }
             }
         }
         foreach ($this->oXMLReader->getElements('/office:document-content/office:body/office:presentation/draw:page') as $oElement) {
@@ -795,7 +814,12 @@ class ODPresentation implements ReaderInterface
             if ($oTextRunLink instanceof DOMElement) {
                 $oTextRun->setText($oTextRunLink->nodeValue);
                 if ($oTextRunLink->hasAttribute('xlink:href')) {
-                    $oTextRun->getHyperlink()->setUrl($oTextRunLink->getAttribute('xlink:href'));
+                    $href = $oTextRunLink->getAttribute('xlink:href');
+                    if (0 === strpos($href, '#') && isset($this->arraySlideNumbers[substr($href, 1)])) {
+                        $oTextRun->getHyperlink()->setSlideNumber($this->arraySlideNumbers[substr($href, 1)]);
+                    } else {
+                        $oTextRun->getHyperlink()->setUrl($href);
+                    }
                 }
             } else {
                 $oTextRun->setText($oNodeParent->nodeValue);

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1640,7 +1640,15 @@ class PowerPoint2007 implements ReaderInterface
             $hyperlink->setTooltip($element->getAttribute('tooltip'));
         }
         if ($element->hasAttribute('r:id') && isset($this->arrayRels[$this->fileRels][$element->getAttribute('r:id')]['Target'])) {
-            $hyperlink->setUrl($this->arrayRels[$this->fileRels][$element->getAttribute('r:id')]['Target']);
+            $target = $this->arrayRels[$this->fileRels][$element->getAttribute('r:id')]['Target'];
+            // A link to another slide is a relationship to its part, and the action says so. Without
+            // this the slide number is lost and only the raw part name, `slide2.xml`, comes back.
+            if ('ppaction://hlinksldjump' === $element->getAttribute('action')
+                && 1 === preg_match('/slide(\d+)\.xml$/', $target, $matches)) {
+                $hyperlink->setSlideNumber((int) $matches[1]);
+            } else {
+                $hyperlink->setUrl($target);
+            }
         }
         if ($subElementExt = $xmlReader->getElement('a:extLst/a:ext', $element)) {
             if ($subElementExt->hasAttribute('uri') && $subElementExt->getAttribute('uri') == '{A12FA001-AC4F-418D-AE19-62706E023703}') {

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -30,6 +30,7 @@ use PhpOffice\PhpPresentation\Shape\Chart;
 use PhpOffice\PhpPresentation\Shape\Comment;
 use PhpOffice\PhpPresentation\Shape\Drawing\AbstractDrawingAdapter;
 use PhpOffice\PhpPresentation\Shape\Group;
+use PhpOffice\PhpPresentation\Shape\Hyperlink;
 use PhpOffice\PhpPresentation\Shape\Line;
 use PhpOffice\PhpPresentation\Shape\Media;
 use PhpOffice\PhpPresentation\Shape\Placeholder;
@@ -347,10 +348,7 @@ class Content extends AbstractDecoratorWriter
         for ($i = 0; $i < $slideCount; ++$i) {
             $pSlide = $this->getPresentation()->getSlide($i);
             $objWriter->startElement('draw:page');
-            $name = $pSlide->getName();
-            if (null !== $name) {
-                $objWriter->writeAttribute('draw:name', $name);
-            }
+            $objWriter->writeAttribute('draw:name', $this->getSlideName($pSlide, $i + 1));
             $objWriter->writeAttribute('draw:master-page-name', 'Standard');
             $objWriter->writeAttribute('draw:style-name', 'stylePage' . $i);
             // Images
@@ -516,7 +514,7 @@ class Content extends AbstractDecoratorWriter
             $objWriter->startElement('presentation:event-listener');
             $objWriter->writeAttribute('script:event-name', 'dom:click');
             $objWriter->writeAttribute('presentation:action', 'show');
-            $objWriter->writeAttribute('xlink:href', $shape->getHyperlink()->getUrl());
+            $objWriter->writeAttribute('xlink:href', $this->getHyperlinkHref($shape->getHyperlink()));
             $objWriter->writeAttribute('xlink:type', 'simple');
             $objWriter->writeAttribute('xlink:show', 'embed');
             $objWriter->writeAttribute('xlink:actuate', 'onRequest');
@@ -599,7 +597,7 @@ class Content extends AbstractDecoratorWriter
                             // text:a
                             $objWriter->startElement('text:a');
                             $objWriter->writeAttribute('xlink:type', 'simple');
-                            $objWriter->writeAttribute('xlink:href', $richtext->getHyperlink()->getUrl());
+                            $objWriter->writeAttribute('xlink:href', $this->getHyperlinkHref($richtext->getHyperlink()));
                             $objWriter->text($richtext->getText());
                             $objWriter->endElement();
                         } elseif (null !== $fieldName) {
@@ -665,7 +663,7 @@ class Content extends AbstractDecoratorWriter
                             // text:a
                             $objWriter->startElement('text:a');
                             $objWriter->writeAttribute('xlink:type', 'simple');
-                            $objWriter->writeAttribute('xlink:href', $richtext->getHyperlink()->getUrl());
+                            $objWriter->writeAttribute('xlink:href', $this->getHyperlinkHref($richtext->getHyperlink()));
                             $objWriter->text($richtext->getText());
                             $objWriter->endElement();
                         } elseif (null !== $fieldName) {
@@ -772,6 +770,38 @@ class Content extends AbstractDecoratorWriter
     }
 
     /**
+     * The name ODF addresses a slide by, which every page carries so that a link can reach it.
+     *
+     * A slide with no name of its own is named after its position. Not as `page3`, though:
+     * LibreOffice generates exactly that form for the pages it exports and treats it as its own,
+     * so a link to `#page3` is left as an unresolved URI rather than followed.
+     */
+    protected function getSlideName(Slide $slide, int $slideNumber): string
+    {
+        return $slide->getName() ?? 'Slide ' . $slideNumber;
+    }
+
+    /**
+     * The target of a hyperlink, in the terms ODF addresses it.
+     *
+     * A link to another slide is stored as the PowerPoint action string `ppaction://hlinksldjump`,
+     * which ODF has never heard of -- there a slide is addressed by name.
+     */
+    protected function getHyperlinkHref(Hyperlink $hyperlink): string
+    {
+        if (!$hyperlink->isInternal()) {
+            return $hyperlink->getUrl();
+        }
+
+        $slideNumber = $hyperlink->getSlideNumber();
+        if ($slideNumber < 1 || $slideNumber > $this->getPresentation()->getSlideCount()) {
+            return $hyperlink->getUrl();
+        }
+
+        return '#' . $this->getSlideName($this->getPresentation()->getSlide($slideNumber - 1), $slideNumber);
+    }
+
+    /**
      * Write table Shape.
      */
     protected function writeShapeTable(XMLWriter $objWriter, Table $shape): void
@@ -828,7 +858,7 @@ class Content extends AbstractDecoratorWriter
                                         // text:a
                                         $objWriter->startElement('text:a');
                                         $objWriter->writeAttribute('xlink:type', 'simple');
-                                        $objWriter->writeAttribute('xlink:href', $shapeRichText->getHyperlink()->getUrl());
+                                        $objWriter->writeAttribute('xlink:href', $this->getHyperlinkHref($shapeRichText->getHyperlink()));
                                         $objWriter->text($shapeRichText->getText());
                                         $objWriter->endElement();
                                     } else {

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -28,6 +28,7 @@ use PhpOffice\PhpPresentation\Reader\ODPresentation;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
+use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
 use PhpOffice\PhpPresentation\Style\Font;
@@ -1200,5 +1201,50 @@ class ODPresentationTest extends TestCase
         self::assertEquals('Budget spent to date: 45% of 1.2M EUR', $arrayShape[0]->getDescription());
         self::assertEquals('The logo of the company', $arrayShape[1]->getDescription());
         self::assertEquals('Legacy', $arrayShape[2]->getDescription());
+    }
+
+    public function testHyperlinkToSlide(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oRun = $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+        $oRun->getHyperlink()->setSlideNumber(3);
+        $oPhpPresentation->createSlide();
+        $oPhpPresentation->createSlide()->setName('Milestone Overview');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        $arrayRichText = $arrayShape[0]->getParagraph()->getRichTextElements();
+        self::assertInstanceOf(TextElement::class, $arrayRichText[0]);
+        $oHyperlink = $arrayRichText[0]->getHyperlink();
+
+        // Without the lookup this comes back as the literal `#Milestone Overview`
+        self::assertTrue($oHyperlink->isInternal());
+        self::assertEquals(3, $oHyperlink->getSlideNumber());
+    }
+
+    public function testHyperlinkToUrl(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oRun = $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+        $oRun->getHyperlink()->setUrl('https://github.com/PHPOffice/PHPPresentation/');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        $arrayRichText = $arrayShape[0]->getParagraph()->getRichTextElements();
+        self::assertInstanceOf(TextElement::class, $arrayRichText[0]);
+        $oHyperlink = $arrayRichText[0]->getHyperlink();
+
+        self::assertFalse($oHyperlink->isInternal());
+        self::assertEquals('https://github.com/PHPOffice/PHPPresentation/', $oHyperlink->getUrl());
     }
 }

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -32,6 +32,7 @@ use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
+use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
 use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
 use PhpOffice\PhpPresentation\Style\Color;
@@ -1229,5 +1230,28 @@ class PowerPoint2007Test extends TestCase
 
         self::assertEquals('Introduction', $oPhpPresentationRead->getSlide(0)->getName());
         self::assertNull($oPhpPresentationRead->getSlide(1)->getName());
+    }
+
+    public function testHyperlinkToSlide(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oRun = $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+        $oRun->getHyperlink()->setSlideNumber(2);
+        $oPhpPresentation->createSlide();
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = $oPhpPresentationRead->getSlide(0)->getShapeCollection();
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        $arrayRichText = $arrayShape[0]->getParagraph()->getRichTextElements();
+        self::assertInstanceOf(TextElement::class, $arrayRichText[0]);
+        $oHyperlink = $arrayRichText[0]->getHyperlink();
+
+        // Without the slide number this comes back as the raw part name, `slide2.xml`
+        self::assertTrue($oHyperlink->isInternal());
+        self::assertEquals(2, $oHyperlink->getSlideNumber());
     }
 }

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -711,8 +711,10 @@ class ContentTest extends PhpPresentationTestCase
     {
         $element = '/office:document-content/office:body/office:presentation/draw:page';
 
+        // Every page is named, so that a link can address it; a slide with no name of its own is
+        // named after its position
         $this->assertZipXmlElementExists('content.xml', $element);
-        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'draw:name');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'draw:name', 'Slide 1');
         $this->assertIsSchemaOpenDocumentValid('1.2');
 
         $this->oPresentation->getActiveSlide()->setName('AAAA');
@@ -727,7 +729,38 @@ class ContentTest extends PhpPresentationTestCase
         $this->resetPresentationFile();
 
         $this->assertZipXmlElementExists('content.xml', $element);
-        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'draw:name');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'draw:name', 'Slide 1');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testSlideLink(): void
+    {
+        $oRun = $this->oPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+        $oRun->getHyperlink()->setSlideNumber(3);
+        $this->oPresentation->createSlide();
+        $this->oPresentation->createSlide()->setName('Milestone Overview');
+
+        $element = '/office:document-content/office:body/office:presentation/draw:page/draw:frame/draw:text-box/text:p/text:span/text:a';
+        $this->assertZipXmlElementExists('content.xml', $element);
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'xlink:href', '#Milestone Overview');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        // A slide with no name of its own is addressed by the name its page carries
+        $this->oPresentation->getSlide(2)->setName();
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'xlink:href', '#Slide 3');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testSlideLinkOutOfRange(): void
+    {
+        $oRun = $this->oPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+        $oRun->getHyperlink()->setSlideNumber(9);
+
+        // Nothing to address, so the action string is left as it was rather than pointing nowhere
+        $element = '/office:document-content/office:body/office:presentation/draw:page/draw:frame/draw:text-box/text:p/text:span/text:a';
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'xlink:href', 'ppaction://hlinksldjump');
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 


### PR DESCRIPTION
### Description

A hyperlink created with `setSlideNumber()` stores the PowerPoint action string `ppaction://hlinksldjump`, and the ODPresentation Writer wrote it verbatim into `xlink:href`. ODF has never heard of that string, so the link opened nothing -- converted to PDF it comes out as `/A<</Type/Action/S/URI/URI(ppaction://hlinksldjump)>>`, an unresolvable URI rather than a jump.

ODF addresses a slide by the name of its page, so the Writer now writes `#<page name>`, and every `draw:page` carries a `draw:name` so that a link can reach it. A slide with no name of its own is named after its position, as `Slide N`. Not as `pageN`: LibreOffice generates exactly that form for the pages it exports and treats it as its own, so a link to `#page3` is left unresolved -- I probed the three forms and only the non-`pageN` ones produce a real destination. With the fix both `#Milestone Overview` and `#Slide 3` come out as `/Dest[9 0 R/FitR 0 0 720 541.417]`.

If the slide number points outside the deck there is nothing to address, so the value is left as it was rather than pointing nowhere.

Neither Reader recognised such a link either, so the number never survived a round trip and the fixed Writer alone could not carry a link across a format conversion. The PowerPoint2007 Reader stored the raw part name, `slide2.xml`, as the URL; the ODPresentation Reader stored the raw `#Name`. Both now resolve the target back to its number -- the PowerPoint2007 Reader from the `slide` relationship plus the `action` attribute, the ODPresentation Reader from a pre-pass over the page names, collected before any slide is read because a link can point forwards.

One existing expectation changed as a consequence: `ContentTest::testSlideName` asserted that an unnamed slide gets no `draw:name`, and now every page has one. A save/load round trip therefore gives a previously unnamed slide the name `Slide N` -- the same thing that already happens with any ODP produced by LibreOffice.

### Checklist:

- [x] My CI is :green_circle:
  > Every job is green, including PHPUnit on 7.4 and 8.0.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `ContentTest::testSlideLink` covers both the named and the position-named target, `testSlideLinkOutOfRange` the untouched fallback, and `PowerPoint2007Test::testHyperlinkToSlide` / `ODPresentationTest::testHyperlinkToSlide` the round trip through each Reader, with `ODPresentationTest::testHyperlinkToUrl` guarding the external-URL path. I checked each one fails without the change.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > `docs/usage/shapes/richtext.md` gained a "Link to another slide" section explaining `setSlideNumber()` and how each format addresses the target.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
  > Added an entry under 1.3.0.
