### PR TITLE
Style\Color : A six-digit colour is no longer given an alpha it never asked for

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -31,6 +31,7 @@
 - PowerPoint2007 Reader : Fixed the minor tick mark of an axis being read into its major tick mark, and the outline of the value axis not being read at all, by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
 - Fixed the media part of an image whose path carries no extension being named with a trailing dot, and written under no content type, by [@dkulyk](http://github.com/dkulyk) in [#922](https://github.com/PHPOffice/PHPPresentation/pull/922)
 - PowerPoint2007 Reader : Fixed a text run written without `a:rPr` being dropped, which loses part of the text of a Keynote export, by [@Wilkolicious](http://github.com/Wilkolicious) in [#871](https://github.com/PHPOffice/PHPPresentation/pull/871) and [@dkulyk](http://github.com/dkulyk) in [#914](https://github.com/PHPOffice/PHPPresentation/pull/914)
+- `Style\Color` : Fixed a colour written as a plain RGB being given an alpha it never asked for by [@dkulyk](http://github.com/dkulyk) in [#910](https://github.com/PHPOffice/PHPPresentation/pull/910)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/styles.md
+++ b/docs/usage/styles.md
@@ -192,3 +192,15 @@ Colors can be applied to different objects, e.g. font or border.
 $textRun = $shape->createTextRun('Text');
 $textRun->getFont()->setColor(new Color('C00000'));
 ```
+
+A colour is written either as six characters, `RRGGBB`, or as eight, `AARRGGBB`, where the two in
+front are the alpha. Six characters are opaque; the constants of the class, `Color::COLOR_BLACK`
+and the rest, are the eight-character form with `FF` in front. The alpha can also be set on its own,
+in percent:
+
+``` php
+<?php
+
+$color = new Color('C00000');
+$color->setAlpha(50);
+```

--- a/src/PhpPresentation/Style/Color.php
+++ b/src/PhpPresentation/Style/Color.php
@@ -94,11 +94,14 @@ class Color implements ComparableInterface
     /**
      * Get the alpha % of the ARGB
      * Will return 100 if no ARGB.
+     *
+     * Six characters are an RGB, and an RGB is opaque: only the eight-character form carries an
+     * alpha, in the two characters in front of the colour.
      */
     public function getAlpha(): int
     {
         $alpha = 100;
-        if (strlen($this->argb) >= 6) {
+        if (strlen($this->argb) >= 8) {
             $dec = hexdec(substr($this->argb, 0, 2));
             $alpha = (int) number_format(($dec / 255) * 100, 0);
         }
@@ -122,7 +125,8 @@ class Color implements ComparableInterface
         $alpha = round(($alpha / 100) * 255);
         $alpha = dechex((int) $alpha);
         $alpha = str_pad($alpha, 2, '0', STR_PAD_LEFT);
-        $this->argb = $alpha . substr($this->argb, 2);
+        // The colour keeps its six characters whether it arrived with an alpha in front of it or not
+        $this->argb = $alpha . $this->getRGB();
 
         return $this;
     }

--- a/tests/PhpPresentation/Tests/Style/ColorTest.php
+++ b/tests/PhpPresentation/Tests/Style/ColorTest.php
@@ -59,6 +59,22 @@ class ColorTest extends TestCase
     }
 
     /**
+     * Test Alpha of a colour written as a plain RGB.
+     */
+    public function testAlphaOfAnRGB(): void
+    {
+        $object = new Color('D0D0D0');
+        self::assertEquals(100, $object->getAlpha());
+        self::assertEquals('D0D0D0', $object->getRGB());
+
+        // The alpha goes in front of the colour, and does not eat the first two characters of it
+        $object->setAlpha(50);
+        self::assertEquals('80D0D0D0', $object->getARGB());
+        self::assertEquals('D0D0D0', $object->getRGB());
+        self::assertEquals(50, $object->getAlpha());
+    }
+
+    /**
      * Test get/set ARGB.
      */
     public function testSetGetARGB(): void

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -1037,6 +1037,28 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testRichTextRunFontColorRGB(): void
+    {
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:solidFill/a:srgbClr';
+
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oRun = $oSlide->createRichTextShape()->createTextRun('MyText');
+        $oRun->getFont()->setColor(new Color('D0D0D0'));
+
+        // A six-character colour is an RGB, so it is opaque: the two characters in front of an
+        // eight-character one are the alpha, and a plain RGB has none to read
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'val', 'D0D0D0');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element . '/a:alpha', 'val', 100000);
+        $this->assertIsSchemaECMA376Valid();
+
+        $oRun->getFont()->setColor(new Color('80D0D0D0'));
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'val', 'D0D0D0');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element . '/a:alpha', 'val', 50000);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testRichTextRunFontFormat(): void
     {
         $latinElement = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:latin';


### PR DESCRIPTION
### Description

`Color::getAlpha()` reads the first two characters of the value as the alpha whenever the string is six characters or more. The plain RGB form the class documents therefore comes back translucent: `D0D0D0` is `hexdec('D0') / 255` = **82% opaque**, `71C569` is 44%, and `C00000` -- the colour in the library's own documentation, `docs/usage/styles.md` -- is 75%.

`AbstractDecoratorWriter::writeColor()` writes that number into `<a:alpha>` for every font, bullet, border and solid or gradient fill, so it reaches the file. Measured on a deck with a `D0D0D0` font colour and a `71C569` cell fill:

```xml
<a:srgbClr val="D0D0D0"><a:alpha val="82000"/></a:srgbClr>
<a:srgbClr val="71C569"><a:alpha val="44000"/></a:srgbClr>
```

The cost is not only the wrong colour. Anything translucent is drawn by LibreOffice inside a transparency group, and the marked content opened inside that group is never closed -- `/P<</MCID 2>>BDC … Q` with no `EMC`, which is the "BMC and/or BDC operators not terminated by a balanced EMC" that PAC reports and PDF/UA 7.1 refuses. On one six-slide report that was **27 failed checks** from six-digit colours alone, and 37 form XObjects that disappear once the colours are opaque, with not one painted colour changing.

Six characters are an RGB, and an RGB is opaque: only the eight-character form carries an alpha, in the two characters in front of the colour. `getRGB()` already tells the two forms apart, so `getAlpha()` was the one place that read them differently.

`setAlpha()` had the same blind spot from the other side -- it wrote the alpha over `substr($this->argb, 2)`, so `new Color('D0D0D0')` given an alpha of 50 became the colour `80D0D0`, and `getRGB()` returned that. It now keeps the six characters whole, whether they arrived with an alpha in front of them or not.

The eight-character form is untouched: `80D0D0D0` still reads as 50%, and every existing test passed before I added one, since they all use eight-character values.

### Checklist:

- [x] My CI is :green_circle:
  > phpstan and php-cs-fixer are clean, and the suite passes: 811 tests, 7208 assertions.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `ColorTest::testAlphaOfAnRGB` covers both directions on the model, and `PptSlidesTest::testRichTextRunFontColorRGB` covers what reaches the file, in both forms. I checked each fails without the change.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > `docs/usage/styles.md` now says which form is which, and that six characters are opaque.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
  > Added an entry under 1.3.0.
