### PR TITLE
ODPresentation Reader : Read back the alignment of a paragraph

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -33,6 +33,7 @@
 - PowerPoint2007 Reader : Fixed a text run written without `a:rPr` being dropped, which loses part of the text of a Keynote export, by [@Wilkolicious](http://github.com/Wilkolicious) in [#871](https://github.com/PHPOffice/PHPPresentation/pull/871) and [@dkulyk](http://github.com/dkulyk) in [#914](https://github.com/PHPOffice/PHPPresentation/pull/914)
 - `Style\Color` : Fixed a colour written as a plain RGB being given an alpha it never asked for by [@dkulyk](http://github.com/dkulyk) in [#910](https://github.com/PHPOffice/PHPPresentation/pull/910)
 - PowerPoint2007 Reader : Fixed a slide size written with an explicit `type="custom"` crashing the reader instead of being read with its own dimensions by [@SAY-5](http://github.com/SAY-5) in [#929](https://github.com/PHPOffice/PHPPresentation/pull/929)
+- ODPresentation Reader : Fixed the alignment of a paragraph being dropped on load, and its direction being read as left to right whatever the file said, by [@dkulyk](http://github.com/dkulyk) in [#927](https://github.com/PHPOffice/PHPPresentation/pull/927)
 
 ## BC Breaks
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -521,7 +521,25 @@ class ODPresentation implements ReaderInterface
             }
             $oAlignment = new Alignment();
             if ($nodeParagraphProps->hasAttribute('fo:text-align')) {
-                $oAlignment->setHorizontal($nodeParagraphProps->getAttribute('fo:text-align'));
+                switch ($nodeParagraphProps->getAttribute('fo:text-align')) {
+                    case 'right':
+                        $oAlignment->setHorizontal(Alignment::HORIZONTAL_RIGHT);
+
+                        break;
+                    case 'center':
+                        $oAlignment->setHorizontal(Alignment::HORIZONTAL_CENTER);
+
+                        break;
+                    case 'justify':
+                        $oAlignment->setHorizontal(Alignment::HORIZONTAL_JUSTIFY);
+
+                        break;
+                    case 'left':
+                    default:
+                        $oAlignment->setHorizontal(Alignment::HORIZONTAL_LEFT);
+
+                        break;
+                }
             }
             if ($nodeParagraphProps->hasAttribute('style:writing-mode')) {
                 switch ($nodeParagraphProps->getAttribute('style:writing-mode')) {
@@ -534,7 +552,7 @@ class ODPresentation implements ReaderInterface
                     case 'rl-tb':
                     case 'tb-rl':
                     case 'rl':
-                        $oAlignment->setIsRTL(false);
+                        $oAlignment->setIsRTL(true);
 
                         break;
                     case 'tb':
@@ -766,6 +784,9 @@ class ODPresentation implements ReaderInterface
         if ($oNodeParent->hasAttribute('text:style-name')) {
             $keyStyle = $oNodeParent->getAttribute('text:style-name');
             if (isset($this->arrayStyles[$keyStyle])) {
+                if (null !== $this->arrayStyles[$keyStyle]['alignment']) {
+                    $oParagraph->setAlignment($this->arrayStyles[$keyStyle]['alignment']);
+                }
                 if (!empty($this->arrayStyles[$keyStyle]['spacingAfter'])) {
                     $oParagraph->setSpacingAfter($this->arrayStyles[$keyStyle]['spacingAfter']);
                 }

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1240,6 +1240,9 @@ class ODPresentationTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider dataProviderHorizontalAlignment
+     */
     #[DataProvider('dataProviderHorizontalAlignment')]
     public function testHorizontalAlignmentSurvivesTheRoundTrip(string $alignment): void
     {

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1227,6 +1227,60 @@ class ODPresentationTest extends TestCase
         self::assertEquals(3, $oHyperlink->getSlideNumber());
     }
 
+    /**
+     * @return array<array<string>>
+     */
+    public static function dataProviderHorizontalAlignment(): array
+    {
+        return [
+            [Alignment::HORIZONTAL_LEFT],
+            [Alignment::HORIZONTAL_RIGHT],
+            [Alignment::HORIZONTAL_CENTER],
+            [Alignment::HORIZONTAL_JUSTIFY],
+        ];
+    }
+
+    #[DataProvider('dataProviderHorizontalAlignment')]
+    public function testHorizontalAlignmentSurvivesTheRoundTrip(string $alignment): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('AAAA');
+        $oShape->getActiveParagraph()->getAlignment()->setHorizontal($alignment);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        // and it is the value the model uses, not the one ODF spells it with
+        self::assertEquals($alignment, $arrayShape[0]->getParagraph()->getAlignment()->getHorizontal());
+    }
+
+    public function testTextDirectionSurvivesTheRoundTrip(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('\u{645}\u{631}\u{62d}\u{628}\u{627}');
+        $oShape->getActiveParagraph()->getAlignment()->setIsRTL(true);
+        // and a second shape that reads the other way, to pin the arm next to it
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('AAAA');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getSlide(0)->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        // The writer wrote `style:writing-mode="rl-tb"`, so it has to come back right to left
+        self::assertTrue($arrayShape[0]->getParagraph()->getAlignment()->isRTL());
+        self::assertInstanceOf(RichText::class, $arrayShape[1]);
+        self::assertFalse($arrayShape[1]->getParagraph()->getAlignment()->isRTL());
+    }
+
     public function testHyperlinkToUrl(): void
     {
         $oPhpPresentation = new PhpPresentation();


### PR DESCRIPTION
### Description

`loadStyle()` parses `style:paragraph-properties` into an `Alignment` and files it in `arrayStyles` under `alignment`. In the whole of the Reader that key has exactly one reader — `readListItem()` — and the object it reads there is a *different* one, built from `text:list-style` for the indent and the margins. So for an ordinary paragraph the alignment was parsed and then dropped: `readParagraph()` takes `spacingAfter`, `spacingBefore`, `lineSpacingMode` and `lineSpacing` out of the same style entry and walks straight past the alignment sitting next to them.

Three things had to be right for the round trip. Two were not.

**`fo:text-align` was stored raw.** `setHorizontal($nodeParagraphProps->getAttribute('fo:text-align'))` puts the ODF spelling — `left`, `right`, `center`, `justify` — into a model whose constants are `l`, `r`, `ctr` and `just`. So even on the one path that did use this object, the value could never match what the Writer switches on. It is mapped now, over the four alignments this library writes. (`start` and `end` are deliberately not mapped: their meaning depends on the direction of the text, and LibreOffice writes `left` — checked on a file it saved — so nothing here produces them.)

**`style:writing-mode` was read as left to right in both arms of its switch.** `lr-tb`/`tb-lr`/`lr` and `rl-tb`/`tb-rl`/`rl` alike called `setIsRTL(false)`; the second is a typo for `true`, present since be48bb383 added right-to-left support in July 2021. On its own it changes nothing observable, which is exactly why it survived four years: with no paragraph ever reading the alignment, the value it corrects was never asked for by anything.

**And `readParagraph()` now applies the alignment it already had in hand.**

Measured before the change, on a shape written by this library: `style:writing-mode="rl-tb"` goes into `content.xml`, and `isRTL()` comes back `false`. After it, all four horizontal alignments and the direction survive a save and a load.

Independent of #925 and #926 — different region of the file, `git merge-tree` clean against both, and the full suite passes on each.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `ODPresentationTest::testHorizontalAlignmentSurvivesTheRoundTrip` over the four alignments, and `testTextDirectionSurvivesTheRoundTrip` with a second shape reading the other way to pin the arm next to it. Checked from both sides: with the `src/` change reverted they give 4 failures — `left` passes either way, since it is what an unread alignment defaults to.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > No documented API changed; `alignment` is already listed as a paragraph property, and this is the Reader catching up with it.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
