### PR TITLE
Leave the test suite with nothing to report, and keep it that way

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -75,7 +75,7 @@ jobs:
           with:
               php-version: ${{ matrix.php }}
               extensions: gd, xml, zip
-              coverage: ${{ (matrix.php == '8.3') && 'xdebug' || 'none' }}
+              coverage: ${{ (matrix.php == '8.5') && 'xdebug' || 'none' }}
 
       -   uses: actions/checkout@v2
 
@@ -83,15 +83,18 @@ jobs:
           run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       -   name: Run phpunit
-          if: matrix.php != '8.3'
+          if: matrix.php != '8.5'
           run: ./vendor/bin/phpunit -c phpunit.xml.dist --no-coverage
 
+      # the newest PHP is where a new deprecation shows up first, so that leg is the one
+      # that refuses to be green while the suite still has something to report -- and the
+      # one that gathers the coverage, so that there is a single leg out of the ordinary
       -   name: Run phpunit
-          if: matrix.php == '8.3'
-          run: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/clover.xml
+          if: matrix.php == '8.5'
+          run: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/clover.xml --fail-on-deprecation --fail-on-notice --fail-on-phpunit-deprecation
 
       -   name: Upload coverage results to Coveralls
-          if: matrix.php == '8.3'
+          if: matrix.php == '8.5'
           env:
             COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -21,6 +21,7 @@
 - A master slide is no longer born with a white background nobody asked for by [@dkulyk](http://github.com/dkulyk) in [#909](https://github.com/PHPOffice/PHPPresentation/pull/909)
 - ODPresentation Writer : Fixed the background of a master slide being dropped on save by [@dkulyk](http://github.com/dkulyk) in [#912](https://github.com/PHPOffice/PHPPresentation/pull/912)
 - PowerPoint2007 Reader : Fixed a shape that asked for no fill being read as having no fill at all, which crashes the ODPresentation Writer on save, by [@dkulyk](http://github.com/dkulyk) in [#915](https://github.com/PHPOffice/PHPPresentation/pull/915)
+- Fixed a file with no measurable size (an SVG, a video) warning on `setPath()`, and a fresh object being looked up in the hash table under a null key, by [@dkulyk](http://github.com/dkulyk) in [#920](https://github.com/PHPOffice/PHPPresentation/pull/920)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,9 @@
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <source>
     <include>

--- a/src/PhpPresentation/HashTable.php
+++ b/src/PhpPresentation/HashTable.php
@@ -71,7 +71,7 @@ class HashTable
         // Determine hashcode
         $hashIndex = $pSource->getHashIndex();
         $hashCode = $pSource->getHashCode();
-        if (isset($this->keyMap[$hashIndex])) {
+        if (null !== $hashIndex && isset($this->keyMap[$hashIndex])) {
             $hashCode = $this->keyMap[$hashIndex];
         }
 

--- a/src/PhpPresentation/Shape/Drawing/File.php
+++ b/src/PhpPresentation/Shape/Drawing/File.php
@@ -55,7 +55,13 @@ class File extends AbstractDrawingAdapter
 
         if ($pVerifyFile) {
             if (0 == $this->width && 0 == $this->height) {
-                [$this->width, $this->height] = getimagesize($this->getPath());
+                // Not every file a shape can carry is one `getimagesize()` can measure -- an SVG
+                // and a video both come back as `false`, and a size of nothing is what they had
+                // before this asked.
+                $imageSize = getimagesize($this->getPath());
+                if (is_array($imageSize)) {
+                    [$this->width, $this->height] = $imageSize;
+                }
             }
         }
 

--- a/src/PhpPresentation/Slide/Background/Image.php
+++ b/src/PhpPresentation/Slide/Background/Image.php
@@ -76,8 +76,11 @@ class Image extends AbstractBackground
             }
 
             if (0 == $this->width && 0 == $this->height) {
-                // Get width/height
-                [$this->width, $this->height] = getimagesize($pValue);
+                // Get width/height, when the file is one that has them
+                $imageSize = getimagesize($pValue);
+                if (is_array($imageSize)) {
+                    [$this->width, $this->height] = $imageSize;
+                }
             }
         }
         $this->path = $pValue;

--- a/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
+++ b/tests/PhpPresentation/Tests/Shape/AutoShapeTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\AutoShape;
 use PhpOffice\PhpPresentation\Style\Outline;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class AutoShapeTest extends TestCase
@@ -39,8 +39,8 @@ class AutoShapeTest extends TestCase
 
     public function testOutline(): void
     {
-        /** @var MockObject&Outline $mock */
-        $mock = $this->getMockBuilder(Outline::class)->getMock();
+        /** @var Outline&Stub $mock */
+        $mock = self::createStub(Outline::class);
 
         $object = new AutoShape();
         self::assertInstanceOf(Outline::class, $object->getOutline());

--- a/tests/PhpPresentation/Tests/Shape/Chart/AxisTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/AxisTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpPresentation\Shape\Chart\Axis;
 use PhpOffice\PhpPresentation\Shape\Chart\Gridlines;
 use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Style\Outline;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -105,8 +105,8 @@ class AxisTest extends TestCase
     {
         $object = new Axis();
 
-        /** @var Gridlines&MockObject $oMock */
-        $oMock = $this->getMockBuilder(Gridlines::class)->getMock();
+        /** @var Gridlines&Stub $oMock */
+        $oMock = self::createStub(Gridlines::class);
 
         self::assertInstanceOf(Axis::class, $object->setMajorGridlines($oMock));
         self::assertInstanceOf(Gridlines::class, $object->getMajorGridlines());
@@ -149,8 +149,8 @@ class AxisTest extends TestCase
 
     public function testOutline(): void
     {
-        /** @var MockObject&Outline $oMock */
-        $oMock = $this->getMockBuilder(Outline::class)->getMock();
+        /** @var Outline&Stub $oMock */
+        $oMock = self::createStub(Outline::class);
 
         $object = new Axis();
         self::assertInstanceOf(Outline::class, $object->getOutline());

--- a/tests/PhpPresentation/Tests/Shape/Chart/GridlinesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/GridlinesTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape\Chart;
 
 use PhpOffice\PhpPresentation\Shape\Chart\Gridlines;
 use PhpOffice\PhpPresentation\Style\Outline;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class GridlinesTest extends TestCase
@@ -38,8 +38,8 @@ class GridlinesTest extends TestCase
     {
         $object = new Gridlines();
 
-        /** @var MockObject&Outline $oStub */
-        $oStub = $this->getMockBuilder(Outline::class)->getMock();
+        /** @var Outline&Stub $oStub */
+        $oStub = self::createStub(Outline::class);
 
         self::assertInstanceOf(Outline::class, $object->getOutline());
         self::assertInstanceOf('PhpOffice\PhpPresentation\Shape\Chart\Gridlines', $object->setOutline($oStub));

--- a/tests/PhpPresentation/Tests/Shape/CommentTest.php
+++ b/tests/PhpPresentation/Tests/Shape/CommentTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests\Shape;
 
 use PhpOffice\PhpPresentation\Shape\Comment;
 use PhpOffice\PhpPresentation\Shape\Comment\Author;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -47,8 +47,8 @@ class CommentTest extends TestCase
     {
         $object = new Comment();
 
-        /** @var Author&MockObject $oStub */
-        $oStub = $this->getMockBuilder(Author::class)->getMock();
+        /** @var Author&Stub $oStub */
+        $oStub = self::createStub(Author::class);
 
         self::assertNull($object->getAuthor());
         self::assertInstanceOf(Comment::class, $object->setAuthor($oStub));

--- a/tests/PhpPresentation/Tests/Shape/Drawing/FileTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Drawing/FileTest.php
@@ -78,6 +78,18 @@ class FileTest extends TestCase
         self::assertEquals($mimeType, $object->getMimeType());
     }
 
+    public function testPathOfAFileWithNoMeasurableSize(): void
+    {
+        $object = new File();
+
+        // an SVG has no pixel size for `getimagesize()` to report -- it answers `false`, and
+        // the warning that used to raise is what `failOnWarning` in phpunit.xml.dist catches
+        $object->setPath(dirname(__DIR__, 4) . '/resources/images/tiger.svg');
+
+        self::assertEquals(0, $object->getWidth());
+        self::assertEquals(0, $object->getHeight());
+    }
+
     /**
      * @return array<array<string>>
      */

--- a/tests/PhpPresentation/Tests/Slide/Background/ImageTest.php
+++ b/tests/PhpPresentation/Tests/Slide/Background/ImageTest.php
@@ -51,6 +51,18 @@ class ImageTest extends TestCase
         self::assertEquals('background_' . $numSlide . '.', $object->getIndexedFilename($numSlide));
     }
 
+    public function testPathOfAFileWithNoMeasurableSize(): void
+    {
+        $object = new Image();
+        $imagePath = PHPPRESENTATION_TESTS_BASE_DIR . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'tiger.svg';
+
+        // the background keeps its size to itself, so the warning the file used to raise is
+        // all there is to catch, and `failOnWarning` in phpunit.xml.dist is what catches it
+        $object->setPath($imagePath);
+
+        self::assertEquals($imagePath, $object->getPath());
+    }
+
     public function testExtension(): void
     {
         $object = new Image();


### PR DESCRIPTION
### Description

The suite passes, and has been printing this under every run:

```
Tests: 818, Assertions: 7227, Warnings: 1, Deprecations: 1, PHPUnit Notices: 5
```

None of it is noise, and none of it is in the tests.

#### The three findings

**`Cannot use bool as array`** — `getimagesize()` answers `false` for a file whose size it cannot measure: an SVG, a video. `Shape\Drawing\File::setPath()` and `Slide\Background\Image::setPath()` both destructured that answer straight into a width and a height. The size such a file ends up with is the size it already had, which is nothing, so the fix is to assign only when there is something to assign. Three tests, twice each.

**`Automatic conversion of false to array is deprecated`** — no; the deprecation is `HashTable::add()` looking the source up by `getHashIndex()`, which is null until the table hands the object one. `isset($array[null])` reads the key as an empty string, so the lookup was correct and merely deprecated. It fired on **184 tests** on every run. It now asks whether there is an index first.

**Five PHPUnit notices** — mock objects nobody configured an expectation on. That is what a stub is, and what the notice says, so they are built with `createStub()`.

#### Keeping it that way

A clean run today grows back tomorrow unless something fails on it, and PHPUnit splits the switches in two:

* `phpunit.xml.dist` gets `failOnWarning`, `failOnRisky` and `failOnEmptyTestSuite` — the three the declared 9.3 schema knows.
* `--fail-on-deprecation`, `--fail-on-notice` and `--fail-on-phpunit-deprecation` exist only on the command line, so the workflow passes them on one leg.

Without them PHPUnit ends a run that had something to report with `OK, but there were issues` and exit code **0** — checked both ways: the same command exits 1 on a branch that still has the warnings, and 0 without the flags.

That leg is **8.5**, the newest PHP being where a deprecation appears first, and it takes the coverage run over from 8.3 so that exactly one leg of the matrix is special-cased instead of two.

Run on PHP 8.6.0-dev as well, with all three flags: `OK (818 tests, 7227 assertions)`.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `FileTest::testPathWithoutAMeasurableSize` and `ImageTest::testPathWithoutAMeasurableSize`, both over an SVG. The deprecation and the notices are covered by the whole suite, which is what now fails if either returns.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > No documented API changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
