### PR TITLE
PowerPoint2007 Reader : Read the text of a chart axis

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -27,6 +27,8 @@
 - ODPresentation Writer and Reader : Fixed the italic, the bold, the underline and the strikethrough of a font being dropped on save and not read back, in a chart style and in a text run alike, by [@dkulyk](http://github.com/dkulyk) in [#917](https://github.com/PHPOffice/PHPPresentation/pull/917)
 - ODPresentation Writer : Fixed the tick labels of a chart axis being styled from `getFont()` rather than `getTickLabelFont()`, which is the font the PowerPoint2007 Writer uses for them, and fixed the strikethrough of those labels being read from the wrong font in the PowerPoint2007 Writer, by [@dkulyk](http://github.com/dkulyk) in [#923](https://github.com/PHPOffice/PHPPresentation/pull/923)
 - PowerPoint2007 Writer and Reader : Fixed the charset of a font being written in hexadecimal, which the schema forbids above 127 and the Reader read as decimal either way, by [@dkulyk](http://github.com/dkulyk) in [#919](https://github.com/PHPOffice/PHPPresentation/pull/919)
+- PowerPoint2007 Reader : Fixed the title of a chart axis, its rotation and the two fonts of the axis not being read back by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
+- PowerPoint2007 Reader : Fixed the minor tick mark of an axis being read into its major tick mark, and the outline of the value axis not being read at all, by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -25,8 +25,9 @@
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <!-- PptSlides needs more coupling (default: 13) -->
         <!-- Writer/Office2007/AbstractSlide needs more coupling (default: 13) -->
+        <!-- Reader/PowerPoint2007 reads a chart axis, and an axis is a class of its own -->
 		<properties>
-            <property name="maximum" value="38" />
+            <property name="maximum" value="39" />
         </properties>
     </rule>
     <rule ref="rulesets/design.xml/NumberOfChildren">

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1380,7 +1380,7 @@ class PowerPoint2007 implements ReaderInterface
                             $oShape->getPlotArea()->getAxisX()->setMajorTickMark($elementMajorTickMark->getAttribute('val'));
                         }
                         if ($elementMinorTickMark = $xmlReader->getElement('c:minorTickMark', $oElement)) {
-                            $oShape->getPlotArea()->getAxisX()->setMajorTickMark($elementMinorTickMark->getAttribute('val'));
+                            $oShape->getPlotArea()->getAxisX()->setMinorTickMark($elementMinorTickMark->getAttribute('val'));
                         }
                         if ($elementTickLabelPosition = $xmlReader->getElement('c:tickLblPos', $oElement)) {
                             $oShape->getPlotArea()->getAxisX()->setTickLabelPosition($elementTickLabelPosition->getAttribute('val'));
@@ -1395,6 +1395,8 @@ class PowerPoint2007 implements ReaderInterface
                                 $oShape->getPlotArea()->getAxisX()->setOutline($outline);
                             }
                         }
+
+                        $this->loadAxisText($xmlReader, $oElement, $oShape->getPlotArea()->getAxisX());
                     }
 
                     if ($oElement = $xmlReader->getElement('/c:chartSpace/c:chart/c:plotArea/c:valAx')) {
@@ -1412,7 +1414,7 @@ class PowerPoint2007 implements ReaderInterface
                             $oShape->getPlotArea()->getAxisY()->setMajorTickMark($elementMajorTickMark->getAttribute('val'));
                         }
                         if ($elementMinorTickMark = $xmlReader->getElement('c:minorTickMark', $oElement)) {
-                            $oShape->getPlotArea()->getAxisY()->setMajorTickMark($elementMinorTickMark->getAttribute('val'));
+                            $oShape->getPlotArea()->getAxisY()->setMinorTickMark($elementMinorTickMark->getAttribute('val'));
                         }
                         if ($elementTickLabelPosition = $xmlReader->getElement('c:tickLblPos', $oElement)) {
                             $oShape->getPlotArea()->getAxisY()->setTickLabelPosition($elementTickLabelPosition->getAttribute('val'));
@@ -1420,11 +1422,13 @@ class PowerPoint2007 implements ReaderInterface
                         if ($elementCrosses = $xmlReader->getElement('c:crosses', $oElement)) {
                             $oShape->getPlotArea()->getAxisY()->setCrossesAt($elementCrosses->getAttribute('val'));
                         }
-                        if ($elementFill = $xmlReader->getElement('c:spPr/a:ln', $oElement)) {
+                        if ($elementFill = $xmlReader->getElement('c:spPr', $oElement)) {
                             if ($outline = $this->loadStyleOutline($xmlReader, $elementFill)) {
                                 $oShape->getPlotArea()->getAxisY()->setOutline($outline);
                             }
                         }
+
+                        $this->loadAxisText($xmlReader, $oElement, $oShape->getPlotArea()->getAxisY());
                     }
 
                     if ($oElement = $xmlReader->getElement('/c:chartSpace/c:chart/c:legend')) {
@@ -1800,6 +1804,75 @@ class PowerPoint2007 implements ReaderInterface
         }
 
         return null;
+    }
+
+    /**
+     * The `a:defRPr` a chart writes for a font: the same attributes a run carries, on an element
+     * that styles a whole paragraph rather than a piece of one.
+     */
+    protected function loadStyleFont(XMLReader $xmlReader, DOMElement $oElement, Font $oFont): void
+    {
+        if ($oElement->hasAttribute('b')) {
+            $oFont->setBold('true' == $oElement->getAttribute('b') || '1' == $oElement->getAttribute('b'));
+        }
+        if ($oElement->hasAttribute('i')) {
+            $oFont->setItalic('true' == $oElement->getAttribute('i') || '1' == $oElement->getAttribute('i'));
+        }
+        if ($oElement->hasAttribute('strike')) {
+            $oFont->setStrikethrough($oElement->getAttribute('strike'));
+        }
+        if ($oElement->hasAttribute('u')) {
+            $oFont->setUnderline($oElement->getAttribute('u'));
+        }
+        if ($oElement->hasAttribute('sz')) {
+            $oFont->setSize((int) ((int) $oElement->getAttribute('sz') / 100));
+        }
+        if ($oElement->hasAttribute('baseline')) {
+            $oFont->setBaseline((int) $oElement->getAttribute('baseline'));
+        }
+        $oElementColor = $xmlReader->getElement('a:solidFill/a:srgbClr', $oElement);
+        if ($oElementColor instanceof DOMElement) {
+            $oFont->setColor($this->loadStyleColor($xmlReader, $oElementColor));
+        }
+        $oElementLatin = $xmlReader->getElement('a:latin', $oElement);
+        if ($oElementLatin instanceof DOMElement && $oElementLatin->hasAttribute('typeface')) {
+            $oFont->setName($oElementLatin->getAttribute('typeface'));
+        }
+    }
+
+    /**
+     * The text of an axis: the title it was given, how that title is turned and styled, and the
+     * font of the tick labels. All four are written by this library and none was read back.
+     *
+     * @param DOMElement $oElement the `c:catAx` or `c:valAx` element of the axis
+     */
+    protected function loadAxisText(XMLReader $xmlReader, DOMElement $oElement, Chart\Axis $oAxis): void
+    {
+        $oElementTitle = $xmlReader->getElement('c:title/c:tx/c:rich', $oElement);
+        if ($oElementTitle instanceof DOMElement) {
+            $title = '';
+            foreach ($xmlReader->getElements('a:p/a:r/a:t', $oElementTitle) as $oElementText) {
+                $title .= $oElementText->nodeValue;
+            }
+            if ('' !== $title) {
+                $oAxis->setTitle($title);
+            }
+
+            $oElementBody = $xmlReader->getElement('a:bodyPr', $oElementTitle);
+            if ($oElementBody instanceof DOMElement && $oElementBody->hasAttribute('rot')) {
+                $oAxis->setTitleRotation((int) CommonDrawing::angleToDegrees((int) $oElementBody->getAttribute('rot')));
+            }
+
+            $oElementFont = $xmlReader->getElement('a:p/a:pPr/a:defRPr', $oElementTitle);
+            if ($oElementFont instanceof DOMElement && null !== $oAxis->getFont()) {
+                $this->loadStyleFont($xmlReader, $oElementFont, $oAxis->getFont());
+            }
+        }
+
+        $oElementFont = $xmlReader->getElement('c:txPr/a:p/a:pPr/a:defRPr', $oElement);
+        if ($oElementFont instanceof DOMElement && null !== $oAxis->getTickLabelFont()) {
+            $this->loadStyleFont($xmlReader, $oElementFont, $oAxis->getTickLabelFont());
+        }
     }
 
     protected function loadRels(string $fileRels): void

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -27,6 +27,7 @@ use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\PresentationProperties;
 use PhpOffice\PhpPresentation\Reader\PowerPoint2007;
 use PhpOffice\PhpPresentation\Shape\Chart;
+use PhpOffice\PhpPresentation\Shape\Chart\Axis;
 use PhpOffice\PhpPresentation\Shape\Chart\Series;
 use PhpOffice\PhpPresentation\Shape\Chart\Type\Bar;
 use PhpOffice\PhpPresentation\Shape\Drawing\Gd;
@@ -1149,6 +1150,86 @@ class PowerPoint2007Test extends TestCase
 
         self::assertEquals(Fill::FILL_NONE, $seriesRead->getDataPointFill(1)->getFillType());
         self::assertEquals(Fill::FILL_NONE, $seriesRead->getDataPointOutline(1)->getFill()->getFillType());
+    }
+
+    public function testAxisTextIsReadBack(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oBar = new Bar();
+        $oBar->addSeries(new Series('Downloads', ['Jan' => '1', 'Feb' => '5']));
+        $oShape = $oPhpPresentation->getActiveSlide()->createChartShape();
+        $oShape->getPlotArea()->setType($oBar);
+
+        $oAxisX = $oShape->getPlotArea()->getAxisX();
+        $oAxisX->setTitle('Quarter')->setTitleRotation(45);
+        $oAxisX->getFont()->setName('Georgia')->setSize(18)->setBold(true)->setItalic(true)
+            ->setUnderline(Font::UNDERLINE_DOUBLE)->getColor()->setRGB('FF0000');
+        $oAxisX->getTickLabelFont()->setName('Verdana')->setSize(7)->getColor()->setRGB('00AA00');
+        $oShape->getPlotArea()->getAxisY()->setTitle('Downloads');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(Chart::class, $arrayShape[0]);
+        $oAxisXRead = $arrayShape[0]->getPlotArea()->getAxisX();
+
+        self::assertEquals('Quarter', $oAxisXRead->getTitle());
+        self::assertEquals(45, $oAxisXRead->getTitleRotation());
+
+        $oFont = $oAxisXRead->getFont();
+        self::assertInstanceOf(Font::class, $oFont);
+        self::assertEquals('Georgia', $oFont->getName());
+        self::assertEquals(18, $oFont->getSize());
+        self::assertTrue($oFont->isBold());
+        self::assertTrue($oFont->isItalic());
+        self::assertEquals(Font::UNDERLINE_DOUBLE, $oFont->getUnderline());
+        self::assertEquals('FF0000', $oFont->getColor()->getRGB());
+
+        // the two fonts of an axis are separate: the title is styled by one, the labels by the other
+        $oTickLabelFont = $oAxisXRead->getTickLabelFont();
+        self::assertInstanceOf(Font::class, $oTickLabelFont);
+        self::assertEquals('Verdana', $oTickLabelFont->getName());
+        self::assertEquals(7, $oTickLabelFont->getSize());
+        self::assertFalse($oTickLabelFont->isBold());
+        self::assertEquals('00AA00', $oTickLabelFont->getColor()->getRGB());
+
+        self::assertEquals('Downloads', $arrayShape[0]->getPlotArea()->getAxisY()->getTitle());
+    }
+
+    public function testAxisTickMarksAndOutlineAreReadBack(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oBar = new Bar();
+        $oBar->addSeries(new Series('Downloads', ['Jan' => '1']));
+        $oShape = $oPhpPresentation->getActiveSlide()->createChartShape();
+        $oShape->getPlotArea()->setType($oBar);
+
+        foreach ([$oShape->getPlotArea()->getAxisX(), $oShape->getPlotArea()->getAxisY()] as $oAxis) {
+            $oAxis->setMajorTickMark(Axis::TICK_MARK_OUTSIDE);
+            $oAxis->setMinorTickMark(Axis::TICK_MARK_INSIDE);
+            $oAxis->getOutline()->setWidth(3)->getFill()
+                ->setFillType(Fill::FILL_SOLID)
+                ->setStartColor(new Color('FF00FF00'));
+        }
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(Chart::class, $arrayShape[0]);
+
+        // both axes, because the two blocks that read them are copies of one another
+        foreach ([$arrayShape[0]->getPlotArea()->getAxisX(), $arrayShape[0]->getPlotArea()->getAxisY()] as $oAxis) {
+            self::assertEquals(Axis::TICK_MARK_OUTSIDE, $oAxis->getMajorTickMark());
+            self::assertEquals(Axis::TICK_MARK_INSIDE, $oAxis->getMinorTickMark());
+            self::assertEquals(3, $oAxis->getOutline()->getWidth());
+            self::assertEquals('00FF00', $oAxis->getOutline()->getFill()->getStartColor()->getRGB());
+        }
     }
 
     public function testShapeAskingForNoFillIsReadBack(): void


### PR DESCRIPTION
### Description

`c:catAx` and `c:valAx` were read for six things -- the orientation, whether the axis is deleted, the two tick marks, the label position and where it crosses -- and for none of the text. Round trip of a deck that styles its category axis:

| | before | after |
|---|---|---|
| `getTitle()` | `Axis Title` (the constructor default) | `Quarter` |
| `getTitleRotation()` | `0` | `45` |
| `getFont()` | Calibri 10pt black | Georgia 18pt bold italic double-underlined red |
| `getTickLabelFont()` | Calibri 10pt black | Verdana 7pt green |

Nothing else reads them either: the ODPresentation Reader does not read charts at all.

`a:defRPr` is the run properties of a run that does not exist yet, so it is read the way a run is read -- weight, italic, underline, strikethrough, size, baseline, colour and typeface -- into the two fonts an axis carries. The title text is every `a:t` of the rich text, and the rotation is the `rot` of its `a:bodyPr`. Both axes go through one `loadAxisText()`, because the two blocks that read them are copies of one another.

Which is how two more came to light, in the copied halves:

* **`c:minorTickMark` was assigned with `setMajorTickMark()`**, on both axes. A file written with `major=out, minor=in` came back as `major=in, minor=none`: the minor mark overwrote the major one and was itself lost.
* **The value axis passed `c:spPr/a:ln` to `loadStyleOutline()`**, which looks for an `a:ln` inside what it is given, so it never found one. An axis line written 3px green came back at the default 1px black. The category axis passes `c:spPr`, and that is the one that is right.

Both are one-line fixes in the blocks this PR was already rewriting, so they are in it; each has its own assertion.

Not touched, for the record: the writer's own slip at `PptCharts.php:2510`, where `strike` in the tick-label block reads `getFont()` while its seven neighbours read `getTickLabelFont()`. The Reader now faithfully reads back what that writes, which is how it showed up. It belongs with the larger question of which font an axis is styled with.

**One line of `phpmd.xml.dist`.** `Chart\Axis` in the signature of `loadAxisText()` is the class's 38th dependency, and the ceiling was 38, so the mess detector fails on the type hint alone. I raised it to 39, the way this file has been raised five times before (29 → 30 → 31 → 32 → 35 → 38, the last of them in #856). If you would rather not move it, the alternative is to drop the type declaration and leave only a `@param` -- say the word and I will.

### Checklist:

- [x] My CI is :green_circle:
  > 818 tests, 7247 assertions; phpstan clean; php-cs-fixer `0 of 276`.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `PowerPoint2007Test::testAxisTextIsReadBack` (title, rotation, both fonts, and that the two fonts stay separate) and `::testAxisTickMarksAndOutlineAreReadBack` (both axes). Checked by breaking each of the four fixes in turn -- suppressing the title, misspelling the tick-label XPath, restoring `setMajorTickMark()` and restoring `c:spPr/a:ln` -- every one fails an assertion.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > Reader behaviour; no documented API changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
