### PR TITLE
DocumentLayout : Convert between units without a layout to hold them

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -9,6 +9,7 @@
 - Added an alternative text (`description`) on every shape, and not only on graphics, by [@dkulyk](http://github.com/dkulyk) in [#898](https://github.com/PHPOffice/PHPPresentation/pull/898)
 - Added the ability to mark a shape as decorative, so that assistive technologies skip it, by [@dkulyk](http://github.com/dkulyk) in [#899](https://github.com/PHPOffice/PHPPresentation/pull/899)
 - Added an outline on the data points of a chart serie, next to the fill they already had, by [@dkulyk](http://github.com/dkulyk) in [#900](https://github.com/PHPOffice/PHPPresentation/pull/900)
+- `DocumentLayout::convertUnit()` is public and static, so a value that belongs to no layout can be converted too, by [@dkulyk](http://github.com/dkulyk) in [#921](https://github.com/PHPOffice/PHPPresentation/pull/921)
 
 ## Bug fixes
 - Fixed adding custom SVGs by [@seanlynchwv](http://github.com/seanlynchwv) in [#881](https://github.com/PHPOffice/PHPPresentation/pull/881)

--- a/docs/usage/presentation.md
+++ b/docs/usage/presentation.md
@@ -264,3 +264,35 @@ $properties->setZoom(3);
 echo $properties->getZoom();
 // Output : 3
 ```
+
+## Slide size
+
+The size of a slide is held by the document layout, in EMU. Both the getters and the setters take
+the unit they should speak in, so a caller never has to convert by hand.
+
+``` php
+<?php
+
+$presentation = new PhpPresentation();
+
+$layout = $presentation->getLayout();
+// A preset : 4/3, 16/9, A4, letter, ... (see DocumentLayout::LAYOUT_*)
+$layout->setDocumentLayout(DocumentLayout::LAYOUT_SCREEN_16X9);
+// Or a size of your own, in the unit of your choice
+$layout->setCX(25.4, DocumentLayout::UNIT_CENTIMETER);
+$layout->setCY(14.29, DocumentLayout::UNIT_CENTIMETER);
+
+// Read it back in any unit : EMU (the default), CENTIMETER, MILLIMETER, INCH, POINT, PIXEL
+echo $layout->getCX(DocumentLayout::UNIT_INCH);
+// Output : 10
+```
+
+The conversion itself is available on its own, for a value that belongs to no layout — the offset
+of a shape, for instance, which is expressed in pixels.
+
+``` php
+<?php
+
+// 2.5 cm, in the pixels a shape is positioned with
+$offsetX = DocumentLayout::convertUnit(2.5, DocumentLayout::UNIT_CENTIMETER, DocumentLayout::UNIT_PIXEL);
+```

--- a/src/PhpPresentation/DocumentLayout.php
+++ b/src/PhpPresentation/DocumentLayout.php
@@ -159,7 +159,7 @@ class DocumentLayout
      */
     public function getCX(string $unit = self::UNIT_EMU): float
     {
-        return $this->convertUnit($this->dimensionX, self::UNIT_EMU, $unit);
+        return self::convertUnit($this->dimensionX, self::UNIT_EMU, $unit);
     }
 
     /**
@@ -167,7 +167,7 @@ class DocumentLayout
      */
     public function getCY(string $unit = self::UNIT_EMU): float
     {
-        return $this->convertUnit($this->dimensionY, self::UNIT_EMU, $unit);
+        return self::convertUnit($this->dimensionY, self::UNIT_EMU, $unit);
     }
 
     /**
@@ -176,7 +176,7 @@ class DocumentLayout
     public function setCX(float $value, string $unit = self::UNIT_EMU): self
     {
         $this->layout = self::LAYOUT_CUSTOM;
-        $this->dimensionX = $this->convertUnit($value, $unit, self::UNIT_EMU);
+        $this->dimensionX = self::convertUnit($value, $unit, self::UNIT_EMU);
 
         return $this;
     }
@@ -187,15 +187,15 @@ class DocumentLayout
     public function setCY(float $value, string $unit = self::UNIT_EMU): self
     {
         $this->layout = self::LAYOUT_CUSTOM;
-        $this->dimensionY = $this->convertUnit($value, $unit, self::UNIT_EMU);
+        $this->dimensionY = self::convertUnit($value, $unit, self::UNIT_EMU);
 
         return $this;
     }
 
     /**
-     * Convert EMUs to differents units.
+     * Convert a value from one unit to another, without a layout to hold it.
      */
-    protected function convertUnit(float $value, string $fromUnit, string $toUnit): float
+    public static function convertUnit(float $value, string $fromUnit, string $toUnit): float
     {
         // Convert from $fromUnit to EMU
         switch ($fromUnit) {

--- a/tests/PhpPresentation/Tests/DocumentLayoutTest.php
+++ b/tests/PhpPresentation/Tests/DocumentLayoutTest.php
@@ -76,6 +76,17 @@ class DocumentLayoutTest extends TestCase
         self::assertEquals(2700000, $object->getCY());
     }
 
+    public function testConvertUnitWithoutALayout(): void
+    {
+        // the point of it being public: a caller who thinks in centimetres has no layout to ask
+        self::assertEquals(914400, DocumentLayout::convertUnit(1, DocumentLayout::UNIT_INCH, DocumentLayout::UNIT_EMU));
+        self::assertEquals(2.54, DocumentLayout::convertUnit(1, DocumentLayout::UNIT_INCH, DocumentLayout::UNIT_CENTIMETER));
+        self::assertEquals(25.4, DocumentLayout::convertUnit(1, DocumentLayout::UNIT_INCH, DocumentLayout::UNIT_MILLIMETER));
+        self::assertEquals(96, DocumentLayout::convertUnit(1, DocumentLayout::UNIT_INCH, DocumentLayout::UNIT_PIXEL));
+        self::assertEquals(72, DocumentLayout::convertUnit(1, DocumentLayout::UNIT_INCH, DocumentLayout::UNIT_POINT));
+        self::assertEquals(1, DocumentLayout::convertUnit(1, DocumentLayout::UNIT_INCH, DocumentLayout::UNIT_INCH));
+    }
+
     public function testCX(): void
     {
         $value = mt_rand(1, 100000);


### PR DESCRIPTION
Closes #590.

### Description

`DocumentLayout::convertUnit()` (`DocumentLayout.php:198`) is the only unit converter the model owns, and it is `protected`. The size of a slide can be read and written in any unit — `getCX(UNIT_CENTIMETER)`, `setCY(14.29, UNIT_CENTIMETER)` — but nothing else in the library can, so a caller placing a shape 2.5 cm from the edge multiplies by 9525 by hand.

The body has no `$this` in it: `self::UNIT_*` constants, and `Drawing::pixelsToEmu()` / `emuToPixels()`. It is already static in everything but the keyword.

```diff
-    protected function convertUnit(float $value, string $fromUnit, string $toUnit): float
+    public static function convertUnit(float $value, string $fromUnit, string $toUnit): float
```

plus `self::convertUnit(...)` at the four call sites (`:162`, `:170`, `:179`, `:190`).

Widening visibility breaks no caller, and `static` breaks no subclass — nothing in the library or in the tests overrides it.

```php
$offsetX = DocumentLayout::convertUnit(2.5, DocumentLayout::UNIT_CENTIMETER, DocumentLayout::UNIT_PIXEL);
```

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `DocumentLayoutTest::testConvertUnitWithoutALayout`, one inch into each of the six units. Checked by putting `protected` back: the test errors out.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > `docs/usage/presentation.md` gains a "Slide size" section — the layout had none — and shows the converter there for a value that belongs to no layout.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
