### PR TITLE
ODPresentation Writer and Reader : Keep what a font says about itself

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -22,6 +22,7 @@
 - ODPresentation Writer : Fixed the background of a master slide being dropped on save by [@dkulyk](http://github.com/dkulyk) in [#912](https://github.com/PHPOffice/PHPPresentation/pull/912)
 - PowerPoint2007 Reader : Fixed a shape that asked for no fill being read as having no fill at all, which crashes the ODPresentation Writer on save, by [@dkulyk](http://github.com/dkulyk) in [#915](https://github.com/PHPOffice/PHPPresentation/pull/915)
 - Fixed a file with no measurable size (an SVG, a video) warning on `setPath()`, and a fresh object being looked up in the hash table under a null key, by [@dkulyk](http://github.com/dkulyk) in [#920](https://github.com/PHPOffice/PHPPresentation/pull/920)
+- ODPresentation Writer and Reader : Fixed the italic, the bold, the underline and the strikethrough of a font being dropped on save and not read back, in a chart style and in a text run alike, by [@dkulyk](http://github.com/dkulyk) in [#917](https://github.com/PHPOffice/PHPPresentation/pull/917)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -49,6 +49,31 @@ use ZipArchive;
 class ODPresentation implements ReaderInterface
 {
     /**
+     * The reverse of what the Writer spells out: a style, a type and a width back into the single
+     * token OOXML names an underline with. `words` is not here -- ODF says it with a mode.
+     *
+     * @var array<string, string>
+     */
+    protected const UNDERLINE_OOXML = [
+        'dash|single|' => Font::UNDERLINE_DASH,
+        'dash|single|bold' => Font::UNDERLINE_DASHHEAVY,
+        'long-dash|single|' => Font::UNDERLINE_DASHLONG,
+        'long-dash|single|bold' => Font::UNDERLINE_DASHLONGHEAVY,
+        'dot-dash|single|' => Font::UNDERLINE_DOTHASH,
+        'dot-dash|single|bold' => Font::UNDERLINE_DOTHASHHEAVY,
+        'dot-dot-dash|single|' => Font::UNDERLINE_DOTDOTDASH,
+        'dot-dot-dash|single|bold' => Font::UNDERLINE_DOTDOTDASHHEAVY,
+        'dotted|single|' => Font::UNDERLINE_DOTTED,
+        'dotted|single|bold' => Font::UNDERLINE_DOTTEDHEAVY,
+        'solid|double|' => Font::UNDERLINE_DOUBLE,
+        'solid|single|bold' => Font::UNDERLINE_HEAVY,
+        'solid|single|' => Font::UNDERLINE_SINGLE,
+        'wave|single|' => Font::UNDERLINE_WAVY,
+        'wave|double|' => Font::UNDERLINE_WAVYDOUBLE,
+        'wave|single|bold' => Font::UNDERLINE_WAVYHEAVY,
+    ];
+
+    /**
      * Output Object.
      *
      * @var PhpPresentation
@@ -404,6 +429,45 @@ class ODPresentation implements ReaderInterface
                 $oFont
                     ->setSize((int) substr($nodeTextProperties->getAttribute('style:font-size-complex'), 0, -2))
                     ->setFormat(Font::FORMAT_COMPLEX_SCRIPT);
+            }
+            // Italic, spelled once per script the way the family, the size and the weight are
+            if ('italic' == $nodeTextProperties->getAttribute('fo:font-style')) {
+                $oFont
+                    ->setItalic(true)
+                    ->setFormat(Font::FORMAT_LATIN);
+            }
+            if ('italic' == $nodeTextProperties->getAttribute('style:font-style-asian')) {
+                $oFont
+                    ->setItalic(true)
+                    ->setFormat(Font::FORMAT_EAST_ASIAN);
+            }
+            if ('italic' == $nodeTextProperties->getAttribute('style:font-style-complex')) {
+                $oFont
+                    ->setItalic(true)
+                    ->setFormat(Font::FORMAT_COMPLEX_SCRIPT);
+            }
+            // Underline and strikethrough, one family each for the whole run
+            $underlineStyle = $nodeTextProperties->getAttribute('style:text-underline-style');
+            if ('' !== $underlineStyle && 'none' !== $underlineStyle) {
+                if ('skip-white-space' == $nodeTextProperties->getAttribute('style:text-underline-mode')) {
+                    $oFont->setUnderline(Font::UNDERLINE_WORDS);
+                } else {
+                    $underlineType = $nodeTextProperties->getAttribute('style:text-underline-type');
+                    $underlineWidth = $nodeTextProperties->getAttribute('style:text-underline-width');
+                    $key = $underlineStyle
+                        . '|' . ('' === $underlineType ? 'single' : $underlineType)
+                        . '|' . ('bold' === $underlineWidth ? 'bold' : '');
+                    // a file written elsewhere can name a pair OOXML has no word for
+                    $oFont->setUnderline(self::UNDERLINE_OOXML[$key] ?? Font::UNDERLINE_SINGLE);
+                }
+            }
+            $lineThroughStyle = $nodeTextProperties->getAttribute('style:text-line-through-style');
+            if ('' !== $lineThroughStyle && 'none' !== $lineThroughStyle) {
+                $oFont->setStrikethrough(
+                    'double' == $nodeTextProperties->getAttribute('style:text-line-through-type')
+                        ? Font::STRIKE_DOUBLE
+                        : Font::STRIKE_SINGLE
+                );
             }
             if ($nodeTextProperties->hasAttribute('style:script-type')) {
                 switch ($nodeTextProperties->getAttribute('style:script-type')) {

--- a/src/PhpPresentation/Writer/ODPresentation/AbstractDecoratorWriter.php
+++ b/src/PhpPresentation/Writer/ODPresentation/AbstractDecoratorWriter.php
@@ -20,11 +20,71 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpPresentation\Writer\ODPresentation;
 
+use PhpOffice\Common\XMLWriter;
 use PhpOffice\PhpPresentation\Shape\Chart;
 use PhpOffice\PhpPresentation\Slide\AbstractBackground;
+use PhpOffice\PhpPresentation\Style\Font;
 
 abstract class AbstractDecoratorWriter extends \PhpOffice\PhpPresentation\Writer\AbstractDecoratorWriter
 {
+    /**
+     * OOXML names an underline with a single token; ODF spells the same thing over a style, a type
+     * and a width, and has no name of its own for a few of the eighteen.
+     *
+     * @var array<string, array{0: string, 1: string, 2: null|string}>
+     */
+    protected const UNDERLINE_ODF = [
+        Font::UNDERLINE_DASH => ['dash', 'single', null],
+        Font::UNDERLINE_DASHHEAVY => ['dash', 'single', 'bold'],
+        Font::UNDERLINE_DASHLONG => ['long-dash', 'single', null],
+        Font::UNDERLINE_DASHLONGHEAVY => ['long-dash', 'single', 'bold'],
+        Font::UNDERLINE_DOTHASH => ['dot-dash', 'single', null],
+        Font::UNDERLINE_DOTHASHHEAVY => ['dot-dash', 'single', 'bold'],
+        Font::UNDERLINE_DOTDOTDASH => ['dot-dot-dash', 'single', null],
+        Font::UNDERLINE_DOTDOTDASHHEAVY => ['dot-dot-dash', 'single', 'bold'],
+        Font::UNDERLINE_DOTTED => ['dotted', 'single', null],
+        Font::UNDERLINE_DOTTEDHEAVY => ['dotted', 'single', 'bold'],
+        Font::UNDERLINE_DOUBLE => ['solid', 'double', null],
+        Font::UNDERLINE_HEAVY => ['solid', 'single', 'bold'],
+        Font::UNDERLINE_SINGLE => ['solid', 'single', null],
+        Font::UNDERLINE_WAVY => ['wave', 'single', null],
+        Font::UNDERLINE_WAVYDOUBLE => ['wave', 'double', null],
+        Font::UNDERLINE_WAVYHEAVY => ['wave', 'single', 'bold'],
+        Font::UNDERLINE_WORDS => ['solid', 'single', null],
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected const STRIKETHROUGH_ODF = [
+        Font::STRIKE_SINGLE => 'single',
+        Font::STRIKE_DOUBLE => 'double',
+    ];
+
+    /**
+     * The underline and the strikethrough of a font, written into the `style:text-properties` the
+     * caller has open. Both are one attribute family for the whole run, unlike the family, the
+     * size and the weight, which ODF spells once per script.
+     */
+    protected function writeFontStates(XMLWriter $objWriter, Font $font): void
+    {
+        if (isset(self::UNDERLINE_ODF[$font->getUnderline()])) {
+            [$style, $type, $width] = self::UNDERLINE_ODF[$font->getUnderline()];
+            $objWriter->writeAttribute('style:text-underline-style', $style);
+            $objWriter->writeAttribute('style:text-underline-type', $type);
+            if (null !== $width) {
+                $objWriter->writeAttribute('style:text-underline-width', $width);
+            }
+            if (Font::UNDERLINE_WORDS === $font->getUnderline()) {
+                $objWriter->writeAttribute('style:text-underline-mode', 'skip-white-space');
+            }
+        }
+        if (isset(self::STRIKETHROUGH_ODF[$font->getStrikethrough()])) {
+            $objWriter->writeAttribute('style:text-line-through-style', 'solid');
+            $objWriter->writeAttribute('style:text-line-through-type', self::STRIKETHROUGH_ODF[$font->getStrikethrough()]);
+        }
+    }
+
     /**
      * @var Chart[]
      */

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -297,6 +297,7 @@ class Content extends AbstractDecoratorWriter
                         $objWriter->writeAttribute('fo:font-family', $item->getFont()->getName());
                         $objWriter->writeAttribute('fo:font-size', $item->getFont()->getSize() . 'pt');
                         $objWriter->writeAttributeIf($item->getFont()->isBold(), 'fo:font-weight', 'bold');
+                        $objWriter->writeAttributeIf($item->getFont()->isItalic(), 'fo:font-style', 'italic');
                         $objWriter->writeAttribute('fo:language', ($item->getLanguage() ? substr($item->getLanguage(), 0, 2) : 'en'));
                         $objWriter->writeAttribute('style:script-type', 'latin');
 
@@ -305,6 +306,7 @@ class Content extends AbstractDecoratorWriter
                         $objWriter->writeAttribute('style:font-family-asian', $item->getFont()->getName());
                         $objWriter->writeAttribute('style:font-size-asian', $item->getFont()->getSize() . 'pt');
                         $objWriter->writeAttributeIf($item->getFont()->isBold(), 'style:font-weight-asian', 'bold');
+                        $objWriter->writeAttributeIf($item->getFont()->isItalic(), 'style:font-style-asian', 'italic');
                         $objWriter->writeAttribute('style:language-asian', ($item->getLanguage() ? $item->getLanguage() : 'en'));
                         $objWriter->writeAttribute('style:script-type', 'asian');
 
@@ -313,11 +315,15 @@ class Content extends AbstractDecoratorWriter
                         $objWriter->writeAttribute('style:font-family-complex', $item->getFont()->getName());
                         $objWriter->writeAttribute('style:font-size-complex', $item->getFont()->getSize() . 'pt');
                         $objWriter->writeAttributeIf($item->getFont()->isBold(), 'style:font-weight-complex', 'bold');
+                        $objWriter->writeAttributeIf($item->getFont()->isItalic(), 'style:font-style-complex', 'italic');
                         $objWriter->writeAttribute('style:language-complex', ($item->getLanguage() ? $item->getLanguage() : 'en'));
                         $objWriter->writeAttribute('style:script-type', 'complex');
 
                         break;
                 }
+                // the underline and the strikethrough are one family for the whole run, whatever
+                // the script the rest of it was spelled for
+                $this->writeFontStates($objWriter, $item->getFont());
 
                 // > style:style > style:text-properties
                 $objWriter->endElement();

--- a/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
+++ b/src/PhpPresentation/Writer/ODPresentation/ObjectsChart.php
@@ -40,6 +40,7 @@ use PhpOffice\PhpPresentation\Shape\Chart\Type\Pie3D;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Radar;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter;
 use PhpOffice\PhpPresentation\Style\Fill;
+use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Style\Outline;
 
 class ObjectsChart extends AbstractDecoratorWriter
@@ -312,6 +313,23 @@ class ObjectsChart extends AbstractDecoratorWriter
         $this->writeGridlineStyle($chart->getPlotArea()->getAxisY()->getMinorGridlines(), 'styleAxisYGridlinesMinor');
     }
 
+    /**
+     * Every chart style is styled from the same four attributes, and used to stop there: a font
+     * that was made bold, underlined or struck through reached the PowerPoint2007 file with all
+     * three and this one with none.
+     */
+    protected function writeTextProperties(Font $font): void
+    {
+        $this->xmlContent->startElement('style:text-properties');
+        $this->xmlContent->writeAttribute('fo:color', '#' . $font->getColor()->getRGB());
+        $this->xmlContent->writeAttribute('fo:font-family', $font->getName());
+        $this->xmlContent->writeAttribute('fo:font-size', $font->getSize() . 'pt');
+        $this->xmlContent->writeAttribute('fo:font-style', $font->isItalic() ? 'italic' : 'normal');
+        $this->xmlContent->writeAttributeIf($font->isBold(), 'fo:font-weight', 'bold');
+        $this->writeFontStates($this->xmlContent, $font);
+        $this->xmlContent->endElement();
+    }
+
     protected function writeAxisMainStyle(Axis $axis, string $styleName, AbstractType $chartType): void
     {
         // style:style
@@ -358,12 +376,7 @@ class ObjectsChart extends AbstractDecoratorWriter
         $this->xmlContent->writeAttribute('svg:stroke-color', '#' . $axis->getOutline()->getFill()->getStartColor()->getRGB());
         $this->xmlContent->endElement();
         // style:style > style:text-properties
-        $this->xmlContent->startElement('style:text-properties');
-        $this->xmlContent->writeAttribute('fo:color', '#' . $axis->getFont()->getColor()->getRGB());
-        $this->xmlContent->writeAttribute('fo:font-family', $axis->getFont()->getName());
-        $this->xmlContent->writeAttribute('fo:font-size', $axis->getFont()->getSize() . 'pt');
-        $this->xmlContent->writeAttribute('fo:font-style', $axis->getFont()->isItalic() ? 'italic' : 'normal');
-        $this->xmlContent->endElement();
+        $this->writeTextProperties($axis->getFont());
         // ## style:style
         $this->xmlContent->endElement();
     }
@@ -381,13 +394,7 @@ class ObjectsChart extends AbstractDecoratorWriter
         // > style:chart-properties
         $this->xmlContent->endElement();
         // style:text-properties
-        $this->xmlContent->startElement('style:text-properties');
-        $this->xmlContent->writeAttribute('fo:color', '#' . $axis->getFont()->getColor()->getRGB());
-        $this->xmlContent->writeAttribute('fo:font-family', $axis->getFont()->getName());
-        $this->xmlContent->writeAttribute('fo:font-size', $axis->getFont()->getSize() . 'pt');
-        $this->xmlContent->writeAttribute('fo:font-style', $axis->getFont()->isItalic() ? 'italic' : 'normal');
-        // > style:text-properties
-        $this->xmlContent->endElement();
+        $this->writeTextProperties($axis->getFont());
         // > style:style
         $this->xmlContent->endElement();
     }
@@ -512,13 +519,7 @@ class ObjectsChart extends AbstractDecoratorWriter
         // > style:chart-properties
         $this->xmlContent->endElement();
         // style:text-properties
-        $this->xmlContent->startElement('style:text-properties');
-        $this->xmlContent->writeAttribute('fo:color', '#' . $chart->getLegend()->getFont()->getColor()->getRGB());
-        $this->xmlContent->writeAttribute('fo:font-family', $chart->getLegend()->getFont()->getName());
-        $this->xmlContent->writeAttribute('fo:font-size', $chart->getLegend()->getFont()->getSize() . 'pt');
-        $this->xmlContent->writeAttribute('fo:font-style', $chart->getLegend()->getFont()->isItalic() ? 'italic' : 'normal');
-        // > style:text-properties
-        $this->xmlContent->endElement();
+        $this->writeTextProperties($chart->getLegend()->getFont());
         // > style:style
         $this->xmlContent->endElement();
     }
@@ -840,12 +841,7 @@ class ObjectsChart extends AbstractDecoratorWriter
         // > style:graphic-properties
         $this->xmlContent->endElement();
         // style:text-properties
-        $this->xmlContent->startElement('style:text-properties');
-        $this->xmlContent->writeAttribute('fo:color', '#' . $series->getFont()->getColor()->getRGB());
-        $this->xmlContent->writeAttribute('fo:font-family', $series->getFont()->getName());
-        $this->xmlContent->writeAttribute('fo:font-size', $series->getFont()->getSize() . 'pt');
-        // > style:text-properties
-        $this->xmlContent->endElement();
+        $this->writeTextProperties($series->getFont());
 
         // > style:style
         $this->xmlContent->endElement();
@@ -1011,13 +1007,7 @@ class ObjectsChart extends AbstractDecoratorWriter
         $this->xmlContent->writeAttribute('style:name', 'styleTitle');
         $this->xmlContent->writeAttribute('style:family', 'chart');
         // style:text-properties
-        $this->xmlContent->startElement('style:text-properties');
-        $this->xmlContent->writeAttribute('fo:color', '#' . $oTitle->getFont()->getColor()->getRGB());
-        $this->xmlContent->writeAttribute('fo:font-family', $oTitle->getFont()->getName());
-        $this->xmlContent->writeAttribute('fo:font-size', $oTitle->getFont()->getSize() . 'pt');
-        $this->xmlContent->writeAttribute('fo:font-style', $oTitle->getFont()->isItalic() ? 'italic' : 'normal');
-        // > style:text-properties
-        $this->xmlContent->endElement();
+        $this->writeTextProperties($oTitle->getFont());
         // > style:style
         $this->xmlContent->endElement();
     }

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -32,6 +32,7 @@ use PhpOffice\PhpPresentation\Style\Alignment;
 use PhpOffice\PhpPresentation\Style\Bullet;
 use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Writer\ODPresentation as ODPresentationWriter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1066,6 +1067,93 @@ class ODPresentationTest extends TestCase
         $oElement = reset($arrayElements);
         self::assertInstanceOf('PhpOffice\\PhpPresentation\\Shape\\RichText\\TextElement', $oElement);
         self::assertEquals('TEST IMAGE', $oElement->getText());
+    }
+
+    /**
+     * @return array<array{0: string}>
+     */
+    public static function dataProviderUnderlines(): array
+    {
+        return [
+            [Font::UNDERLINE_DASH],
+            [Font::UNDERLINE_DASHHEAVY],
+            [Font::UNDERLINE_DASHLONG],
+            [Font::UNDERLINE_DASHLONGHEAVY],
+            [Font::UNDERLINE_DOTHASH],
+            [Font::UNDERLINE_DOTHASHHEAVY],
+            [Font::UNDERLINE_DOTDOTDASH],
+            [Font::UNDERLINE_DOTDOTDASHHEAVY],
+            [Font::UNDERLINE_DOTTED],
+            [Font::UNDERLINE_DOTTEDHEAVY],
+            [Font::UNDERLINE_DOUBLE],
+            [Font::UNDERLINE_HEAVY],
+            [Font::UNDERLINE_SINGLE],
+            [Font::UNDERLINE_WAVY],
+            [Font::UNDERLINE_WAVYDOUBLE],
+            [Font::UNDERLINE_WAVYHEAVY],
+            [Font::UNDERLINE_WORDS],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderUnderlines
+     */
+    #[DataProvider('dataProviderUnderlines')]
+    public function testFontUnderlineSurvivesTheRoundTrip(string $underline): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oRun = $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('Sample');
+        $oRun->getFont()->setUnderline($underline);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        $oFont = $arrayShape[0]->getParagraph()->getRichTextElements()[0]->getFont();
+        self::assertInstanceOf(Font::class, $oFont);
+        self::assertEquals($underline, $oFont->getUnderline());
+    }
+
+    public function testFontStateSurvivesTheRoundTrip(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSlide = $oPhpPresentation->getActiveSlide();
+        foreach ([Font::FORMAT_LATIN, Font::FORMAT_EAST_ASIAN, Font::FORMAT_COMPLEX_SCRIPT] as $format) {
+            $oRun = $oSlide->createRichTextShape()->createTextRun('Sample');
+            $oRun->getFont()
+                ->setFormat($format)
+                ->setBold(true)
+                ->setItalic(true)
+                ->setStrikethrough(Font::STRIKE_DOUBLE);
+        }
+        // a run nobody styled comes back as plain as it went in
+        $oSlide->createRichTextShape()->createTextRun('Plain');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertCount(4, $arrayShape);
+        foreach ([Font::FORMAT_LATIN, Font::FORMAT_EAST_ASIAN, Font::FORMAT_COMPLEX_SCRIPT] as $idx => $format) {
+            self::assertInstanceOf(RichText::class, $arrayShape[$idx]);
+            $oFont = $arrayShape[$idx]->getParagraph()->getRichTextElements()[0]->getFont();
+            self::assertInstanceOf(Font::class, $oFont);
+            self::assertEquals($format, $oFont->getFormat());
+            self::assertTrue($oFont->isBold());
+            self::assertTrue($oFont->isItalic());
+            self::assertEquals(Font::STRIKE_DOUBLE, $oFont->getStrikethrough());
+        }
+        self::assertInstanceOf(RichText::class, $arrayShape[3]);
+        $oFont = $arrayShape[3]->getParagraph()->getRichTextElements()[0]->getFont();
+        self::assertInstanceOf(Font::class, $oFont);
+        self::assertFalse($oFont->isItalic());
+        self::assertEquals(Font::UNDERLINE_NONE, $oFont->getUnderline());
+        self::assertEquals(Font::STRIKE_NONE, $oFont->getStrikethrough());
     }
 
     public function testShapeDecorative(): void

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -447,6 +447,55 @@ class ContentTest extends PhpPresentationTestCase
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 
+    public function testRichTextRunFontState(): void
+    {
+        $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();
+        $oRun = $oRichText->createTextRun('Run1');
+
+        $expectedHashCode = $oRun->getHashCode();
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'T_' . $expectedHashCode . '\']/style:text-properties';
+        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'fo:font-style');
+        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'style:text-underline-style');
+        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'style:text-line-through-style');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oRun->getFont()->setItalic(true);
+        $oRun->getFont()->setUnderline(Font::UNDERLINE_WAVYHEAVY);
+        $oRun->getFont()->setStrikethrough(Font::STRIKE_DOUBLE);
+        $this->resetPresentationFile();
+
+        $expectedHashCode = $oRun->getHashCode();
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'T_' . $expectedHashCode . '\']/style:text-properties';
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:font-style', 'italic');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-underline-style', 'wave');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-underline-type', 'single');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-underline-width', 'bold');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-line-through-style', 'solid');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-line-through-type', 'double');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        // the italic is spelled once per script, the way the family, the size and the weight are
+        $oRun->getFont()->setFormat(Font::FORMAT_EAST_ASIAN);
+        $this->resetPresentationFile();
+
+        $expectedHashCode = $oRun->getHashCode();
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'T_' . $expectedHashCode . '\']/style:text-properties';
+        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'fo:font-style');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:font-style-asian', 'italic');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-underline-style', 'wave');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:text-line-through-type', 'double');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $oRun->getFont()->setFormat(Font::FORMAT_COMPLEX_SCRIPT);
+        $this->resetPresentationFile();
+
+        $expectedHashCode = $oRun->getHashCode();
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'T_' . $expectedHashCode . '\']/style:text-properties';
+        $this->assertZipXmlAttributeNotExists('content.xml', $element, 'fo:font-style');
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:font-style-complex', 'italic');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
     public function testRichTextRunLanguage(): void
     {
         $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ObjectsChartTest.php
@@ -38,8 +38,10 @@ use PhpOffice\PhpPresentation\Shape\Chart\Type\Radar;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Scatter;
 use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\Fill;
+use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Style\Outline;
 use PhpOffice\PhpPresentation\Tests\PhpPresentationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test class for PhpOffice\PhpPresentation\Writer\ODPresentation\Manifest.
@@ -1478,6 +1480,118 @@ class ObjectsChartTest extends PhpPresentationTestCase
         $this->assertZipXmlElementExists('Object 1/content.xml', $element);
         $this->assertZipXmlAttributeExists('Object 1/content.xml', $element, 'chart:interpolation');
         $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'chart:interpolation', 'cubic-spline');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    /**
+     * @return array<array{0: string, 1: string, 2: string, 3: null|string}>
+     */
+    public static function dataProviderUnderlines(): array
+    {
+        return [
+            [Font::UNDERLINE_DASH, 'dash', 'single', null],
+            [Font::UNDERLINE_DASHHEAVY, 'dash', 'single', 'bold'],
+            [Font::UNDERLINE_DASHLONG, 'long-dash', 'single', null],
+            [Font::UNDERLINE_DASHLONGHEAVY, 'long-dash', 'single', 'bold'],
+            [Font::UNDERLINE_DOTHASH, 'dot-dash', 'single', null],
+            [Font::UNDERLINE_DOTHASHHEAVY, 'dot-dash', 'single', 'bold'],
+            [Font::UNDERLINE_DOTDOTDASH, 'dot-dot-dash', 'single', null],
+            [Font::UNDERLINE_DOTDOTDASHHEAVY, 'dot-dot-dash', 'single', 'bold'],
+            [Font::UNDERLINE_DOTTED, 'dotted', 'single', null],
+            [Font::UNDERLINE_DOTTEDHEAVY, 'dotted', 'single', 'bold'],
+            [Font::UNDERLINE_DOUBLE, 'solid', 'double', null],
+            [Font::UNDERLINE_HEAVY, 'solid', 'single', 'bold'],
+            [Font::UNDERLINE_SINGLE, 'solid', 'single', null],
+            [Font::UNDERLINE_WAVY, 'wave', 'single', null],
+            [Font::UNDERLINE_WAVYDOUBLE, 'wave', 'double', null],
+            [Font::UNDERLINE_WAVYHEAVY, 'wave', 'single', 'bold'],
+            [Font::UNDERLINE_WORDS, 'solid', 'single', null],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderUnderlines
+     */
+    #[DataProvider('dataProviderUnderlines')]
+    public function testAxisFontUnderline(string $underline, string $style, string $type, ?string $width): void
+    {
+        $oShape = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oSeries = new Series('Series', $this->seriesData);
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oShape->getPlotArea()->setType($oBar);
+        $oShape->getPlotArea()->getAxisX()->getFont()->setUnderline($underline);
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleAxisX\']/style:text-properties';
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-underline-style', $style);
+        $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-underline-type', $type);
+        if (null === $width) {
+            $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'style:text-underline-width');
+        } else {
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-underline-width', $width);
+        }
+        // `words` is the one underline ODF spells with a mode rather than a style of its own
+        if (Font::UNDERLINE_WORDS === $underline) {
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-underline-mode', 'skip-white-space');
+        } else {
+            $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'style:text-underline-mode');
+        }
+
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testFontStateOfEveryChartStyle(): void
+    {
+        $oShape = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oSeries = new Series('Series', $this->seriesData);
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oShape->getPlotArea()->setType($oBar);
+        $oShape->getPlotArea()->getAxisX()->setTitle('Axis');
+        $oShape->getTitle()->setVisible(true);
+        $oShape->getLegend()->setVisible(true);
+
+        $fonts = [
+            $oShape->getPlotArea()->getAxisX()->getFont(),
+            $oShape->getLegend()->getFont(),
+            $oSeries->getFont(),
+            $oShape->getTitle()->getFont(),
+        ];
+        foreach ($fonts as $oFont) {
+            $oFont->setBold(true);
+            $oFont->setItalic(true);
+            $oFont->setUnderline(Font::UNDERLINE_DOUBLE);
+            $oFont->setStrikethrough(Font::STRIKE_DOUBLE);
+        }
+
+        // the axis carries the same font twice: on its labels and on its title
+        foreach (['styleAxisX', 'styleAxisXTitle', 'styleLegend', 'styleSeries0', 'styleTitle'] as $styleName) {
+            $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'' . $styleName . '\']/style:text-properties';
+            $this->assertZipXmlElementExists('Object 1/content.xml', $element);
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'fo:font-weight', 'bold');
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'fo:font-style', 'italic');
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-underline-style', 'solid');
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-underline-type', 'double');
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-line-through-style', 'solid');
+            $this->assertZipXmlAttributeEquals('Object 1/content.xml', $element, 'style:text-line-through-type', 'double');
+        }
+
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
+    public function testFontStateLeftAloneIsNotWritten(): void
+    {
+        $oShape = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oSeries = new Series('Series', $this->seriesData);
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oShape->getPlotArea()->setType($oBar);
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'styleAxisX\']/style:text-properties';
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'fo:font-weight');
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'style:text-underline-style');
+        $this->assertZipXmlAttributeNotExists('Object 1/content.xml', $element, 'style:text-line-through-style');
+
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 }


### PR DESCRIPTION
### Description

Every `style:text-properties` this Writer builds was assembled by hand, and each one left something out.

| | italic | bold | underline | strikethrough |
|---|---|---|---|---|
| chart style (axis, axis title, legend, chart title) | kept | **lost** | **lost** | **lost** |
| chart style, series | **lost** | **lost** | **lost** | **lost** |
| text run | **lost** | kept | **lost** | **lost** |
| the same deck saved as PPTX | kept | kept | kept | kept |

Measured on one font set `b + i + u + strike`, saved both ways.

ODF splits these differently from OOXML: the underline (`style:text-underline-style` with a type, a width and a mode) and the strikethrough (`style:text-line-through-style` with a type) are one family for the whole run, while the family, the size, the weight and the italic are spelled once per script. The shared half now lives on the ODPresentation `AbstractDecoratorWriter` as `writeFontStates()`, with the table that turns each of the eighteen OOXML underlines into the style, type and width ODF names it with. The per-script half stays in the `switch` that already handled it, and the five chart blocks became one `writeTextProperties()` -- which is what closes the series block that was missing even the italic.

The Reader is the same defect read backwards: it took the family, the weight and the size, so a file this library had just written came back without its italic, its underline or its strikethrough. Round trip, before and after:

```
before   ODPresentation  bold=true  italic=false underline=none   strike=noStrike
after    ODPresentation  bold=true  italic=true  underline=sng    strike=sngStrike
         PowerPoint2007  bold=true  italic=true  underline=sng    strike=sngStrike
```

A pair ODF allows and OOXML has no word for is read as a plain single underline rather than dropped.

**Charts are untouched on the reading side** -- the PowerPoint2007 Reader takes only the name, the description and the geometry of a chart shape, and the ODPresentation Reader does not read charts at all. Both are separate holes.

### Checklist:

- [x] My CI is :green_circle:
  > 854 tests, 7513 assertions; phpstan clean; php-cs-fixer `0 of 276`.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `ObjectsChartTest::testFontStateOfEveryChartStyle` and `::testAxisFontUnderline` (all 17 mappings, each validated against the ODF 1.2 schema), `ContentTest::testRichTextRunFontState` (per script), `ODPresentationTest::testFontUnderlineSurvivesTheRoundTrip` and `::testFontStateSurvivesTheRoundTrip`. Checked by breaking each half -- dropping `fo:font-weight`, corrupting `WAVYHEAVY`, deleting `wave|double` from the Reader's table, and disabling the complex-script italic -- every mutation fails a test.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > Writer and Reader behaviour; no documented API changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
