### PR TITLE
PowerPoint2007 Reader : Read a shape that asked for no fill

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -20,6 +20,7 @@
 - ODPresentation Writer : Fixed the number of a slide and its date being written as dead text instead of the fields they are by [@dkulyk](http://github.com/dkulyk) in [#913](https://github.com/PHPOffice/PHPPresentation/pull/913)
 - A master slide is no longer born with a white background nobody asked for by [@dkulyk](http://github.com/dkulyk) in [#909](https://github.com/PHPOffice/PHPPresentation/pull/909)
 - ODPresentation Writer : Fixed the background of a master slide being dropped on save by [@dkulyk](http://github.com/dkulyk) in [#912](https://github.com/PHPOffice/PHPPresentation/pull/912)
+- PowerPoint2007 Reader : Fixed a shape that asked for no fill being read as having no fill at all, which crashes the ODPresentation Writer on save, by [@dkulyk](http://github.com/dkulyk) in [#915](https://github.com/PHPOffice/PHPPresentation/pull/915)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1762,6 +1762,16 @@ class PowerPoint2007 implements ReaderInterface
             return $oFill;
         }
 
+        // No fill. This is a fill, and it is not the same thing as the absence of one below:
+        // `a:noFill` is what the file says when something asked to stay transparent.
+        $oElementFill = $xmlReader->getElement('a:noFill', $oElement);
+        if ($oElementFill instanceof DOMElement) {
+            $oFill = new Fill();
+            $oFill->setFillType(Fill::FILL_NONE);
+
+            return $oFill;
+        }
+
         return null;
     }
 

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1149,6 +1149,25 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals(Fill::FILL_NONE, $seriesRead->getDataPointOutline(1)->getFill()->getFillType());
     }
 
+    public function testShapeAskingForNoFillIsReadBack(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('Nothing behind me');
+        $oShape->getFill()->setFillType(Fill::FILL_NONE);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        // The shape wrote `a:noFill`, so it must come back with a fill that says so, not with none at all
+        self::assertNotNull($arrayShape[0]->getFill());
+        self::assertEquals(Fill::FILL_NONE, $arrayShape[0]->getFill()->getFillType());
+    }
+
     public function testLoadingFileWithNoteInSlide(): void
     {
         $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/PPTX_SlideNoteWithRichText.pptx';


### PR DESCRIPTION
### Description

`loadStyleFill()` ended in a single `return null`, reached by two unrelated files: a `p:spPr` that names no fill at all, and one that carries `<a:noFill/>`. The second is not an absence — it is a shape saying it wants to stay transparent, and it is what PowerPoint writes whenever you clear a fill. It now comes back as a `Fill` of type `FILL_NONE`.

**This also removes one of the two ways a real deck kills a conversion.** `Reader/PowerPoint2007.php` hands whatever the helper returned straight to `setFill()`, `AbstractShape::getFill(): ?Fill` hands the null on, and the ODPresentation Writer dereferences it:

```php
$oPhp = IOFactory::createReader('PowerPoint2007')->load('deck.pptx');
IOFactory::createWriter($oPhp, 'ODPresentation')->save('deck.odp');
// Error: Call to a member function getFillType() on null — Content.php:983
```

Any shape whose fill was cleared in PowerPoint carries `<a:noFill/>`, so this is not a corner case; it is most decks that were touched by hand. Reading such a file and saving it as ODP now works.

**What is deliberately left.** The other `null` — a shape with no fill element whatsoever — stays. That one is not about `a:noFill`; it is about `setFill(?Fill)` and `getFill(): ?Fill` letting a null into the model at all, which is a wider question than this fix and touches `Font` the same way.

### Checklist:

- [x] My CI is :green_circle:
  > 816 tests, 7222 assertions; phpstan clean; php-cs-fixer clean.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `PowerPoint2007Test::testShapeAskingForNoFillIsReadBack` writes a shape with `FILL_NONE`, saves it and reads it back. Checked by restoring the old code and watching it fail on `assertNotNull` — the assertion on the type alone would pass either way, since `FILL_NONE` is also the default of a fresh `Fill`.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > Reader behaviour; no documented API changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
