### PR TITLE
PowerPoint2007 : Fixed the charset of a font being written in hexadecimal

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -25,6 +25,7 @@
 - Fixed a file with no measurable size (an SVG, a video) warning on `setPath()`, and a fresh object being looked up in the hash table under a null key, by [@dkulyk](http://github.com/dkulyk) in [#920](https://github.com/PHPOffice/PHPPresentation/pull/920)
 - ODPresentation Writer and Reader : Fixed the italic, the bold, the underline and the strikethrough of a font being dropped on save and not read back, in a chart style and in a text run alike, by [@dkulyk](http://github.com/dkulyk) in [#917](https://github.com/PHPOffice/PHPPresentation/pull/917)
 - ODPresentation Writer : Fixed the tick labels of a chart axis being styled from `getFont()` rather than `getTickLabelFont()`, which is the font the PowerPoint2007 Writer uses for them, and fixed the strikethrough of those labels being read from the wrong font in the PowerPoint2007 Writer, by [@dkulyk](http://github.com/dkulyk) in [#923](https://github.com/PHPOffice/PHPPresentation/pull/923)
+- PowerPoint2007 Writer and Reader : Fixed the charset of a font being written in hexadecimal, which the schema forbids above 127 and the Reader read as decimal either way, by [@dkulyk](http://github.com/dkulyk) in [#919](https://github.com/PHPOffice/PHPPresentation/pull/919)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1623,7 +1623,8 @@ class PowerPoint2007 implements ReaderInterface
                             $oText->getFont()->setPitchFamily((int) $oElementFont->getAttribute('pitchFamily'));
                         }
                         if ($oElementFont->hasAttribute('charset')) {
-                            $oText->getFont()->setCharset((int) $oElementFont->getAttribute('charset'));
+                            $charset = (int) $oElementFont->getAttribute('charset');
+                            $oText->getFont()->setCharset($charset < 0 ? $charset + 256 : $charset);
                         }
                     }
 

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -734,10 +734,13 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
             'pitchFamily',
             $element->getFont()->getPitchFamily()
         );
+        // the schema calls this a byte, so the charsets above 127 are spelled as the
+        // negative value that byte holds: Arabic is 178 to the model and -78 to the file
+        $charset = $element->getFont()->getCharset();
         $objWriter->writeAttributeIf(
-            $element->getFont()->getCharset() !== Font::CHARSET_DEFAULT,
+            $charset !== Font::CHARSET_DEFAULT,
             'charset',
-            dechex($element->getFont()->getCharset())
+            (string) ($charset > 127 ? $charset - 256 : $charset)
         );
         $objWriter->endElement();
 

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -39,6 +39,7 @@ use PhpOffice\PhpPresentation\Style\Color;
 use PhpOffice\PhpPresentation\Style\Fill;
 use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Writer\PowerPoint2007 as PowerPoint2007Writer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1215,6 +1216,45 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals('Budget', $arrayShape[0]->getName());
         self::assertEquals('Budget spent to date: 45% of 1.2M EUR', $arrayShape[0]->getDescription());
         self::assertEquals('', $arrayShape[1]->getDescription());
+    }
+
+    /**
+     * @dataProvider dataProviderCharsets
+     */
+    #[DataProvider('dataProviderCharsets')]
+    public function testFontCharsetSurvivesTheRoundTrip(int $charset): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oRun = $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('MyText');
+        $oRun->getFont()->setCharset($charset);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        $arrayElement = $arrayShape[0]->getParagraph()->getRichTextElements();
+
+        self::assertEquals($charset, $arrayElement[0]->getFont()->getCharset());
+    }
+
+    /**
+     * @return array<int, array<int, int>>
+     */
+    public static function dataProviderCharsets(): array
+    {
+        return [
+            [Font::CHARSET_DEFAULT],
+            [0],
+            [18],
+            // the ones that do not fit in a byte, which the file spells as negative
+            [134],
+            [178],
+            [204],
+            [255],
+        ];
     }
 
     public function testSlideName(): void

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -995,7 +995,7 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $latinElement, 'typeface');
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'typeface', 'Calibri');
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $latinElement, 'charset');
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'charset', '12');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'charset', '18');
         $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $eastAsianElement);
         $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $complexScriptElement);
         $this->assertIsSchemaECMA376Valid();
@@ -1008,7 +1008,7 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $eastAsianElement, 'typeface');
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $eastAsianElement, 'typeface', 'Calibri');
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $eastAsianElement, 'charset');
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $eastAsianElement, 'charset', '12');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $eastAsianElement, 'charset', '18');
         $this->assertZipXmlElementNotExists('ppt/slides/slide1.xml', $complexScriptElement);
         $this->assertIsSchemaECMA376Valid();
 
@@ -1021,7 +1021,19 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $complexScriptElement, 'typeface');
         $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $complexScriptElement, 'typeface', 'Calibri');
         $this->assertZipXmlAttributeExists('ppt/slides/slide1.xml', $complexScriptElement, 'charset');
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $complexScriptElement, 'charset', '12');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $complexScriptElement, 'charset', '18');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    public function testRichTextRunFontCharsetAboveAByte(): void
+    {
+        $latinElement = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr/a:latin';
+
+        $oRun = $this->oPresentation->getActiveSlide()->createRichTextShape()->createTextRun('MyText');
+        // Arabic, which is 178 in the table the model holds and does not fit in a byte
+        $oRun->getFont()->setCharset(178);
+
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $latinElement, 'charset', '-78');
         $this->assertIsSchemaECMA376Valid();
     }
 


### PR DESCRIPTION
### Description

`CT_TextFont@charset` is an `xsd:byte`. The Writer spells it in hexadecimal (`AbstractSlide::writeRunStyles()`), the Reader reads it as decimal (`PowerPoint2007::loadParagraph()`), and the schema allows only the decimal form. Nobody agrees with anybody.

#### What is wrong

A charset never comes back as it went in:

| `setCharset()` | written | read back |
|---|---|---|
| 18 | `"12"` | 12 |
| 134 (GB2312) | `"86"` | 86 |
| 178 (Arabic) | `"b2"` | 0 |

The last row is the worse half: `b2` is not a value `xsd:byte` allows, so the file is invalid. `assertIsSchemaECMA376Valid()` would have said so, had any test set a charset above 127 — the one test there is sets 18 and asserts the `"12"`, which is how this survived.

#### What PowerPoint writes

Measured on a deck saved by PowerPoint, one run in Traditional Arabic and one in Wingdings:

```xml
<a:latin typeface="Traditional Arabic" panose="02020603050405020304" pitchFamily="18" charset="-78"/>
<a:cs    typeface="Traditional Arabic" panose="02020603050405020304" pitchFamily="18" charset="-78"/>
<a:latin typeface="Wingdings" pitchFamily="2" charset="2"/>
```

−78 is 178 as a signed byte; 2 needs no wrapping. Other decks in the same sample carry `charset="-122"` (134, GB2312) and `charset="-120"` (136, Big5). So the file spells the Windows charset ids above 127 as the negative byte they occupy, which is what the schema requires.

#### The change

The Writer writes the decimal byte — negative above 127 — and the Reader turns it back into the number the model holds. Nothing else moves; `Font::setCharset()` keeps taking the id the caller knows (178 for Arabic), which is what `Font::CHARSET_DEFAULT` and every Windows table mean by it.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `PptSlidesTest::testRichTextRunFontCharset()` now asserts the decimal it should always have asserted; `::testRichTextRunFontCharsetAboveAByte()` covers the byte that wraps, schema validation included; `PowerPoint2007Test::testFontCharsetSurvivesTheRoundTrip()` covers the pair over seven charsets (1, 0, 18, 134, 178, 204, 255). Each half was checked by breaking it: with the old Writer the wrapping test fails, with the old Reader four of the seven round trips fail.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > No documented API changed — `setCharset()` takes the same numbers it always did.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
