### PR TITLE
Order the columns of a text shape, instead of always left to right

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -43,6 +43,7 @@
 - PowerPoint2007 Reader : Fixed a slide number and a date being read back without the font, size and colour they were written with by [@dkulyk](http://github.com/dkulyk) in [#916](https://github.com/PHPOffice/PHPPresentation/pull/916)
 - Fixed a font set to `null` -- which every font setter accepts -- crashing both Writers on save, by [@dkulyk](http://github.com/dkulyk) in [#924](https://github.com/PHPOffice/PHPPresentation/pull/924)
 - ODPresentation Writer and Reader : Fixed the columns of a text shape being dropped on save and never read back, by [@dkulyk](http://github.com/dkulyk) in [#925](https://github.com/PHPOffice/PHPPresentation/pull/925)
+- Fixed the columns of a text shape always being written left to right, and added `RichText::setColumnsRTL()` to say the order outright, by [@dkulyk](http://github.com/dkulyk) in [#926](https://github.com/PHPOffice/PHPPresentation/pull/926)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/docs/usage/shapes/richtext.md
+++ b/docs/usage/shapes/richtext.md
@@ -19,6 +19,7 @@ Below are the properties that you can set for a rich text shape.
 - `upright`
 - `vertical`
 - `columns` see *Columns*
+- `columnsRTL` see *Columns*
 - `bottomInset` in pixels
 - `leftInset` in pixels
 - `rightInset` in pixels
@@ -50,6 +51,25 @@ $richText = new RichText();
 $richText->setColumns(3);
 $columns = $richText->getColumns();
 ```
+
+The columns are ordered left to right unless every paragraph of the shape reads right to left, in
+which case they follow the text. `setColumnsRTL()` says the order outright and overrides that:
+
+``` php
+<?php
+
+use PhpOffice\PhpPresentation\Shape\RichText;
+
+$richText = new RichText();
+$richText->setColumns(3);
+// right to left columns, whatever direction the text runs in
+$richText->setColumnsRTL(true);
+// null, the default, takes the order from the paragraphs
+$richText->setColumnsRTL();
+```
+
+`hasColumnsRTL()` gives back what was set, `null` included; `isColumnsRTL()` gives the order the
+writers use, taking it from the paragraphs when nothing was set.
 
 ## Column Spacing
 

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -88,7 +88,7 @@ class ODPresentation implements ReaderInterface
     protected $oZip;
 
     /**
-     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, columns: null|int, columnSpacing: null|int, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string}>
+     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, columns: null|int, columnSpacing: null|int, columnsRTL: null|bool, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string}>
      */
     protected $arrayStyles = [];
 
@@ -367,6 +367,27 @@ class ODPresentation implements ReaderInterface
                     );
                 }
             }
+            // Read the order of the columns
+            if ($nodeGraphicProps->hasAttribute('style:writing-mode')) {
+                switch ($nodeGraphicProps->getAttribute('style:writing-mode')) {
+                    case 'lr-tb':
+                    case 'tb-lr':
+                    case 'lr':
+                        $columnsRTL = false;
+
+                        break;
+                    case 'rl-tb':
+                    case 'tb-rl':
+                    case 'rl':
+                        $columnsRTL = true;
+
+                        break;
+                    case 'tb':
+                    case 'page':
+                    default:
+                        break;
+                }
+            }
             // Read Fill
             if ($nodeGraphicProps->hasAttribute('draw:fill')) {
                 $value = $nodeGraphicProps->getAttribute('draw:fill');
@@ -622,6 +643,7 @@ class ODPresentation implements ReaderInterface
             'background' => $oBackground ?? null,
             'columns' => $columns ?? null,
             'columnSpacing' => $columnSpacing ?? null,
+            'columnsRTL' => $columnsRTL ?? null,
             'fill' => $oFill ?? null,
             'font' => $oFont ?? null,
             'shadow' => $oShadow ?? null,
@@ -780,6 +802,9 @@ class ODPresentation implements ReaderInterface
                 }
                 if (null !== $this->arrayStyles[$keyStyle]['columnSpacing']) {
                     $oShape->setColumnSpacing($this->arrayStyles[$keyStyle]['columnSpacing']);
+                }
+                if (null !== $this->arrayStyles[$keyStyle]['columnsRTL']) {
+                    $oShape->setColumnsRTL($this->arrayStyles[$keyStyle]['columnsRTL']);
                 }
             }
         }

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1058,6 +1058,9 @@ class PowerPoint2007 implements ReaderInterface
             if ($bodyPr->hasAttribute('anchorCtr')) {
                 $oShape->setVerticalAlignCenter((int) $bodyPr->getAttribute('anchorCtr'));
             }
+            if ($bodyPr->hasAttribute('rtlCol')) {
+                $oShape->setColumnsRTL((bool) (int) $bodyPr->getAttribute('rtlCol'));
+            }
         }
 
         $arrayElements = $document->getElements('p:txBody/a:p', $node);

--- a/src/PhpPresentation/Shape/RichText.php
+++ b/src/PhpPresentation/Shape/RichText.php
@@ -121,6 +121,15 @@ class RichText extends AbstractShape implements ComparableInterface
     private $columnSpacing = 0;
 
     /**
+     * Are the columns ordered right to left?
+     *
+     * Null - the default - takes the order from the paragraphs.
+     *
+     * @var null|bool
+     */
+    private $columnsRTL;
+
+    /**
      * Bottom inset (in pixels).
      *
      * @var float
@@ -671,6 +680,48 @@ class RichText extends AbstractShape implements ComparableInterface
     }
 
     /**
+     * Get the order of the columns as it was set, null when it was never set.
+     */
+    public function hasColumnsRTL(): ?bool
+    {
+        return $this->columnsRTL;
+    }
+
+    /**
+     * Set the order of the columns.
+     *
+     * Null - the default - takes the order from the paragraphs. The order of the columns and the
+     * direction of the text are independent: left-to-right text in right-to-left columns is a
+     * state both formats can hold, so it has to stay reachable.
+     */
+    public function setColumnsRTL(?bool $value = null): self
+    {
+        $this->columnsRTL = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the order of the columns, taking it from the paragraphs when it was never set.
+     */
+    public function isColumnsRTL(): bool
+    {
+        if (null !== $this->columnsRTL) {
+            return $this->columnsRTL;
+        }
+        if (empty($this->richTextParagraphs)) {
+            return false;
+        }
+        foreach ($this->richTextParagraphs as $paragraph) {
+            if (!$paragraph->getAlignment()->isRTL()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get hash code.
      *
      * @return string Hash code
@@ -692,6 +743,7 @@ class RichText extends AbstractShape implements ComparableInterface
             . ($this->vertical ? '1' : '0')
             . $this->columns
             . $this->columnSpacing
+            . (null === $this->columnsRTL ? '' : ($this->columnsRTL ? '1' : '0'))
             . $this->bottomInset
             . $this->leftInset
             . $this->rightInset

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -1079,6 +1079,9 @@ class Content extends AbstractDecoratorWriter
         }
 
         $objWriter->writeAttribute('fo:wrap-option', 'wrap');
+        // The writing mode of the frame orders its columns; the direction of the text comes from
+        // the writing mode each paragraph style states for itself.
+        $objWriter->writeAttribute('style:writing-mode', $shape->isColumnsRTL() ? 'rl-tb' : 'lr-tb');
         // style:graphic-properties > style:columns
         // An element rather than an attribute, so it is written after every attribute of the block
         if ($shape->getColumns() > 1) {

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -290,7 +290,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
             if (RichText::WRAP_SQUARE != $shape->getWrap()) {
                 $objWriter->writeAttribute('wrap', $shape->getWrap());
             }
-            $objWriter->writeAttribute('rtlCol', '0');
+            $objWriter->writeAttribute('rtlCol', $shape->isColumnsRTL() ? '1' : '0');
             if (RichText::OVERFLOW_OVERFLOW != $shape->getHorizontalOverflow()) {
                 $objWriter->writeAttribute('horzOverflow', $shape->getHorizontalOverflow());
             }

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1305,6 +1305,28 @@ class ODPresentationTest extends TestCase
         self::assertEquals('https://github.com/PHPOffice/PHPPresentation/', $oHyperlink->getUrl());
     }
 
+    public function testTextColumnsRTL(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('AAAA');
+        $oShape->setColumns(2)->setColumnsRTL(true);
+        // and a second shape that never said anything about the order of its columns
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('BBBB');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertTrue($arrayShape[0]->hasColumnsRTL());
+        // the frame always states its writing mode, so what was never set comes back said outright
+        self::assertInstanceOf(RichText::class, $arrayShape[1]);
+        self::assertFalse($arrayShape[1]->hasColumnsRTL());
+    }
+
     public function testTextColumns(): void
     {
         $oPhpPresentation = new PhpPresentation();

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -35,6 +35,7 @@ use PhpOffice\PhpPresentation\Style\Font;
 use PhpOffice\PhpPresentation\Writer\ODPresentation as ODPresentationWriter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ZipArchive;
 
 /**
  * Test class for ODPresentation reader.
@@ -1303,6 +1304,59 @@ class ODPresentationTest extends TestCase
 
         self::assertFalse($oHyperlink->isInternal());
         self::assertEquals('https://github.com/PHPOffice/PHPPresentation/', $oHyperlink->getUrl());
+    }
+
+    /**
+     * @return array<array{string, null|bool}>
+     */
+    public static function dataProviderWritingModes(): array
+    {
+        return [
+            // the three ODF spells right to left with, and the three it spells left to right with
+            ['rl-tb', true],
+            ['tb-rl', true],
+            ['rl', true],
+            ['lr-tb', false],
+            ['tb-lr', false],
+            ['lr', false],
+            // and the two that state no direction of their own
+            ['tb', null],
+            ['page', null],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderWritingModes
+     */
+    #[DataProvider('dataProviderWritingModes')]
+    public function testTextColumnsRTLWritingModes(string $writingMode, ?bool $expected): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+
+        // This library writes two of the eight spellings; putting the others into a file it wrote
+        // says what the reader makes of one that came from somewhere else.
+        $oZip = new ZipArchive();
+        $oZip->open($file);
+        $sContent = $oZip->getFromName('content.xml');
+        self::assertIsString($sContent);
+        $oZip->deleteName('content.xml');
+        $oZip->addFromString('content.xml', str_replace(
+            'fo:wrap-option="wrap" style:writing-mode="lr-tb"',
+            'fo:wrap-option="wrap" style:writing-mode="' . $writingMode . '"',
+            $sContent
+        ));
+        $oZip->close();
+
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertSame($expected, $arrayShape[0]->hasColumnsRTL());
     }
 
     public function testTextColumnsRTL(): void

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1283,6 +1283,28 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals(6858000, $oPhpPresentationRead->getLayout()->getCY());
     }
 
+    public function testColumnsRTL(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('AAAA');
+        $oShape->setColumns(2)->setColumnsRTL(true);
+        // and a second shape that never said anything about the order of its columns
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('BBBB');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertTrue($arrayShape[0]->hasColumnsRTL());
+        // `rtlCol` is written for every text body, so what was never set comes back said outright
+        self::assertInstanceOf(RichText::class, $arrayShape[1]);
+        self::assertFalse($arrayShape[1]->hasColumnsRTL());
+    }
+
     public function testTextRunWithoutProperties(): void
     {
         $oPhpPresentation = new PhpPresentation();

--- a/tests/PhpPresentation/Tests/Shape/RichTextTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichTextTest.php
@@ -96,6 +96,44 @@ class RichTextTest extends TestCase
         self::assertEquals($value, $object->getColumnSpacing());
     }
 
+    public function testColumnsRTL(): void
+    {
+        $object = new RichText();
+
+        // never set, and no paragraph asked for right to left
+        self::assertNull($object->hasColumnsRTL());
+        self::assertFalse($object->isColumnsRTL());
+
+        self::assertInstanceOf(RichText::class, $object->setColumnsRTL(true));
+        self::assertTrue($object->hasColumnsRTL());
+        self::assertTrue($object->isColumnsRTL());
+
+        self::assertInstanceOf(RichText::class, $object->setColumnsRTL(false));
+        self::assertFalse($object->hasColumnsRTL());
+        self::assertFalse($object->isColumnsRTL());
+
+        self::assertInstanceOf(RichText::class, $object->setColumnsRTL());
+        self::assertNull($object->hasColumnsRTL());
+    }
+
+    public function testColumnsRTLFromParagraphs(): void
+    {
+        $object = new RichText();
+        // the shape starts with one paragraph, which is left to right
+        self::assertFalse($object->isColumnsRTL());
+
+        $object->getActiveParagraph()->getAlignment()->setIsRTL(true);
+        self::assertTrue($object->isColumnsRTL());
+
+        // one paragraph left to right is enough to leave the columns as they were
+        $object->createParagraph()->getAlignment()->setIsRTL(false);
+        self::assertFalse($object->isColumnsRTL());
+
+        // left to right text in right to left columns, which is why the setter exists
+        $object->setColumnsRTL(true);
+        self::assertTrue($object->isColumnsRTL());
+    }
+
     public function testColumnsException(): void
     {
         $this->expectException(OutOfBoundsException::class);

--- a/tests/PhpPresentation/Tests/Shape/RichTextTest.php
+++ b/tests/PhpPresentation/Tests/Shape/RichTextTest.php
@@ -132,6 +132,12 @@ class RichTextTest extends TestCase
         // left to right text in right to left columns, which is why the setter exists
         $object->setColumnsRTL(true);
         self::assertTrue($object->isColumnsRTL());
+
+        // and a shape with no paragraph at all has nothing to take the order from: "every
+        // paragraph reads right to left" is vacuously true on an empty array, and must not be
+        $object->setColumnsRTL();
+        $object->setParagraphs([]);
+        self::assertFalse($object->isColumnsRTL());
     }
 
     public function testColumnsException(): void

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -1604,6 +1604,41 @@ class ContentTest extends PhpPresentationTestCase
         ];
     }
 
+    public function testRichTextColumnsRTL(): void
+    {
+        $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();
+        $oRichText->createTextRun('AAA');
+
+        $element = '/office:document-content/office:automatic-styles/style:style[@style:name=\'gr1\']/style:graphic-properties';
+
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:writing-mode', 'lr-tb');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        // a shape whose every paragraph reads right to left orders its columns the same way
+        $this->resetPresentationFile();
+        $oRichText->setColumns(2);
+        $oRichText->getActiveParagraph()->getAlignment()->setIsRTL(true);
+
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:writing-mode', 'rl-tb');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+
+        // and the order can be said outright, which is the only way to right to left text in
+        // left to right columns
+        $this->resetPresentationFile();
+        $oRichText->setColumnsRTL(false);
+
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'style:writing-mode', 'lr-tb');
+        // the paragraph keeps saying what it says for itself
+        $this->assertZipXmlAttributeEquals(
+            'content.xml',
+            '/office:document-content/office:automatic-styles/style:style[@style:name=\'P_'
+                . $oRichText->getActiveParagraph()->getHashCode() . '\']/style:paragraph-properties',
+            'style:writing-mode',
+            'rl-tb'
+        );
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
     public function testRichTextColumns(): void
     {
         $oRichText = $this->oPresentation->getActiveSlide()->createRichTextShape();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -832,6 +832,32 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testParagraphColumnsRTL(): void
+    {
+        $richText = $this->oPresentation->getActiveSlide()->createRichTextShape();
+        $richText->createTextRun('AAA');
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:bodyPr';
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'rtlCol', '0');
+        $this->assertIsSchemaECMA376Valid();
+
+        // a shape whose every paragraph reads right to left orders its columns the same way
+        $this->resetPresentationFile();
+        $richText->setColumns(2);
+        $richText->getActiveParagraph()->getAlignment()->setIsRTL(true);
+
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'rtlCol', '1');
+        $this->assertIsSchemaECMA376Valid();
+
+        // and the order can be said outright, which is the only way to right to left text in
+        // left to right columns
+        $this->resetPresentationFile();
+        $richText->setColumnsRTL(false);
+
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'rtlCol', '0');
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testParagraphColumns(): void
     {
         $richText = $this->oPresentation->getActiveSlide()->createRichTextShape();


### PR DESCRIPTION
### Description

`rtlCol` on `a:bodyPr` is written as `'0'` at three sites in the PowerPoint2007 Writer, with no setter, no documentation and no test. Only one of the three sits on a shape that can have columns at all — `writeShapeText()`, sixteen lines above the `numCol` it belongs with. The other two are a table cell and an autoshape, neither of which has a `setColumns()`, so they stay `'0'`.

ECMA-376 calls the attribute *Columns Right-To-Left* (`dml-main.xsd:8299`): it orders the columns of a multi-column text body and says nothing about the direction of the text, which `a:pPr@rtl` already carries correctly. So a deck whose text reads right to left had its columns laid out left to right, and no way to say otherwise.

**The setter is nullable on purpose.** It follows `setAutoShrinkVertical()` in the same class:

```php
$richText->setColumnsRTL(true);   // right to left, whatever the text does
$richText->setColumnsRTL(false);  // left to right, whatever the text does
$richText->setColumnsRTL();       // null, the default: take the order from the paragraphs
```

Deriving the order from the paragraphs and stopping there would have been smaller, and it would have made a legal document unreachable from the model: **left-to-right text in right-to-left columns**. PPTX spells it `rtlCol="1"` alongside `rtl="0"` on each `a:pPr`; ODF spells it `style:writing-mode="rl-tb"` on the frame while every paragraph style carries its own `lr-tb`. The two are independent in both schemas, so `null` derives and an explicit value overrides. The derivation needs the paragraphs to be non-empty and all right to left — "every element satisfies it" is vacuously true on an empty array, which would have put `rtlCol="1"` on an empty shape.

`hasColumnsRTL()` gives back what was set, `null` included; `isColumnsRTL()` gives the order the writers use.

**Both writers, not just one.** ODF carries the same thing as `style:writing-mode` on the frame's `style:graphic-properties` — valid there per the schema (`OpenDocument-v1.2-os-schema.rng:17007`, through `common-writing-mode-attlist`), and written by LibreOffice itself on every frame it saves. It cannot leak into the text: the neighbouring `writeTxtStyle()` code writes `style:writing-mode` on every paragraph style unconditionally, so each paragraph always states its own direction. A PPTX-only setter would be an API one writer honours and the other silently drops, which is the defect #925 just fixed for `setColumns()` itself.

Both writers state the order for every shape, as the PowerPoint2007 Writer already did for `rtlCol`, so a value that was never set comes back said outright after a round trip. Nothing that was already correct changes: a deck with left-to-right paragraphs writes `rtlCol="0"` and `style:writing-mode="lr-tb"` exactly as before.

**What LibreOffice does with it, measured, since it is worth being straight about:** nothing. It drops `rtlCol` on a PPTX round trip (the attribute is absent from its output entirely) and resets a frame's `style:writing-mode` to `lr-tb` on an ODP round trip. It models column order in neither format, so it can neither confirm nor contradict the change; the references here are the two schemas and PowerPoint's own reading of `rtlCol`.

> [!IMPORTANT]
> **Stacked on #925 — please do not merge this one first.** Its base is `feature/odp-text-columns`, because the `style:columns` element it orders is what #925 adds. Against `master` alone the ODP half of this PR would write a writing mode for columns that do not exist yet. Once #925 is in I will rebase this onto `master`; the diff below is then this commit alone.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `RichTextTest::testColumnsRTL` and `testColumnsRTLFromParagraphs` for the tri-state and the derivation, including the empty-shape case. `PptSlidesTest::testParagraphColumnsRTL` and `ContentTest::testRichTextColumnsRTL` for the two writers, in all three states, schema-checked; the ODP one also pins that the paragraph keeps its own writing mode when the frame disagrees with it. `PowerPoint2007Test::testColumnsRTL` and `ODPresentationTest::testTextColumnsRTL` write, read and compare, each with a second shape that never asked for anything.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > `docs/usage/shapes/richtext.md` — the *Columns* section #925 added gains the order, and `columnsRTL` joins the property list.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
