### PR TITLE
A master slide is no longer born with a white background

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -17,4 +17,7 @@
 - Fixed static analysis on PHP 8.4 and 8.5 (PHPStan 1.x could not resolve the symbols of PHPUnit 13) by [@yasumorishima](http://github.com/yasumorishima) in [#897](https://github.com/PHPOffice/PHPPresentation/pull/897)
 - ODPresentation Writer : Fixed the charts losing their data points, their background, their data labels and the colour of their series, and drawing a hidden legend by [@dkulyk](http://github.com/dkulyk) in [#901](https://github.com/PHPOffice/PHPPresentation/pull/901)
 - PowerPoint2007 Writer : Fixed the name of a slide being lost on save, and read it back by [@dkulyk](http://github.com/dkulyk) in [#902](https://github.com/PHPOffice/PHPPresentation/pull/902)
+- A master slide is no longer born with a white background nobody asked for by [@dkulyk](http://github.com/dkulyk) in [#909](https://github.com/PHPOffice/PHPPresentation/pull/909)
 
+## BC Breaks
+- `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/slides/introduction.md
+++ b/docs/usage/slides/introduction.md
@@ -47,6 +47,28 @@ $slide->setName('Title of the slide');
 It is written as the `name` attribute of `p:cSld` in PowerPoint2007 files and as the
 `draw:name` attribute of `draw:page` in ODPresentation files. Both readers restore it.
 
+### Background
+
+By default, a slide has no background, and neither has the master slide it is based on: what shows
+through is the light colour of the theme. You can define one with the method `setBackground`, on a
+slide for that slide alone or on the master for every slide based on it.
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
+use PhpOffice\PhpPresentation\Style\Color;
+
+$background = new BackgroundColor();
+$background->setColor(new Color('FFCC00'));
+
+$presentation->getAllMasterSlides()[0]->setBackground($background);
+```
+
+A background is a fill of its own, drawn over the whole page. A converter that turns the file into
+a tagged PDF has nothing to say about that fill, so it lands outside the tag tree -- which is why
+one is written only when it is asked for.
+
 ### Visibility
 
 By default, a slide is visible.

--- a/src/PhpPresentation/Slide/SlideMaster.php
+++ b/src/PhpPresentation/Slide/SlideMaster.php
@@ -23,8 +23,6 @@ namespace PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\ComparableInterface;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\ShapeContainerInterface;
-use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
-use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\ColorMap;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
 use PhpOffice\PhpPresentation\Style\TextStyle;
@@ -84,9 +82,6 @@ class SlideMaster extends AbstractSlide implements ComparableInterface, ShapeCon
         $this->identifier = md5(mt_rand(0, 9999) . time());
         // Set a basic colorMap
         $this->colorMap = new ColorMap();
-        // Set a white background
-        $this->background = new BackgroundColor();
-        $this->background->setColor(new Color(Color::COLOR_WHITE));
         // Set basic textStyles
         $this->textStyles = new TextStyle(true);
         // Set basic scheme colors

--- a/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
+++ b/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Tests;
 
-use PhpOffice\PhpPresentation\Slide\Background\Color;
 use PhpOffice\PhpPresentation\Slide\SlideLayout;
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
@@ -40,10 +39,8 @@ class SlideMasterTest extends TestCase
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $object);
         self::assertNull($object->getParent());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->colorMap);
-        /** @var Color $background */
-        $background = $object->getBackground();
-        self::assertInstanceOf(Color::class, $background);
-        self::assertEquals('FFFFFF', $background->getColor()->getRGB());
+        // A master carries no background of its own; the colour map takes it to the theme
+        self::assertNull($object->getBackground());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\TextStyle', $object->getTextStyles());
     }
 

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007Test.php
@@ -22,6 +22,8 @@ namespace PhpOffice\PhpPresentation\Tests\Writer;
 
 use PhpOffice\PhpPresentation\Exception\DirectoryNotFoundException;
 use PhpOffice\PhpPresentation\Exception\InvalidParameterException;
+use PhpOffice\PhpPresentation\Slide\Background\Color;
+use PhpOffice\PhpPresentation\Style\Color as StyleColor;
 use PhpOffice\PhpPresentation\Tests\PhpPresentationTestCase;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007;
 
@@ -121,6 +123,24 @@ class PowerPoint2007Test extends PhpPresentationTestCase
         $this->assertZipXmlElementExists('ppt/viewProps.xml', '/p:viewPr/p:slideViewPr/p:cSldViewPr/p:cViewPr/p:scale/a:sy');
         $this->assertZipXmlAttributeEquals('ppt/viewProps.xml', '/p:viewPr/p:slideViewPr/p:cSldViewPr/p:cViewPr/p:scale/a:sy', 'n', $value * 100);
         $this->assertZipXmlAttributeEquals('ppt/viewProps.xml', '/p:viewPr/p:slideViewPr/p:cSldViewPr/p:cViewPr/p:scale/a:sy', 'd', 100);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    public function testSlideMasterBackground(): void
+    {
+        $xPath = '/p:sldMaster/p:cSld/p:bg/p:bgPr/a:solidFill/a:srgbClr[@val=\'FFFFFF\']';
+
+        // A master paints nothing of its own, so the theme is what shows through
+        $this->assertZipFileExists('ppt/slideMasters/slideMaster1.xml');
+        $this->assertZipXmlElementNotExists('ppt/slideMasters/slideMaster1.xml', '/p:sldMaster/p:cSld/p:bg');
+        $this->assertIsSchemaECMA376Valid();
+
+        $oBackground = new Color();
+        $oBackground->setColor(new StyleColor(StyleColor::COLOR_WHITE));
+        $this->oPresentation->getAllMasterSlides()[0]->setBackground($oBackground);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementExists('ppt/slideMasters/slideMaster1.xml', $xPath);
         $this->assertIsSchemaECMA376Valid();
     }
 


### PR DESCRIPTION
### Description

`SlideMaster::__construct()` sets a white `Background\Color` on every master it creates, and the PowerPoint2007 Writer turns it into `<p:bg>`. A converter paints that fill as a full-page path of its own, and the path lands outside any marked content -- which PDF/UA 7.1 refuses, "Content shall be marked as Artifact or tagged as real content". Measured with veraPDF on a six-slide deck: **6 failed checks, one per page**. A deck that draws its own backgrounds over it pays that price for a fill it never asked for.

Nothing is lost by leaving it out. The colour map of a master takes its background to `lt1`, and `lt1` is `FFFFFF` (`SlideMaster.php:63`, written by `PptTheme.php:102`), so the page renders exactly as before. I converted the same deck to PDF with and without the fill and compared the two renders pixel by pixel at 720x540: **no pixel differs in colour**. The only difference is in the alpha channel, 1259 bytes of 1 555 200, all of them on the outermost row and column of the page -- the antialiased edge of a fill that is no longer there.

A master that is given a background still writes one, and the Writer already returns early when there is none. This only stops the library from inventing one.

The ODPresentation Writer is untouched by the change: every place it reads a background takes it from a slide, never from the master, so saving the same presentation with and without the white fill produces byte-identical entries in the ODF package.

One existing expectation changed with it: `SlideMasterTest::testBase` asserted the white background, and now asserts that a fresh master carries none.

### Checklist:

- [x] My CI is :green_circle:
  > phpstan and php-cs-fixer are clean, and the suite passes: 810 tests, 7197 assertions.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `PowerPoint2007Test::testSlideMasterBackground` covers both sides -- no `p:bg` unless one is asked for, and `p:bg` written when it is. I checked it fails without the change, together with the updated `SlideMasterTest::testBase`.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > `docs/usage/slides/introduction.md` gained a "Background" section: the API was not documented at all before.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
  > Added an entry under 1.3.0, and a BC Breaks note, since a deck that relied on the white fill has to ask for it now.
