### PR TITLE
ODPresentation Writer and Reader : Keep the columns of a text shape

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -42,6 +42,7 @@
 - PowerPoint2007 Writer : Fixed a cell losing its own right and bottom borders whenever it had a neighbour on that side by [@dkulyk](http://github.com/dkulyk) in [#906](https://github.com/PHPOffice/PHPPresentation/pull/906)
 - PowerPoint2007 Reader : Fixed a slide number and a date being read back without the font, size and colour they were written with by [@dkulyk](http://github.com/dkulyk) in [#916](https://github.com/PHPOffice/PHPPresentation/pull/916)
 - Fixed a font set to `null` -- which every font setter accepts -- crashing both Writers on save, by [@dkulyk](http://github.com/dkulyk) in [#924](https://github.com/PHPOffice/PHPPresentation/pull/924)
+- ODPresentation Writer and Reader : Fixed the columns of a text shape being dropped on save and never read back, by [@dkulyk](http://github.com/dkulyk) in [#925](https://github.com/PHPOffice/PHPPresentation/pull/925)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/shapes/richtext.md
+++ b/docs/usage/shapes/richtext.md
@@ -18,7 +18,7 @@ Below are the properties that you can set for a rich text shape.
 - `verticalOverflow`
 - `upright`
 - `vertical`
-- `columns`
+- `columns` see *Columns*
 - `bottomInset` in pixels
 - `leftInset` in pixels
 - `rightInset` in pixels
@@ -34,9 +34,27 @@ Properties that can be set for each paragraphs are as follow.
 - `lineSpacing` see *Line Spacing*
 - `font` <!-- see *[Font](#font)*-->
 
+## Columns
+
+For a rich text, you can lay the text out in more than one column. The spacing between them is
+given in pixels.
+
+Example:
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\RichText;
+
+$richText = new RichText();
+$richText->setColumns(3);
+$columns = $richText->getColumns();
+```
+
 ## Column Spacing
 
-For a paragraph, you can define the column spacing.
+For a rich text, you can define the spacing between its columns, in pixels. It has no effect on a
+shape left with the single column it starts with.
 
 Example:
 

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -88,7 +88,7 @@ class ODPresentation implements ReaderInterface
     protected $oZip;
 
     /**
-     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string}>
+     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, columns: null|int, columnSpacing: null|int, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string}>
      */
     protected $arrayStyles = [];
 
@@ -355,6 +355,18 @@ class ODPresentation implements ReaderInterface
                     $oShadow->setDistance(CommonDrawing::centimetersToPixels($distance));
                 }
             }
+            // Read Columns
+            $nodeColumns = $this->oXMLReader->getElement('style:columns', $nodeGraphicProps);
+            if ($nodeColumns instanceof DOMElement) {
+                if ($nodeColumns->hasAttribute('fo:column-count')) {
+                    $columns = (int) $nodeColumns->getAttribute('fo:column-count');
+                }
+                if ($nodeColumns->hasAttribute('fo:column-gap')) {
+                    $columnSpacing = CommonDrawing::centimetersToPixels(
+                        (float) substr($nodeColumns->getAttribute('fo:column-gap'), 0, -2)
+                    );
+                }
+            }
             // Read Fill
             if ($nodeGraphicProps->hasAttribute('draw:fill')) {
                 $value = $nodeGraphicProps->getAttribute('draw:fill');
@@ -608,6 +620,8 @@ class ODPresentation implements ReaderInterface
         $this->arrayStyles[$keyStyle] = [
             'alignment' => $oAlignment ?? null,
             'background' => $oBackground ?? null,
+            'columns' => $columns ?? null,
+            'columnSpacing' => $columnSpacing ?? null,
             'fill' => $oFill ?? null,
             'font' => $oFont ?? null,
             'shadow' => $oShadow ?? null,
@@ -757,6 +771,18 @@ class ODPresentation implements ReaderInterface
         $oShape->setHeight($oNodeFrame->hasAttribute('svg:height') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:height'), 0, -2)) : 0);
         $oShape->setOffsetX($oNodeFrame->hasAttribute('svg:x') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:x'), 0, -2)) : 0);
         $oShape->setOffsetY($oNodeFrame->hasAttribute('svg:y') ? CommonDrawing::centimetersToPixels((float) substr($oNodeFrame->getAttribute('svg:y'), 0, -2)) : 0);
+
+        if ($oNodeFrame->hasAttribute('draw:style-name')) {
+            $keyStyle = $oNodeFrame->getAttribute('draw:style-name');
+            if (isset($this->arrayStyles[$keyStyle])) {
+                if (null !== $this->arrayStyles[$keyStyle]['columns']) {
+                    $oShape->setColumns($this->arrayStyles[$keyStyle]['columns']);
+                }
+                if (null !== $this->arrayStyles[$keyStyle]['columnSpacing']) {
+                    $oShape->setColumnSpacing($this->arrayStyles[$keyStyle]['columnSpacing']);
+                }
+            }
+        }
 
         foreach ($this->oXMLReader->getElements('draw:text-box/*', $oNodeFrame) as $oNodeParagraph) {
             $this->levelParagraph = 0;

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -1079,6 +1079,17 @@ class Content extends AbstractDecoratorWriter
         }
 
         $objWriter->writeAttribute('fo:wrap-option', 'wrap');
+        // style:graphic-properties > style:columns
+        // An element rather than an attribute, so it is written after every attribute of the block
+        if ($shape->getColumns() > 1) {
+            $objWriter->startElement('style:columns');
+            $objWriter->writeAttribute('fo:column-count', $shape->getColumns());
+            $objWriter->writeAttribute(
+                'fo:column-gap',
+                number_format(CommonDrawing::pixelsToCentimeters($shape->getColumnSpacing()), 3, '.', '') . 'cm'
+            );
+            $objWriter->endElement();
+        }
         // > style:graphic-properties
         $objWriter->endElement();
         // > style:style

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1304,4 +1304,28 @@ class ODPresentationTest extends TestCase
         self::assertFalse($oHyperlink->isInternal());
         self::assertEquals('https://github.com/PHPOffice/PHPPresentation/', $oHyperlink->getUrl());
     }
+
+    public function testTextColumns(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('AAAA');
+        $oShape->setColumns(3)->setColumnSpacing(20);
+        // and a second shape that never asked for columns, to pin the default
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('BBBB');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertEquals(3, $arrayShape[0]->getColumns());
+        // the gap survives the trip through `fo:column-gap`, which is a length in centimetres
+        self::assertEquals(20, $arrayShape[0]->getColumnSpacing());
+        self::assertInstanceOf(RichText::class, $arrayShape[1]);
+        self::assertEquals(1, $arrayShape[1]->getColumns());
+        self::assertEquals(0, $arrayShape[1]->getColumnSpacing());
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -1603,4 +1603,25 @@ class ContentTest extends PhpPresentationTestCase
             ],
         ];
     }
+
+    public function testRichTextColumns(): void
+    {
+        $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();
+        $oRichText->createTextRun('AAA');
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'gr1\']/style:graphic-properties/style:columns';
+
+        // a single column is the default, and says nothing
+        $this->assertZipXmlElementNotExists('content.xml', $element);
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        $this->resetPresentationFile();
+        $oRichText->setColumns(3)->setColumnSpacing(20);
+
+        $this->assertZipXmlElementExists('content.xml', $element);
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:column-count', '3');
+        // 20 pixels, as the gap is measured everywhere else in the model
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:column-gap', '0.529cm');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
 }


### PR DESCRIPTION
`RichText::setColumns()` and `setColumnSpacing()` are listed in [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/master/docs/usage/shapes/richtext.md) as properties of a rich-text shape, with no note that either is writer-specific. In the whole of `src/` they had exactly two readers, and both were the PowerPoint2007 Writer:

```
Writer/PowerPoint2007/AbstractSlide.php:307   if ($shape->getColumns() != 1) {
Writer/PowerPoint2007/AbstractSlide.php:308       writeAttribute('numCol', $shape->getColumns());
Writer/PowerPoint2007/AbstractSlide.php:309       writeAttribute('spcCol', pixelsToEmu($shape->getColumnSpacing()));
```

The ODPresentation Writer never asked for them. One shape, `setColumns(3)->setColumnSpacing(20)`, saved through both writers before this change:

```
PPTX  <a:bodyPr … numCol="3" spcCol="190500">
ODP   no style:columns anywhere; the frame's graphic style is
      <style:style style:name="gr1" style:family="graphic" style:parent-style-name="standard">
        <style:graphic-properties style:mirror="none" draw:fill="none" draw:fill-color="#000000"
          draw:stroke="none" fo:wrap-option="wrap"/>
      </style:style>
```

The setter accepts, the model keeps, one writer honours it and the other drops it without a word.

### This is not a format limitation

ODF 1.2 has the feature: `style:columns` carries `fo:column-count` (required) and `fo:column-gap` (optional), and it is a legal child of `style:graphic-properties` — which is exactly the element `writeTxtStyle()` already opens for the frame's own `gr{shapeId}` style. It is an element rather than an attribute, so it is written after the attributes of that block. A shape left with the single column it starts with writes nothing, which is the same guard the PowerPoint2007 Writer uses.

```xml
<style:graphic-properties style:mirror="none" … fo:wrap-option="wrap">
  <style:columns fo:column-count="3" fo:column-gap="0.529cm"/>
</style:graphic-properties>
```

### The Reader is the other half

`loadShapeRichText()` read the frame's geometry and its paragraphs and never looked at `draw:style-name` at all — so the graphic style of a text frame was parsed into `arrayStyles` and then ignored, while `loadShapeDrawing()` next to it has been reading its own style for shadow and fill all along. It now takes the two values back out of that map.

That makes the round trip exact: 20 pixels of gap are written as `0.529cm` and read back as 20, since `centimetersToPixels()` rounds.

### Tests

- `ContentTest::testRichTextColumns` — a single-column shape writes no `style:columns`; a three-column one writes the count and the gap. Both states validate against the ODF 1.2 schema.
- `ODPresentationTest::testTextColumns` — write, read, compare, with a second shape that never asked for columns to pin the default.

Suite is green — 880 tests, 7649 assertions, under `--fail-on-warning --fail-on-notice --fail-on-deprecation --fail-on-phpunit-deprecation`. PHPStan and PHP-CS-Fixer both clean.

No BC: a deck that never called `setColumns()` writes exactly what it wrote before.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `ContentTest::testRichTextColumns` — a single-column shape writes no `style:columns`, a three-column one writes the count and the gap; both states are checked against the ODF 1.2 schema. `ODPresentationTest::testTextColumns` — write, read, compare, with a second shape that never asked for columns to pin the default.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > `docs/usage/shapes/richtext.md`: `columns` had a line in the property list and no section of its own, and `columnSpacing` said "for a paragraph" where it belongs to the shape.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
