### PR TITLE
ODPresentation Writer : Write the number of a slide and its date as fields

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -17,4 +17,5 @@
 - Fixed static analysis on PHP 8.4 and 8.5 (PHPStan 1.x could not resolve the symbols of PHPUnit 13) by [@yasumorishima](http://github.com/yasumorishima) in [#897](https://github.com/PHPOffice/PHPPresentation/pull/897)
 - ODPresentation Writer : Fixed the charts losing their data points, their background, their data labels and the colour of their series, and drawing a hidden legend by [@dkulyk](http://github.com/dkulyk) in [#901](https://github.com/PHPOffice/PHPPresentation/pull/901)
 - PowerPoint2007 Writer : Fixed the name of a slide being lost on save, and read it back by [@dkulyk](http://github.com/dkulyk) in [#902](https://github.com/PHPOffice/PHPPresentation/pull/902)
+- ODPresentation Writer : Fixed the number of a slide and its date being written as dead text instead of the fields they are by [@dkulyk](http://github.com/dkulyk) in [#913](https://github.com/PHPOffice/PHPPresentation/pull/913)
 

--- a/docs/usage/slides/layout.md
+++ b/docs/usage/slides/layout.md
@@ -52,3 +52,24 @@ A shape defined in each level will have an override for its formatting in each l
 use PhpOffice\PhpPresentation\Shape\Placeholder;
 $shape->setPlaceHolder(new Placeholder(Placeholder::PH_TYPE_TITLE));
 ```
+
+### Fields
+
+The number of a slide and its date are not written as the text they were given: they are
+fields, which the application filling them in replaces with the number of the slide the
+shape ended up on and with the date the presentation is opened on. The text a field is
+created with is only what it stands in for while it is being written.
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\Placeholder;
+
+$shape = $slide->createRichTextShape();
+$shape->createTextRun('<number>');
+$shape->setPlaceHolder(new Placeholder(Placeholder::PH_TYPE_SLIDENUM));
+
+$shape = $slide->createRichTextShape();
+$shape->createTextRun('01-01-25');
+$shape->setPlaceHolder(new Placeholder(Placeholder::PH_TYPE_DATETIME));
+```

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -32,6 +32,7 @@ use PhpOffice\PhpPresentation\Shape\Drawing\AbstractDrawingAdapter;
 use PhpOffice\PhpPresentation\Shape\Group;
 use PhpOffice\PhpPresentation\Shape\Line;
 use PhpOffice\PhpPresentation\Shape\Media;
+use PhpOffice\PhpPresentation\Shape\Placeholder;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\BreakElement;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
@@ -556,6 +557,7 @@ class Content extends AbstractDecoratorWriter
         $sCstShpLastBullet = '';
         $iCstShpLastBulletLvl = 0;
         $bCstShpHasBullet = false;
+        $fieldName = $this->getPlaceholderField($shape);
 
         foreach ($paragraphs as $paragraph) {
             // Close the bullet list
@@ -594,6 +596,8 @@ class Content extends AbstractDecoratorWriter
                             $objWriter->writeAttribute('xlink:href', $richtext->getHyperlink()->getUrl());
                             $objWriter->text($richtext->getText());
                             $objWriter->endElement();
+                        } elseif (null !== $fieldName) {
+                            $objWriter->writeElement($fieldName, $richtext->getText());
                         } else {
                             $objWriter->text($richtext->getText());
                         }
@@ -658,6 +662,8 @@ class Content extends AbstractDecoratorWriter
                             $objWriter->writeAttribute('xlink:href', $richtext->getHyperlink()->getUrl());
                             $objWriter->text($richtext->getText());
                             $objWriter->endElement();
+                        } elseif (null !== $fieldName) {
+                            $objWriter->writeElement($fieldName, $richtext->getText());
                         } else {
                             $objWriter->text($richtext->getText());
                         }
@@ -694,6 +700,29 @@ class Content extends AbstractDecoratorWriter
 
         // > draw:frame
         $objWriter->endElement();
+    }
+
+    /**
+     * The element a placeholder writes its text with, if that text is a field.
+     *
+     * The number of a slide and its date are not the text the shape was given: they are
+     * fields the reader fills in, and the text is only what they stand in for.
+     */
+    protected function getPlaceholderField(RichText $shape): ?string
+    {
+        $placeholder = $shape->getPlaceholder();
+        if (null === $placeholder) {
+            return null;
+        }
+
+        switch ($placeholder->getType()) {
+            case Placeholder::PH_TYPE_SLIDENUM:
+                return 'text:page-number';
+            case Placeholder::PH_TYPE_DATETIME:
+                return 'text:date';
+            default:
+                return null;
+        }
     }
 
     /**

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -27,6 +27,7 @@ use PhpOffice\PhpPresentation\PresentationProperties;
 use PhpOffice\PhpPresentation\Shape\Comment;
 use PhpOffice\PhpPresentation\Shape\Group;
 use PhpOffice\PhpPresentation\Shape\Media;
+use PhpOffice\PhpPresentation\Shape\Placeholder;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Shape\RichText\Run;
 use PhpOffice\PhpPresentation\Slide\Transition;
@@ -557,6 +558,46 @@ class ContentTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('content.xml', $element, 'draw:stroke-dash');
         $this->assertZipXmlAttributeStartsWith('content.xml', $element, 'draw:stroke-dash', 'strokeDash_');
         $this->assertZipXmlAttributeEndsWith('content.xml', $element, 'draw:stroke-dash', $oRichText1->getBorder()->getDashStyle());
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public static function dataProviderPlaceholderField(): array
+    {
+        return [
+            [Placeholder::PH_TYPE_SLIDENUM, 'text:page-number'],
+            [Placeholder::PH_TYPE_DATETIME, 'text:date'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderPlaceholderField
+     */
+    #[DataProvider('dataProviderPlaceholderField')]
+    public function testRichTextPlaceholderField(string $type, string $expectedElement): void
+    {
+        $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();
+        $oRichText->createTextRun('7');
+        $oRichText->setPlaceHolder(new Placeholder($type));
+
+        $element = '/office:document-content/office:body/office:presentation/draw:page/draw:frame/draw:text-box/text:p/text:span/' . $expectedElement;
+        $this->assertZipXmlElementExists('content.xml', $element);
+        $this->assertZipXmlElementEquals('content.xml', $element, '7');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testRichTextPlaceholderTitle(): void
+    {
+        $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();
+        $oRichText->createTextRun('Title');
+        $oRichText->setPlaceHolder(new Placeholder(Placeholder::PH_TYPE_TITLE));
+
+        $element = '/office:document-content/office:body/office:presentation/draw:page/draw:frame/draw:text-box/text:p/text:span';
+        $this->assertZipXmlElementEquals('content.xml', $element, 'Title');
+        $this->assertZipXmlElementNotExists('content.xml', $element . '/text:page-number');
+        $this->assertZipXmlElementNotExists('content.xml', $element . '/text:date');
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 


### PR DESCRIPTION
### Description

A slide number and a date placeholder carry text only as a stand-in for what the application fills in. The PowerPoint2007 Writer has always known that and writes `<a:fld type="slidenum">` / `<a:fld type="datetime">`, but the ODPresentation Writer wrote the stand-in itself, so every slide of a deck showed the same frozen number and the date never moved off the day the file was written.

```php
$shape = $slide->createRichTextShape();
$shape->createTextRun('7');
$shape->setPlaceHolder(new Placeholder(Placeholder::PH_TYPE_SLIDENUM));
```

| | before | after |
| --- | --- | --- |
| `content.xml` | `<text:span>7</text:span>` | `<text:span><text:page-number>7</text:page-number></text:span>` |
| the date placeholder | `<text:span>03-04-05</text:span>` | `<text:span><text:date>03-04-05</text:date></text:span>` |
| the same file converted back to `.pptx` by LibreOffice | the text `7`, on every slide | `<a:fld type="slidenum">` and `<a:fld type="datetime">`, the latter already showing today's date |

These are the elements LibreOffice itself writes for the same two placeholders when it exports a deck of its own, and the output validates against the ODF 1.2 schema. A placeholder of any other type is untouched, and so is a deck that never asked for one.

Two details worth naming: a placeholder holding several runs writes one field element per run (the PowerPoint2007 Writer keeps only the first run), and a run carrying a hyperlink stays a link rather than becoming a field.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)

  `ContentTest::testRichTextPlaceholderField` covers both placeholder types, `ContentTest::testRichTextPlaceholderTitle` covers a placeholder that must keep its plain text. Both assert the ODF 1.2 schema, and both fail on `master`.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/master/docs)

  `docs/usage/slides/layout.md` gained a `### Fields` section.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/master/docs/changes/1.3.0.md)

  One entry under `## Bug fixes`.
