### PR TITLE
PowerPoint2007 Reader : Read a text run that was written without properties

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -30,6 +30,7 @@
 - PowerPoint2007 Reader : Fixed the title of a chart axis, its rotation and the two fonts of the axis not being read back by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
 - PowerPoint2007 Reader : Fixed the minor tick mark of an axis being read into its major tick mark, and the outline of the value axis not being read at all, by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
 - Fixed the media part of an image whose path carries no extension being named with a trailing dot, and written under no content type, by [@dkulyk](http://github.com/dkulyk) in [#922](https://github.com/PHPOffice/PHPPresentation/pull/922)
+- PowerPoint2007 Reader : Fixed a text run written without `a:rPr` being dropped, which loses part of the text of a Keynote export, by [@Wilkolicious](http://github.com/Wilkolicious) in [#871](https://github.com/PHPOffice/PHPPresentation/pull/871) and [@dkulyk](http://github.com/dkulyk) in [#914](https://github.com/PHPOffice/PHPPresentation/pull/914)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1550,9 +1550,9 @@ class PowerPoint2007 implements ReaderInterface
             }
             if ('a:r' == $oSubElement->tagName) {
                 $oElementrPr = $document->getElement('a:rPr', $oSubElement);
-                if (is_object($oElementrPr)) {
-                    $oText = $oParagraph->createTextRun();
 
+                $oText = $oParagraph->createTextRun();
+                if (is_object($oElementrPr)) {
                     if ($oElementrPr->hasAttribute('b')) {
                         $att = $oElementrPr->getAttribute('b');
                         $oText->getFont()->setBold('true' == $att || '1' == $att ? true : false);
@@ -1631,10 +1631,9 @@ class PowerPoint2007 implements ReaderInterface
                             $oText->getFont()->setCharset($charset < 0 ? $charset + 256 : $charset);
                         }
                     }
-
-                    $oSubSubElement = $document->getElement('a:t', $oSubElement);
-                    $oText->setText($oSubSubElement->nodeValue);
                 }
+                $oSubSubElement = $document->getElement('a:t', $oSubElement);
+                $oText->setText($oSubSubElement->nodeValue);
             }
         }
     }

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1551,8 +1551,10 @@ class PowerPoint2007 implements ReaderInterface
             if ('a:r' == $oSubElement->tagName) {
                 $oElementrPr = $document->getElement('a:rPr', $oSubElement);
 
+                // `a:rPr` is optional (ECMA-376, CT_RegularTextRun), and Keynote's export leaves it
+                // out, so the run is made before its properties are looked at rather than by them
                 $oText = $oParagraph->createTextRun();
-                if (is_object($oElementrPr)) {
+                if ($oElementrPr instanceof DOMElement) {
                     if ($oElementrPr->hasAttribute('b')) {
                         $att = $oElementrPr->getAttribute('b');
                         $oText->getFont()->setBold('true' == $att || '1' == $att ? true : false);
@@ -1581,14 +1583,14 @@ class PowerPoint2007 implements ReaderInterface
                     }
                     // Color
                     $oElementSrgbClr = $document->getElement('a:solidFill/a:srgbClr', $oElementrPr);
-                    if (is_object($oElementSrgbClr) && $oElementSrgbClr->hasAttribute('val')) {
+                    if ($oElementSrgbClr instanceof DOMElement && $oElementSrgbClr->hasAttribute('val')) {
                         $oColor = new Color();
                         $oColor->setRGB($oElementSrgbClr->getAttribute('val'));
                         $oText->getFont()->setColor($oColor);
                     }
                     // Hyperlink
                     $oElementHlinkClick = $document->getElement('a:hlinkClick', $oElementrPr);
-                    if (is_object($oElementHlinkClick)) {
+                    if ($oElementHlinkClick instanceof DOMElement) {
                         $oText->setHyperlink(
                             $this->loadHyperlink($document, $oElementHlinkClick, $oText->getHyperlink())
                         );
@@ -1597,21 +1599,21 @@ class PowerPoint2007 implements ReaderInterface
                     // Font
                     $oElementFontFormat = null;
                     $oElementFontFormatComplexScript = $document->getElement('a:cs', $oElementrPr);
-                    if (is_object($oElementFontFormatComplexScript)) {
+                    if ($oElementFontFormatComplexScript instanceof DOMElement) {
                         $oText->getFont()->setFormat(Font::FORMAT_COMPLEX_SCRIPT);
                         $oElementFontFormat = $oElementFontFormatComplexScript;
                     }
                     $oElementFontFormatEastAsian = $document->getElement('a:ea', $oElementrPr);
-                    if (is_object($oElementFontFormatEastAsian)) {
+                    if ($oElementFontFormatEastAsian instanceof DOMElement) {
                         $oText->getFont()->setFormat(Font::FORMAT_EAST_ASIAN);
                         $oElementFontFormat = $oElementFontFormatEastAsian;
                     }
                     $oElementFontFormatLatin = $document->getElement('a:latin', $oElementrPr);
-                    if (is_object($oElementFontFormatLatin)) {
+                    if ($oElementFontFormatLatin instanceof DOMElement) {
                         $oText->getFont()->setFormat(Font::FORMAT_LATIN);
                         $oElementFontFormat = $oElementFontFormatLatin;
                     }
-                    if (is_object($oElementFontFormat) && $oElementFontFormat->hasAttribute('typeface')) {
+                    if ($oElementFontFormat instanceof DOMElement && $oElementFontFormat->hasAttribute('typeface')) {
                         $oText->getFont()->setName($oElementFontFormat->getAttribute('typeface'));
                     }
                     // Font definition
@@ -1632,8 +1634,13 @@ class PowerPoint2007 implements ReaderInterface
                         }
                     }
                 }
+                // The run now exists whether or not it had properties, so the text it holds has
+                // to be looked for rather than assumed: a run without `a:t` is malformed, but it
+                // is the reader that would raise the error
                 $oSubSubElement = $document->getElement('a:t', $oSubElement);
-                $oText->setText($oSubSubElement->nodeValue);
+                if ($oSubSubElement instanceof DOMElement) {
+                    $oText->setText($oSubSubElement->nodeValue);
+                }
             }
         }
     }

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -42,6 +42,7 @@ use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007 as PowerPoint2007Writer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ZipArchive;
 
 /**
  * Test class for PowerPoint2007 reader.
@@ -1249,6 +1250,65 @@ class PowerPoint2007Test extends TestCase
         // The shape wrote `a:noFill`, so it must come back with a fill that says so, not with none at all
         self::assertNotNull($arrayShape[0]->getFill());
         self::assertEquals(Fill::FILL_NONE, $arrayShape[0]->getFill()->getFillType());
+    }
+
+    public function testTextRunWithoutProperties(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('Part 1:');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+
+        // `a:rPr` is optional, and Keynote writes a run without one. Taking it back out of a file
+        // this library wrote says what such a run is without carrying a binary fixture for it.
+        $oZip = new ZipArchive();
+        $oZip->open($file);
+        $sSlide = $oZip->getFromName('ppt/slides/slide1.xml');
+        self::assertIsString($sSlide);
+        $oZip->deleteName('ppt/slides/slide1.xml');
+        $oZip->addFromString(
+            'ppt/slides/slide1.xml',
+            (string) preg_replace('#<a:rPr[^>]*/>|<a:rPr.*?</a:rPr>#s', '', $sSlide)
+        );
+        $oZip->close();
+
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertCount(1, $arrayShape[0]->getParagraph(0)->getRichTextElements());
+        self::assertEquals('Part 1:', $arrayShape[0]->getPlainText());
+    }
+
+    public function testTextRunWithoutText(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('Part 1:');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+
+        // A run without `a:t` is malformed, and the reader is not the one that should say so
+        $oZip = new ZipArchive();
+        $oZip->open($file);
+        $sSlide = $oZip->getFromName('ppt/slides/slide1.xml');
+        self::assertIsString($sSlide);
+        $oZip->deleteName('ppt/slides/slide1.xml');
+        $oZip->addFromString(
+            'ppt/slides/slide1.xml',
+            (string) preg_replace('#<a:t>.*?</a:t>#s', '', $sSlide)
+        );
+        $oZip->close();
+
+        // Reading it must not raise anything of its own; the suite fails on a warning of any kind
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertEquals('', $arrayShape[0]->getPlainText());
     }
 
     public function testLoadingFileWithNoteInSlide(): void


### PR DESCRIPTION
Supersedes #871.

### Description

The commit is @Wilkolicious's, from #871 — the diagnosis and the fix are his. This adds the tests, the guard his change makes necessary, and a rebase onto master.

**What breaks.** `a:rPr` is optional — `minOccurs="0"` in `CT_RegularTextRun` — and `loadParagraph()` wrapped both the creation of the run and its `setText()` in `if (is_object($oElementrPr))`. A run without properties was therefore skipped whole and its text lost, with no error.

**It is not hypothetical.** A deck exported from **Keynote** carries runs with no `a:rPr`, and it mixes them inside one paragraph:

```xml
<a:p>
  <a:pPr/>
  <a:r><a:rPr b="0"/><a:t>Quarterly </a:t></a:r>
  <a:r><a:t>review</a:t></a:r>
</a:p>
```

Read back, before and after:

| shape | master | this PR |
| --- | --- | --- |
| title | `'Quarterly '` | `'Quarterly review'` |
| subtitle | `''` | `'Prepared for the board'` |

The loss is ragged rather than total — a title breaks off mid-sentence — which is why it is easy to mistake for a layout problem. Google Slides writes `a:rPr` when a run has text, but omits it for empty placeholder runs: the same defect, harmless.

**One addition to #871.** Moving `setText()` out of the `is_object()` guard means it runs for every `a:r`, and `getElement()` returns `null` when there is no `a:t`. On master such a run is skipped whole; without a guard it would reach the dereference and the reader would be the one raising a warning about someone else's malformed file. `a:t` is required by the schema, so this is a guard against bad input, not a behaviour anyone should rely on.

**What this does not fix.** A run without `a:rPr` is not unstyled — it inherits, through `a:pPr/a:defRPr`, the shape's `a:lstStyle`, the placeholder's list style in the layout and master, and finally `p:defaultTextStyle`. The reader walks none of that chain, so the recovered text comes back as the library default (Calibri 10pt black) rather than what the file specifies. Separate gap, separate change; before this PR the text was not there at all.

### Checklist:

- [x] My CI is :green_circle:
  > 817 tests, 7226 assertions; phpstan clean.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `testTextRunWithoutProperties` and `testTextRunWithoutText`. Each writes a deck, removes `a:rPr` or `a:t` from the archive and reads it back, so neither carries a fixture. Both were checked by restoring the old code and watching them fail — the second needs an error handler to do it, since a PHP warning alone does not fail this suite.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > Reader behaviour; no documented API changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
  > Under *Bug fixes*, crediting both PRs.
