### PR TITLE
ODPresentation Writer : Keep the background of a master slide

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -19,6 +19,7 @@
 - PowerPoint2007 Writer : Fixed the name of a slide being lost on save, and read it back by [@dkulyk](http://github.com/dkulyk) in [#902](https://github.com/PHPOffice/PHPPresentation/pull/902)
 - ODPresentation Writer : Fixed the number of a slide and its date being written as dead text instead of the fields they are by [@dkulyk](http://github.com/dkulyk) in [#913](https://github.com/PHPOffice/PHPPresentation/pull/913)
 - A master slide is no longer born with a white background nobody asked for by [@dkulyk](http://github.com/dkulyk) in [#909](https://github.com/PHPOffice/PHPPresentation/pull/909)
+- ODPresentation Writer : Fixed the background of a master slide being dropped on save by [@dkulyk](http://github.com/dkulyk) in [#912](https://github.com/PHPOffice/PHPPresentation/pull/912)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -18,4 +18,7 @@
 - ODPresentation Writer : Fixed the charts losing their data points, their background, their data labels and the colour of their series, and drawing a hidden legend by [@dkulyk](http://github.com/dkulyk) in [#901](https://github.com/PHPOffice/PHPPresentation/pull/901)
 - PowerPoint2007 Writer : Fixed the name of a slide being lost on save, and read it back by [@dkulyk](http://github.com/dkulyk) in [#902](https://github.com/PHPOffice/PHPPresentation/pull/902)
 - ODPresentation Writer : Fixed the number of a slide and its date being written as dead text instead of the fields they are by [@dkulyk](http://github.com/dkulyk) in [#913](https://github.com/PHPOffice/PHPPresentation/pull/913)
+- A master slide is no longer born with a white background nobody asked for by [@dkulyk](http://github.com/dkulyk) in [#909](https://github.com/PHPOffice/PHPPresentation/pull/909)
 
+## BC Breaks
+- `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/slides/introduction.md
+++ b/docs/usage/slides/introduction.md
@@ -47,6 +47,28 @@ $slide->setName('Title of the slide');
 It is written as the `name` attribute of `p:cSld` in PowerPoint2007 files and as the
 `draw:name` attribute of `draw:page` in ODPresentation files. Both readers restore it.
 
+### Background
+
+By default, a slide has no background, and neither has the master slide it is based on: what shows
+through is the light colour of the theme. You can define one with the method `setBackground`, on a
+slide for that slide alone or on the master for every slide based on it.
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
+use PhpOffice\PhpPresentation\Style\Color;
+
+$background = new BackgroundColor();
+$background->setColor(new Color('FFCC00'));
+
+$presentation->getAllMasterSlides()[0]->setBackground($background);
+```
+
+A background is a fill of its own, drawn over the whole page. A converter that turns the file into
+a tagged PDF has nothing to say about that fill, so it lands outside the tag tree -- which is why
+one is written only when it is asked for.
+
 ### Visibility
 
 By default, a slide is visible.

--- a/docs/usage/slides/introduction.md
+++ b/docs/usage/slides/introduction.md
@@ -69,6 +69,10 @@ A background is a fill of its own, drawn over the whole page. A converter that t
 a tagged PDF has nothing to say about that fill, so it lands outside the tag tree -- which is why
 one is written only when it is asked for.
 
+Both Writers keep the background of a master: the PowerPoint2007 Writer as the `p:bg` of the master
+slide, the ODPresentation Writer as the drawing-page style of the master page. A colour and an
+image are both carried.
+
 ### Visibility
 
 By default, a slide is visible.

--- a/src/PhpPresentation/Slide/SlideMaster.php
+++ b/src/PhpPresentation/Slide/SlideMaster.php
@@ -23,8 +23,6 @@ namespace PhpOffice\PhpPresentation\Slide;
 use PhpOffice\PhpPresentation\ComparableInterface;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\ShapeContainerInterface;
-use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
-use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\ColorMap;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
 use PhpOffice\PhpPresentation\Style\TextStyle;
@@ -84,9 +82,6 @@ class SlideMaster extends AbstractSlide implements ComparableInterface, ShapeCon
         $this->identifier = md5(mt_rand(0, 9999) . time());
         // Set a basic colorMap
         $this->colorMap = new ColorMap();
-        // Set a white background
-        $this->background = new BackgroundColor();
-        $this->background->setColor(new Color(Color::COLOR_WHITE));
         // Set basic textStyles
         $this->textStyles = new TextStyle(true);
         // Set basic scheme colors

--- a/src/PhpPresentation/Writer/ODPresentation/AbstractDecoratorWriter.php
+++ b/src/PhpPresentation/Writer/ODPresentation/AbstractDecoratorWriter.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpPresentation\Writer\ODPresentation;
 
 use PhpOffice\PhpPresentation\Shape\Chart;
+use PhpOffice\PhpPresentation\Slide\AbstractBackground;
 
 abstract class AbstractDecoratorWriter extends \PhpOffice\PhpPresentation\Writer\AbstractDecoratorWriter
 {
@@ -28,6 +29,20 @@ abstract class AbstractDecoratorWriter extends \PhpOffice\PhpPresentation\Writer
      * @var Chart[]
      */
     protected $arrayChart;
+
+    /**
+     * The background of the master page, which every slide is drawn on top of.
+     *
+     * The Writer has one master page, `Standard`, so the first master slide is the one that owns it.
+     */
+    protected function getMasterBackground(): ?AbstractBackground
+    {
+        foreach ($this->getPresentation()->getAllMasterSlides() as $oMasterSlide) {
+            return $oMasterSlide->getBackground();
+        }
+
+        return null;
+    }
 
     /**
      * @return Chart[]

--- a/src/PhpPresentation/Writer/ODPresentation/MetaInfManifest.php
+++ b/src/PhpPresentation/Writer/ODPresentation/MetaInfManifest.php
@@ -100,6 +100,18 @@ class MetaInfManifest extends AbstractDecoratorWriter
             }
         }
 
+        // Background image of the master page
+        $oBkgImage = $this->getMasterBackground();
+        if ($oBkgImage instanceof Image) {
+            $arrayImage = getimagesize($oBkgImage->getPath());
+            $mimeType = image_type_to_mime_type($arrayImage[2]);
+
+            $objWriter->startElement('manifest:file-entry');
+            $objWriter->writeAttribute('manifest:media-type', $mimeType);
+            $objWriter->writeAttribute('manifest:full-path', 'Pictures/' . str_replace(' ', '_', $oBkgImage->getIndexedFilename(Styles::MASTER_PAGE_STYLE)));
+            $objWriter->endElement();
+        }
+
         if ($this->getPresentation()->getPresentationProperties()->getThumbnailPath()) {
             $pathThumbnail = $this->getPresentation()->getPresentationProperties()->getThumbnailPath();
             // Size : 128x128 pixel

--- a/src/PhpPresentation/Writer/ODPresentation/Pictures.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Pictures.php
@@ -46,6 +46,12 @@ class Pictures extends AbstractDecoratorWriter
             }
         }
 
+        // Add background image of the master page
+        $oBkgImage = $this->getMasterBackground();
+        if ($oBkgImage instanceof Image) {
+            $this->getZip()->addFromString('Pictures/' . $oBkgImage->getIndexedFilename(Styles::MASTER_PAGE_STYLE), file_get_contents($oBkgImage->getPath()));
+        }
+
         return $this->getZip();
     }
 }

--- a/src/PhpPresentation/Writer/ODPresentation/Styles.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Styles.php
@@ -27,12 +27,18 @@ use PhpOffice\Common\XMLWriter;
 use PhpOffice\PhpPresentation\Shape\Group;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\Table;
+use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
 use PhpOffice\PhpPresentation\Slide\Background\Image;
 use PhpOffice\PhpPresentation\Style\Border;
 use PhpOffice\PhpPresentation\Style\Fill;
 
 class Styles extends AbstractDecoratorWriter
 {
+    /**
+     * The name of the style the master page is drawn with.
+     */
+    public const MASTER_PAGE_STYLE = 'sPres0';
+
     /**
      * Stores font styles draw:gradient nodes.
      *
@@ -108,18 +114,11 @@ class Styles extends AbstractDecoratorWriter
 
         // office:styles
         $objWriter->startElement('office:styles');
-        // style:style
-        $objWriter->startElement('style:style');
-        $objWriter->writeAttribute('style:name', 'sPres0');
-        $objWriter->writeAttribute('style:display-name', 'sPres0');
-        $objWriter->writeAttribute('style:family', 'presentation');
-        // style:graphic-properties
-        $objWriter->startElement('style:graphic-properties');
-        $objWriter->writeAttribute('draw:fill-color', '#ffffff');
-        // > style:graphic-properties
-        $objWriter->endElement();
-        // > style:style
-        $objWriter->endElement();
+        // The image a master page is filled with, which the style below names
+        $oMasterBackground = $this->getMasterBackground();
+        if ($oMasterBackground instanceof Image) {
+            $this->writeBackgroundStyle($objWriter, $oMasterBackground, self::MASTER_PAGE_STYLE);
+        }
 
         foreach ($this->getPresentation()->getAllSlides() as $keySlide => $oSlide) {
             foreach ($oSlide->getShapeCollection() as $shape) {
@@ -133,7 +132,7 @@ class Styles extends AbstractDecoratorWriter
             }
             $oBkgImage = $oSlide->getBackground();
             if ($oBkgImage instanceof Image) {
-                $this->writeBackgroundStyle($objWriter, $oBkgImage, $keySlide);
+                $this->writeBackgroundStyle($objWriter, $oBkgImage, (string) $keySlide);
             }
         }
         // > office:styles
@@ -141,6 +140,29 @@ class Styles extends AbstractDecoratorWriter
 
         // office:automatic-styles
         $objWriter->startElement('office:automatic-styles');
+        // The style the master page is drawn with. ODF keeps the background of a page in a
+        // drawing-page style, not on the page itself, and this one has to be an automatic style:
+        // LibreOffice ignores it among the common styles of office:styles.
+        // style:style
+        $objWriter->startElement('style:style');
+        $objWriter->writeAttribute('style:name', self::MASTER_PAGE_STYLE);
+        $objWriter->writeAttribute('style:display-name', self::MASTER_PAGE_STYLE);
+        $objWriter->writeAttribute('style:family', 'drawing-page');
+        // style:drawing-page-properties
+        $objWriter->startElement('style:drawing-page-properties');
+        if ($oMasterBackground instanceof BackgroundColor) {
+            $objWriter->writeAttribute('draw:fill', 'solid');
+            $objWriter->writeAttribute('draw:fill-color', '#' . $oMasterBackground->getColor()->getRGB());
+        }
+        if ($oMasterBackground instanceof Image) {
+            $objWriter->writeAttribute('draw:fill', 'bitmap');
+            $objWriter->writeAttribute('draw:fill-image-name', 'background_' . self::MASTER_PAGE_STYLE);
+            $objWriter->writeAttribute('style:repeat', 'stretch');
+        }
+        // > style:drawing-page-properties
+        $objWriter->endElement();
+        // > style:style
+        $objWriter->endElement();
         // style:page-layout
         $objWriter->startElement('style:page-layout');
         $objWriter->writeAttribute('style:name', $stylePageLayout);
@@ -168,7 +190,7 @@ class Styles extends AbstractDecoratorWriter
         $objWriter->writeAttribute('style:name', 'Standard');
         $objWriter->writeAttribute('style:display-name', 'Standard');
         $objWriter->writeAttribute('style:page-layout-name', $stylePageLayout);
-        $objWriter->writeAttribute('draw:style-name', 'sPres0');
+        $objWriter->writeAttribute('draw:style-name', self::MASTER_PAGE_STYLE);
         $objWriter->endElement();
         $objWriter->endElement();
 
@@ -326,11 +348,11 @@ class Styles extends AbstractDecoratorWriter
     /**
      * Write the background image style.
      */
-    protected function writeBackgroundStyle(XMLWriter $objWriter, Image $oBkgImage, int $numSlide): void
+    protected function writeBackgroundStyle(XMLWriter $objWriter, Image $oBkgImage, string $numSlide): void
     {
         $objWriter->startElement('draw:fill-image');
-        $objWriter->writeAttribute('draw:name', 'background_' . (string) $numSlide);
-        $objWriter->writeAttribute('xlink:href', 'Pictures/' . str_replace(' ', '_', $oBkgImage->getIndexedFilename((string) $numSlide)));
+        $objWriter->writeAttribute('draw:name', 'background_' . $numSlide);
+        $objWriter->writeAttribute('xlink:href', 'Pictures/' . str_replace(' ', '_', $oBkgImage->getIndexedFilename($numSlide)));
         $objWriter->writeAttribute('xlink:type', 'simple');
         $objWriter->writeAttribute('xlink:show', 'embed');
         $objWriter->writeAttribute('xlink:actuate', 'onLoad');

--- a/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
+++ b/tests/PhpPresentation/Tests/Slide/SlideMasterTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Tests;
 
-use PhpOffice\PhpPresentation\Slide\Background\Color;
 use PhpOffice\PhpPresentation\Slide\SlideLayout;
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
 use PhpOffice\PhpPresentation\Style\SchemeColor;
@@ -40,10 +39,8 @@ class SlideMasterTest extends TestCase
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Slide\\AbstractSlide', $object);
         self::assertNull($object->getParent());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\ColorMap', $object->colorMap);
-        /** @var Color $background */
-        $background = $object->getBackground();
-        self::assertInstanceOf(Color::class, $background);
-        self::assertEquals('FFFFFF', $background->getColor()->getRGB());
+        // A master carries no background of its own; the colour map takes it to the theme
+        self::assertNull($object->getBackground());
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Style\\TextStyle', $object->getTextStyles());
     }
 

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/StylesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/StylesTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace PhpOffice\PhpPresentation\Tests\Writer\ODPresentation;
 
 use PhpOffice\PhpPresentation\DocumentLayout;
+use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
+use PhpOffice\PhpPresentation\Slide\Background\Image as BackgroundImage;
 use PhpOffice\PhpPresentation\Style\Border;
 use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\Fill;
@@ -70,6 +72,45 @@ class StylesTest extends PhpPresentationTestCase
         $this->assertZipXmlElementExists('styles.xml', $element);
         $this->assertZipXmlAttributeEquals('styles.xml', $element, 'style:page-layout-name', 'sPL0');
 
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testMasterSlideBackgroundColor(): void
+    {
+        $element = '/office:document-styles/office:automatic-styles/style:style[@style:name=\'sPres0\']/style:drawing-page-properties';
+
+        // The style the master page is drawn with carries no fill until one is asked for
+        $this->assertZipXmlElementExists('styles.xml', $element);
+        $this->assertZipXmlAttributeNotExists('styles.xml', $element, 'draw:fill');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oBackground = new BackgroundColor();
+        $oBackground->setColor(new Color('FFCC00'));
+        $this->oPresentation->getAllMasterSlides()[0]->setBackground($oBackground);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlAttributeEquals('styles.xml', $element, 'draw:fill', 'solid');
+        $this->assertZipXmlAttributeEquals('styles.xml', $element, 'draw:fill-color', '#FFCC00');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testMasterSlideBackgroundImage(): void
+    {
+        $imagePath = PHPPRESENTATION_TESTS_BASE_DIR . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'PhpPresentationLogo.png';
+
+        $oBackground = new BackgroundImage();
+        $oBackground->setPath($imagePath);
+        $this->oPresentation->getAllMasterSlides()[0]->setBackground($oBackground);
+
+        $element = '/office:document-styles/office:automatic-styles/style:style[@style:name=\'sPres0\']/style:drawing-page-properties';
+        $this->assertZipXmlAttributeEquals('styles.xml', $element, 'draw:fill', 'bitmap');
+        $this->assertZipXmlAttributeEquals('styles.xml', $element, 'draw:fill-image-name', 'background_sPres0');
+
+        // The image the style names has to be in the package, and in the manifest with it
+        $element = '/office:document-styles/office:styles/draw:fill-image[@draw:name=\'background_sPres0\']';
+        $this->assertZipXmlAttributeEquals('styles.xml', $element, 'xlink:href', 'Pictures/background_sPres0.png');
+        $this->assertZipFileExists('Pictures/background_sPres0.png');
+        $this->assertZipXmlElementExists('META-INF/manifest.xml', '/manifest:manifest/manifest:file-entry[@manifest:full-path=\'Pictures/background_sPres0.png\']');
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007Test.php
@@ -22,6 +22,8 @@ namespace PhpOffice\PhpPresentation\Tests\Writer;
 
 use PhpOffice\PhpPresentation\Exception\DirectoryNotFoundException;
 use PhpOffice\PhpPresentation\Exception\InvalidParameterException;
+use PhpOffice\PhpPresentation\Slide\Background\Color;
+use PhpOffice\PhpPresentation\Style\Color as StyleColor;
 use PhpOffice\PhpPresentation\Tests\PhpPresentationTestCase;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007;
 
@@ -121,6 +123,24 @@ class PowerPoint2007Test extends PhpPresentationTestCase
         $this->assertZipXmlElementExists('ppt/viewProps.xml', '/p:viewPr/p:slideViewPr/p:cSldViewPr/p:cViewPr/p:scale/a:sy');
         $this->assertZipXmlAttributeEquals('ppt/viewProps.xml', '/p:viewPr/p:slideViewPr/p:cSldViewPr/p:cViewPr/p:scale/a:sy', 'n', $value * 100);
         $this->assertZipXmlAttributeEquals('ppt/viewProps.xml', '/p:viewPr/p:slideViewPr/p:cSldViewPr/p:cViewPr/p:scale/a:sy', 'd', 100);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    public function testSlideMasterBackground(): void
+    {
+        $xPath = '/p:sldMaster/p:cSld/p:bg/p:bgPr/a:solidFill/a:srgbClr[@val=\'FFFFFF\']';
+
+        // A master paints nothing of its own, so the theme is what shows through
+        $this->assertZipFileExists('ppt/slideMasters/slideMaster1.xml');
+        $this->assertZipXmlElementNotExists('ppt/slideMasters/slideMaster1.xml', '/p:sldMaster/p:cSld/p:bg');
+        $this->assertIsSchemaECMA376Valid();
+
+        $oBackground = new Color();
+        $oBackground->setColor(new StyleColor(StyleColor::COLOR_WHITE));
+        $this->oPresentation->getAllMasterSlides()[0]->setBackground($oBackground);
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementExists('ppt/slideMasters/slideMaster1.xml', $xPath);
         $this->assertIsSchemaECMA376Valid();
     }
 


### PR DESCRIPTION
### Description

> Stacked on #909, which is where the white default disappears. Without it every ODF page would suddenly gain a white fill the deck never asked for. Please merge that one first; I will rebase this on master afterwards.

Every place the ODPresentation Writer reads a background takes it from a slide: `Styles.php` and `Pictures.php` and `MetaInfManifest.php` iterate `getAllSlides()`, and `Content.php` is handed one slide at a time by `writeStylePage()`. A background set on the master reached none of them, so it was dropped on save -- and the master is where PowerPoint usually keeps it.

`Styles.php` did write `<style:master-page … draw:style-name="sPres0">`, but `sPres0` was a hardcoded `style:family="presentation"` carrying `<style:graphic-properties draw:fill-color="#ffffff"/>`: the wrong family, the wrong property, and no `draw:fill` to switch it on. It painted nothing. Measured -- saving the same presentation with and without a background on the master produced byte-identical entries in the package.

That style is now what its name says: a drawing-page style built from the background of the master, as LibreOffice writes it.

```xml
<style:style style:name="sPres0" style:display-name="sPres0" style:family="drawing-page">
  <style:drawing-page-properties draw:fill="solid" draw:fill-color="#FFCC00"/>
</style:style>
```

**It has to be an automatic style.** I wrote it into `office:styles` first, next to where it used to be, and LibreOffice ignored it: the render was unchanged. The same style in `office:automatic-styles` -- where LibreOffice writes its own -- is drawn. Measured on the converted PDF:

| the master asks for | colour operators in the PDF | images in the PDF |
| --- | --- | --- |
| nothing | `0 0 0 rg`, `1 1 1 rg` | 0 |
| the colour `FFCC00` | **`1 0.8 0 rg`** | 0 |
| an image | `0 0 0 rg`, `1 1 1 rg` | **2** |

An image also has to reach the package and the manifest, so `Pictures.php` and `MetaInfManifest.php` now look at the master as well as at the slides, under the name `background_sPres0`. `writeBackgroundStyle()` takes that name as a `string` rather than an `int`, since the master is not numbered.

Along the way I checked a wrong guess so it does not come up in review: `presentation:background-visible="true"` on the style of the page changes nothing here. The section the style sits in was the whole of it.

### Checklist:

- [x] My CI is :green_circle:
  > phpstan and php-cs-fixer are clean, and the suite passes: 812 tests, 7212 assertions.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `StylesTest::testMasterSlideBackgroundColor` covers the style with and without a colour, `testMasterSlideBackgroundImage` the style, the `draw:fill-image`, the file in the package and its entry in the manifest. Both are schema-valid against ODF 1.2, and both fail without the change.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > The "Background" section of `docs/usage/slides/introduction.md` now says that both Writers keep the background of a master, and how each stores it.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
  > Added an entry under 1.3.0.
