### PR TITLE
Write the shadow a shape was given, whatever the shape is

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -47,6 +47,7 @@
 - ODPresentation Writer and Reader : Fixed the columns of a text shape being dropped on save and never read back, by [@dkulyk](http://github.com/dkulyk) in [#925](https://github.com/PHPOffice/PHPPresentation/pull/925)
 - Fixed the columns of a text shape always being written left to right, and added `RichText::setColumnsRTL()` to say the order outright, by [@dkulyk](http://github.com/dkulyk) in [#926](https://github.com/PHPOffice/PHPPresentation/pull/926)
 - Fixed a shadow set to `null` -- which `AbstractShape::setShadow()` accepts -- crashing all three Writers on save, by [@phili67](http://github.com/phili67) in [#887](https://github.com/PHPOffice/PHPPresentation/pull/887) and [@dkulyk](http://github.com/dkulyk) in [#928](https://github.com/PHPOffice/PHPPresentation/pull/928)
+- Fixed the shadow of a line, an autoshape, a group, a text shape and a table being dropped on save, so that a shadow is written whatever the shape wearing it, by [@dkulyk](http://github.com/dkulyk) fixing [#736](https://github.com/PHPOffice/PHPPresentation/issues/736) in [#937](https://github.com/PHPOffice/PHPPresentation/pull/937)
 
 ## BC Breaks
 - `AbstractShape::setShadow()` given `null` now stores a fresh `Shadow` instead of the null, so `AbstractShape::getShadow()` returns `Shadow` rather than `?Shadow`. Code that read it back as null tests the shadow it gets instead (`getShadow()->isVisible()`); a subclass that overrode it with a nullable return type widens it.

--- a/src/PhpPresentation/Writer/HTML.php
+++ b/src/PhpPresentation/Writer/HTML.php
@@ -242,6 +242,7 @@ class HTML extends AbstractWriter implements WriterInterface
         $styles[] = 'height: ' . $shape->getHeight() . 'px';
         $styles[] = 'top: ' . $shape->getOffsetY() . 'px';
         $styles[] = 'left: ' . $shape->getOffsetX() . 'px';
+        $styles = array_merge($styles, $this->getStyleShadow($shape->getShadow()));
 
         $this->bodySlides .= '<div style="' . implode(';', $styles) . '">';
         foreach ($shape->getParagraphs() as $paragraph) {
@@ -262,6 +263,7 @@ class HTML extends AbstractWriter implements WriterInterface
         $styles[] = 'height: ' . $shape->getHeight() . 'px';
         $styles[] = 'top: ' . $shape->getOffsetY() . 'px';
         $styles[] = 'left: ' . $shape->getOffsetX() . 'px';
+        $styles = array_merge($styles, $this->getStyleShadow($shape->getShadow()));
 
         $this->bodySlides .= '<div style="' . implode(';', $styles) . '">';
         $this->bodySlides .= '<table style="width:100%"><tbody>';

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -1190,6 +1190,7 @@ class Content extends AbstractDecoratorWriter
         }
         $objWriter->writeAttribute('svg:stroke-color', '#' . $shape->getBorder()->getColor()->getRGB());
         $objWriter->writeAttribute('svg:stroke-width', Text::numberFormat(CommonDrawing::pointsToCentimeters($shape->getBorder()->getLineWidth()), 3) . 'cm');
+        $this->writeStylePartShadow($objWriter, $shape->getShadow());
         $objWriter->endElement();
 
         $objWriter->endElement();

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -856,6 +856,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
 
         $objWriter->endElement();
         $this->writeBorder($objWriter, $shape->getBorder(), '');
+        $this->writeShadow($objWriter, $shape->getShadow());
         $objWriter->endElement();
         $objWriter->endElement();
     }
@@ -1284,6 +1285,8 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $this->writeFill($objWriter, $shape->getFill());
         // Outline
         $this->writeOutline($objWriter, $shape->getOutline());
+        // Shadow
+        $this->writeShadow($objWriter, $shape->getShadow());
 
         // p:sp\p:spPr\
         $objWriter->endElement();
@@ -1603,6 +1606,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
         $objWriter->writeAttribute('cy', CommonDrawing::pixelsToEmu($group->getExtentY()));
         $objWriter->endElement(); // a:chExt
         $objWriter->endElement(); // a:xfrm
+        $this->writeShadow($objWriter, $group->getShadow());
         $objWriter->endElement(); // p:grpSpPr
 
         $this->writeShapeCollection($objWriter, $group->getShapeCollection(), $shapeId);

--- a/tests/PhpPresentation/Tests/Writer/HTMLTest.php
+++ b/tests/PhpPresentation/Tests/Writer/HTMLTest.php
@@ -73,6 +73,25 @@ class HTMLTest extends PhpPresentationTestCase
     /**
      * Test a shape whose shadow was taken away.
      */
+    public function testSaveShadowOnRichTextAndTable(): void
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+
+        $slide = $this->oPresentation->getActiveSlide();
+        $slide->createRichTextShape()->createTextRun('AAA');
+        $slide->createTableShape(1)->createRow()->getCell(0)->createTextRun('BBB');
+        foreach ($slide->getShapeCollection() as $shape) {
+            $shape->getShadow()->setVisible(true)->setAlpha(75)->setBlurRadius(2)->setDirection(45);
+        }
+
+        (new HTML($this->oPresentation))->save($filename);
+        $content = file_get_contents($filename);
+        unlink($filename);
+
+        // one for the text shape, one for the table -- both were dropped before
+        self::assertSame(2, substr_count((string) $content, 'box-shadow'));
+    }
+
     public function testSaveShadowSetBackToNull(): void
     {
         $filename = tempnam(sys_get_temp_dir(), 'PhpPresentation');

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -340,6 +340,19 @@ class ContentTest extends PhpPresentationTestCase
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 
+    public function testLineShadow(): void
+    {
+        $this->oPresentation->getActiveSlide()->createLineShape(10, 10, 100, 100)
+            ->getShadow()->setVisible(true)->setAlpha(75)->setDirection(45)->setDistance(10);
+
+        // the style the line actually points at, whatever it was named
+        $element = '/office:document-content/office:automatic-styles/style:style'
+            . '[@style:name = //draw:line/@draw:style-name]/style:graphic-properties';
+        $this->assertZipXmlElementExists('content.xml', $element);
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'draw:shadow', 'visible');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
     public function testShadowSetBackToNull(): void
     {
         // one of the two shapes this writer reads a shadow from: a text frame, by writeTxtStyle()

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -1341,6 +1341,43 @@ class PptSlidesTest extends PhpPresentationTestCase
         $this->assertIsSchemaECMA376Valid();
     }
 
+    public function testLineShadow(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oSlide->createLineShape(10, 10, 100, 100)
+            ->getShadow()->setVisible(true)->setAlpha(75)->setBlurRadius(2)->setDirection(45);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:cxnSp/p:spPr/a:effectLst/a:outerShdw';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    public function testAutoShapeShadow(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oAutoShape = new AutoShape();
+        $oAutoShape->setType(AutoShape::TYPE_HEART);
+        $oAutoShape->getShadow()->setVisible(true)->setAlpha(75)->setBlurRadius(2)->setDirection(45);
+        $oSlide->addShape($oAutoShape);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:sp/p:spPr/a:effectLst/a:outerShdw';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    public function testGroupShadow(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oGroup = new Group();
+        $oGroup->createRichTextShape()->createTextRun('AAA');
+        $oGroup->getShadow()->setVisible(true)->setAlpha(75)->setBlurRadius(2)->setDirection(45);
+        $oSlide->addShape($oGroup);
+
+        $element = '/p:sld/p:cSld/p:spTree/p:grpSp/p:grpSpPr/a:effectLst/a:outerShdw';
+        $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
+        $this->assertIsSchemaECMA376Valid();
+    }
+
     public function testRichTextShadow(): void
     {
         $oSlide = $this->oPresentation->getActiveSlide();


### PR DESCRIPTION
### Description

Fixes #736

Every `AbstractShape` is born with a `Shadow` and every one of them has `setShadow()`, but only four
kinds of shape had a writer that reads it back. A shadow set on anything else was dropped without a
word — which is what [#736](https://github.com/PHPOffice/PHPPresentation/issues/736) reports, open
since 2023: *"Shadow does not work with AutoShape ... but it works for RichTextShape"*. The
reporter's diagnosis was right and nothing was wrong with their call.

Measured by putting a visible shadow on one shape of each kind and looking for it in the output:

| shape | PowerPoint2007 | ODPresentation | HTML |
| --- | --- | --- | --- |
| RichText | yes | yes | no → **yes** |
| Drawing (image) | yes | yes | yes |
| Media (video) | yes | yes | yes |
| Chart | yes, in its own part | — | n/a |
| Line | no → **yes** | no → **yes** | n/a |
| AutoShape | no → **yes** | — | n/a |
| Group | no → **yes** | n/a | n/a |
| Table | — | — | no → **yes** |

Six cells, six one-line calls into a container each writer already opens: `p:spPr` for a line and an
autoshape, `p:grpSpPr` for a group, `style:graphic-properties` for a line, and the `$styles` array
the HTML writer already merges a shadow into for an image.

`a:effectLst` goes **after** `a:ln`, which is the order `CT_ShapeProperties` wants and what
`writeShapeText()` already does. The ECMA-376 schema rejects the other order, so the new tests hold
the placement as well as the presence — moving the call one line up turns
`testLineShadow` red with *"`a:ln`: This element is not expected"*.

### What it looks like

One slide carrying a shadowed shape of each kind, saved with all three writers, before and after
this PR.

**PowerPoint2007**, rendered by PowerPoint itself — the line, the heart and the group are the three
that changed:

| before | after |
| --- | --- |
| ![pptx before](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/shadow-937-pptx-before.png) | ![pptx after](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/shadow-937-pptx-after.png) |

**ODPresentation**, rendered by LibreOffice — the line:

| before | after |
| --- | --- |
| ![odp before](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/shadow-937-odp-before.png) | ![odp after](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/shadow-937-odp-after.png) |

**HTML**, rendered by Chrome — the text shape and the table:

| before | after |
| --- | --- |
| ![html before](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/shadow-937-html-before.png) | ![html after](https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/shadow-937-html-after.png) |

The autoshape and the group are missing from the ODPresentation pictures because that writer does
not write them, which is the next point.

**What the dashes are, and why they are not this PR.** They are not shadow problems:

- the HTML writer renders four kinds of shape and no others, so a line, an autoshape and a group
  have no element to carry a shadow at all
- the ODPresentation writer does not write an autoshape at all — a slide holding two of them is a
  self-closing `<draw:page/>`. ODF has no `prstGeom`, so every preset has to be translated into a
  `draw:custom-shape` path; that is a change of its own size and it will come as its own PR
- a table is a `p:graphicFrame` in PowerPoint and an unstyled `draw:frame` in ODF, and a chart in
  ODF is the same unstyled frame; `CT_GraphicalObjectFrame` takes no shape properties, and the ODF
  frames name no `draw:style-name` to hang one on. Giving those frames a style of their own is
  again a separate PR, and a shadow follows from it rather than driving it

So the ODPresentation autoshape and the ODPresentation table are both planned, each behind the piece
of writing that has to exist first; this PR stops at the cells where the container was already
there.

### Checklist:

- [x] My CI is :green_circle:
  > 947 tests, 7906 assertions, PHPStan level 4 and PHP-CS-Fixer all clean locally.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
  > `PptSlidesTest::testLineShadow()`, `::testAutoShapeShadow()`, `::testGroupShadow()`,
  > `ContentTest::testLineShadow()` and `HTMLTest::testSaveShadowOnRichTextAndTable()`. All five
  > fail on the base commit. The three PowerPoint ones and the ODPresentation one validate against
  > the ECMA-376 and ODF 1.2 schemas as well.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
  > Nothing to update: no public API changes. `setShadow()` is already documented and was always
  > meant to work on any shape; this makes it do so.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
  > One line under Bug fixes, crediting #736.
