### PR TITLE
Shape\Drawing\File : Name an image file whose path does not name itself

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -29,6 +29,7 @@
 - PowerPoint2007 Writer and Reader : Fixed the charset of a font being written in hexadecimal, which the schema forbids above 127 and the Reader read as decimal either way, by [@dkulyk](http://github.com/dkulyk) in [#919](https://github.com/PHPOffice/PHPPresentation/pull/919)
 - PowerPoint2007 Reader : Fixed the title of a chart axis, its rotation and the two fonts of the axis not being read back by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
 - PowerPoint2007 Reader : Fixed the minor tick mark of an axis being read into its major tick mark, and the outline of the value axis not being read at all, by [@dkulyk](http://github.com/dkulyk) in [#918](https://github.com/PHPOffice/PHPPresentation/pull/918)
+- Fixed the media part of an image whose path carries no extension being named with a trailing dot, and written under no content type, by [@dkulyk](http://github.com/dkulyk) in [#922](https://github.com/PHPOffice/PHPPresentation/pull/922)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Shape/Drawing/File.php
+++ b/src/PhpPresentation/Shape/Drawing/File.php
@@ -75,7 +75,15 @@ class File extends AbstractDrawingAdapter
 
     public function getExtension(): string
     {
-        return pathinfo($this->getPath(), PATHINFO_EXTENSION);
+        $extension = pathinfo($this->getPath(), PATHINFO_EXTENSION);
+        if ('' !== $extension || !CommonFile::fileExists($this->getPath())) {
+            return $extension;
+        }
+
+        // a path is free to carry no extension; the contents still say what the image is
+        $image = getimagesizefromstring(CommonFile::fileGetContents($this->getPath()));
+
+        return is_array($image) ? (string) image_type_to_extension($image[2], false) : '';
     }
 
     public function getMimeType(): string

--- a/tests/PhpPresentation/Tests/Shape/Drawing/FileTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Drawing/FileTest.php
@@ -55,6 +55,21 @@ class FileTest extends TestCase
         self::assertEmpty($object->getPath());
     }
 
+    public function testPathWithoutAnExtension(): void
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        copy(dirname(__DIR__, 4) . '/resources/images/PhpPresentationLogo.png', $path);
+
+        $object = new File();
+        $object->setPath($path);
+
+        // the name says nothing, so the contents have to
+        self::assertEquals('png', $object->getExtension());
+        self::assertStringEndsWith($object->getImageIndex() . '.png', $object->getIndexedFilename());
+
+        unlink($path);
+    }
+
     public function testPathWithRealFile(): void
     {
         $object = new File();


### PR DESCRIPTION
Closes #603.

### Description

#### What is wrong

`Shape\Drawing\File::getExtension()` derives the extension from the path alone:

```php
return pathinfo($this->getPath(), PATHINFO_EXTENSION);
```

A path is free to carry no extension — an upload stored under its hash, a file from `tempnam()`, an image served from a route — and then the answer is `''`. `getIndexedFilename()` builds the name of the media part out of it, so the part is called `logo1.`, ending in a bare dot. Both writers register content types by extension, so that part is written under none.

#### The change

The contents say what the name does not, and the same call already backs `getMimeType()` a few lines below:

```php
$image = getimagesizefromstring(CommonFile::fileGetContents($this->getPath()));

return is_array($image) ? (string) image_type_to_extension($image[2], false) : '';
```

It runs only when `pathinfo()` came back empty **and** the file exists, so a path that has an extension costs exactly what it cost before — no file is opened.

#### What it does not do

An extensionless SVG stays extensionless. `getimagesizefromstring()` reports nothing for it, and there is nothing else in the file for the decision to rest on. Neighbouring reports #741 and #819 are about the same family of images-loaded-from-content problems and are not touched here.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `FileTest::testPathWithoutAnExtension` — the repository's own PNG copied to a `tempnam()` path, so no binary fixture is added. Checked by putting the one-line `getExtension()` back: the test fails.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > No documented API changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
