### PR TITLE
PowerPoint2007 Reader : Read a slide number and a date with their styling

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -39,6 +39,7 @@
 - PowerPoint2007 Writer : Fixed `Axis::setFormatCode()` having no effect, the number format of an axis being taken from the source data instead by [@dkulyk](http://github.com/dkulyk) in [#903](https://github.com/PHPOffice/PHPPresentation/pull/903)
 - Fixed the fill of a table row never reaching the file, in both Writers, by [@dkulyk](http://github.com/dkulyk) in [#911](https://github.com/PHPOffice/PHPPresentation/pull/911)
 - PowerPoint2007 Writer : Fixed a cell losing its own right and bottom borders whenever it had a neighbour on that side by [@dkulyk](http://github.com/dkulyk) in [#906](https://github.com/PHPOffice/PHPPresentation/pull/906)
+- PowerPoint2007 Reader : Fixed a slide number and a date being read back without the font, size and colour they were written with by [@dkulyk](http://github.com/dkulyk) in [#916](https://github.com/PHPOffice/PHPPresentation/pull/916)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1546,7 +1546,7 @@ class PowerPoint2007 implements ReaderInterface
                 $oParagraph->getBulletStyle()->setBulletColor($oColor);
             }
         }
-        $arraySubElements = $document->getElements('(a:r|a:br)', $oElement);
+        $arraySubElements = $document->getElements('(a:r|a:br|a:fld)', $oElement);
         foreach ($arraySubElements as $oSubElement) {
             if (!($oSubElement instanceof DOMElement)) {
                 continue;
@@ -1554,7 +1554,10 @@ class PowerPoint2007 implements ReaderInterface
             if ('a:br' == $oSubElement->tagName) {
                 $oParagraph->createBreak();
             }
-            if ('a:r' == $oSubElement->tagName) {
+            // A field is a run whose text the application recomputes -- a slide number, a date.
+            // `CT_TextField` holds the same `a:rPr` and `a:t` as a run does (ECMA-376), so it is
+            // read the same way: what the field says is a stand-in, but how it is styled is not.
+            if ('a:r' == $oSubElement->tagName || 'a:fld' == $oSubElement->tagName) {
                 $oElementrPr = $document->getElement('a:rPr', $oSubElement);
 
                 // `a:rPr` is optional (ECMA-376, CT_RegularTextRun), and Keynote's export leaves it

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -31,6 +31,7 @@ use PhpOffice\PhpPresentation\Shape\Chart\Axis;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
+use PhpOffice\PhpPresentation\Shape\Placeholder;
 use PhpOffice\PhpPresentation\Shape\RichText;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Shape\RichText\TextElement;
@@ -1485,5 +1486,66 @@ class PowerPoint2007Test extends TestCase
         self::assertInstanceOf(Table::class, $arrayShape[1]);
         self::assertTrue($arrayShape[1]->isFirstRow());
         self::assertTrue($arrayShape[1]->isBandRow());
+    }
+
+    /**
+     * @return array<array{string, string}>
+     */
+    public static function dataProviderFields(): array
+    {
+        return [
+            [Placeholder::PH_TYPE_SLIDENUM, 'slidenum'],
+            [Placeholder::PH_TYPE_DATETIME, 'datetime'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderFields
+     */
+    #[DataProvider('dataProviderFields')]
+    public function testFieldKeepsItsStyle(string $placeholder, string $type): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('Page')
+            ->getFont()
+            ->setName('Georgia')
+            ->setSize(18)
+            ->setBold(true)
+            ->setColor(new Color('FFCC0000'));
+        $oShape->setPlaceHolder(new Placeholder($placeholder));
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+
+        // The writer turns this shape into `a:fld` rather than a run, so the fixture is the file
+        // itself: what the reader has to cope with is exactly what the writer produces.
+        $oZip = new ZipArchive();
+        $oZip->open($file);
+        self::assertStringContainsString(
+            '<a:fld id=',
+            (string) $oZip->getFromName('ppt/slides/slide1.xml')
+        );
+        self::assertStringContainsString(
+            'type="' . $type . '"',
+            (string) $oZip->getFromName('ppt/slides/slide1.xml')
+        );
+        $oZip->close();
+
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertTrue($arrayShape[0]->isPlaceholder());
+        self::assertEquals($placeholder, $arrayShape[0]->getPlaceholder()->getType());
+
+        // The text of a field is only the stand-in the writer put there; the styling is the shape's
+        $arrayElements = $arrayShape[0]->getParagraph(0)->getRichTextElements();
+        self::assertCount(1, $arrayElements);
+        self::assertEquals('Georgia', $arrayElements[0]->getFont()->getName());
+        self::assertEquals(18, $arrayElements[0]->getFont()->getSize());
+        self::assertTrue($arrayElements[0]->getFont()->isBold());
+        self::assertEquals('FFCC0000', $arrayElements[0]->getFont()->getColor()->getARGB());
     }
 }


### PR DESCRIPTION
### Description

Depends on #914 — it rewrites the body of the same loop. The first two commits are that PR (and @Wilkolicious's #871 under it); only the last one belongs to this review.

#### What is wrong

`a:fld` is a run whose text the application recomputes: the number of the slide it ended up on, the date the file is opened on. The Writer emits one for every `sldNum` or `dt` placeholder (`AbstractSlide.php:326`), but the Reader walked `(a:r|a:br)` only, so the element was skipped and everything inside it with it.

The shape survives the round trip — the placeholder is restored from `p:ph` further up, and the Writer re-derives the field from it — so a deck keeps its numbering. What it loses is how that number looks. Measured on a `sldNum` placeholder styled Georgia 18pt bold red:

| | before | after |
|---|---|---|
| placeholder read back | `sldNum` | `sldNum` |
| runs in the paragraph | **0** | 1 |
| `a:fld` on re-save | present, **no `a:rPr` at all** | full `a:rPr` |

`dt` behaves identically.

#### The change

`CT_TextField` holds the same `a:rPr` and `a:t` as `CT_RegularTextRun`, so the element is read by the branch that already reads a run — the XPath and the condition, nothing else. Both field types are covered at once, the kind being an attribute rather than a separate element.

#### One deliberate consequence

A shape that is *not* a placeholder but holds a field — `page <slidenum> of 12` in a plain text box — now reads its stand-in text as an ordinary run, where it used to be dropped. The text of the file is kept rather than lost, but a field is not expressible in the model, so re-saving that shape freezes it into dead text.

Both outcomes are wrong; I think keeping the text is the better of the two, and it is easy to reverse if you disagree. What actually closes it is a field element of its own next to `Run` and `BreakElement`, which is a larger change and a separate PR. For reference, that is how LibreOffice models it — `class TextField final : public TextRun`, and both its OOXML and its ODF exporters decide per run rather than per shape.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `PowerPoint2007Test::testFieldKeepsItsStyle`, over both field types; the fixture is the library's own output, so nothing binary is added. Each half of the fix was checked by breaking it — without `a:fld` in the XPath, and without it in the condition — and both cases fail with `actual size 0`.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > Reader behaviour; no documented API changed. `docs/usage/slides/layout.md` already describes the fields, from #913.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
