### PR TITLE
Both Writers : Point a reference at the part that was written

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -17,6 +17,7 @@
 
 ## Bug fixes
 - PowerPoint2007 Reader : Fixed a colour with an alpha coming back opaque and one character short, taking the first digit of the colour with it, by [@dkulyk](http://github.com/dkulyk) in [#961](https://github.com/PHPOffice/PHPPresentation/pull/961)
+- Both Writers : Fixed a second shape holding the same picture, and a second chart holding the same numbers, being written as a reference to a part that was never put in the archive, which is what PowerPoint offers to repair, by [@dkulyk](http://github.com/dkulyk) in [#948](https://github.com/PHPOffice/PHPPresentation/pull/948)
 - PowerPoint2007 Writer : Fixed a group taking two shape identifiers and using the second, leaving a number no shape carries, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 - PowerPoint2007 Writer : Fixed a hyperlink, an image, a chart or a comment inside a group inside a group getting no relationship written for it, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 - PowerPoint2007 Writer : Fixed the rotation of a group of shapes being dropped on save, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)

--- a/src/PhpPresentation/Shape/Chart.php
+++ b/src/PhpPresentation/Shape/Chart.php
@@ -187,6 +187,11 @@ class Chart extends AbstractGraphic implements ComparableInterface
      */
     public function getHashCode(): string
     {
-        return md5(parent::getHashCode() . $this->title->getHashCode() . $this->legend->getHashCode() . $this->plotArea->getHashCode() . $this->view3D->getHashCode() . ($this->includeSpreadsheet ? 1 : 0) . __CLASS__);
+        // A chart is not a shareable resource the way an image is. Two pictures of the same bytes
+        // are one part that two shapes point at, and that is the whole reason the hash table
+        // deduplicates; two charts that happen to hold the same numbers are still two charts, each
+        // with its own relationship, its own `_rels` and its own embedded workbook. The image index
+        // is what keeps them apart, and it is per instance.
+        return md5(parent::getHashCode() . $this->title->getHashCode() . $this->legend->getHashCode() . $this->plotArea->getHashCode() . $this->view3D->getHashCode() . ($this->includeSpreadsheet ? 1 : 0) . $this->getImageIndex() . __CLASS__);
     }
 }

--- a/src/PhpPresentation/Writer/AbstractDecoratorWriter.php
+++ b/src/PhpPresentation/Writer/AbstractDecoratorWriter.php
@@ -72,7 +72,16 @@ abstract class AbstractDecoratorWriter
      * about the collapse.
      *
      * Answers with the shape itself when the table has not been filled yet, so a writer that runs
-     * without one behaves as it did before.
+     * without one behaves as it did before, and when the entry is of another class: `__CLASS__` in
+     * `AbstractGraphic::getHashCode()` is a literal rather than late static binding, so two
+     * different kinds of graphic are not guaranteed to hash apart, and a part is only ever
+     * interchangeable with one of its own kind.
+     *
+     * @template T of AbstractGraphic
+     *
+     * @param T $shape
+     *
+     * @return T
      */
     protected function writtenPart(AbstractGraphic $shape): AbstractGraphic
     {
@@ -81,7 +90,12 @@ abstract class AbstractDecoratorWriter
             ? null
             : $this->oHashTable->getByIndex($hashIndex);
 
-        return $written instanceof AbstractGraphic ? $written : $shape;
+        if (!$written instanceof $shape) {
+            return $shape;
+        }
+
+        /** @var T $written */
+        return $written;
     }
 
     /**

--- a/src/PhpPresentation/Writer/AbstractDecoratorWriter.php
+++ b/src/PhpPresentation/Writer/AbstractDecoratorWriter.php
@@ -23,6 +23,7 @@ namespace PhpOffice\PhpPresentation\Writer;
 use PhpOffice\Common\Adapter\Zip\ZipInterface;
 use PhpOffice\PhpPresentation\HashTable;
 use PhpOffice\PhpPresentation\PhpPresentation;
+use PhpOffice\PhpPresentation\Shape\AbstractGraphic;
 
 abstract class AbstractDecoratorWriter
 {
@@ -59,6 +60,28 @@ abstract class AbstractDecoratorWriter
     public function getDrawingHashTable()
     {
         return $this->oHashTable;
+    }
+
+    /**
+     * The graphic whose bytes were actually written for this one.
+     *
+     * `HashTable` keeps one entry per hash, so two shapes that compare alike leave a single part
+     * in the archive -- the first of them. The others are handed that one's hash index when they
+     * are added, and this reads it back. A reference has to name the part that exists, not the
+     * name this shape would have had; `getIndexedFilename()` counts instances and knows nothing
+     * about the collapse.
+     *
+     * Answers with the shape itself when the table has not been filled yet, so a writer that runs
+     * without one behaves as it did before.
+     */
+    protected function writtenPart(AbstractGraphic $shape): AbstractGraphic
+    {
+        $hashIndex = $shape->getHashIndex();
+        $written = null === $hashIndex || null === $this->oHashTable
+            ? null
+            : $this->oHashTable->getByIndex($hashIndex);
+
+        return $written instanceof AbstractGraphic ? $written : $shape;
     }
 
     /**

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -521,7 +521,7 @@ class Content extends AbstractDecoratorWriter
         $this->writeShapeDecorative($objWriter, $shape);
         // draw:frame > draw:plugin
         $objWriter->startElement('draw:plugin');
-        $objWriter->writeAttribute('xlink:href', 'Pictures/' . $shape->getIndexedFilename());
+        $objWriter->writeAttribute('xlink:href', 'Pictures/' . $this->writtenPart($shape)->getIndexedFilename());
         $objWriter->writeAttribute('xlink:type', 'simple');
         $objWriter->writeAttribute('xlink:show', 'embed');
         $objWriter->writeAttribute('xlink:actuate', 'onLoad');
@@ -570,7 +570,7 @@ class Content extends AbstractDecoratorWriter
         $this->writeShapeDecorative($objWriter, $shape);
         // draw:image
         $objWriter->startElement('draw:image');
-        $objWriter->writeAttribute('xlink:href', 'Pictures/' . $shape->getIndexedFilename());
+        $objWriter->writeAttribute('xlink:href', 'Pictures/' . $this->writtenPart($shape)->getIndexedFilename());
         $objWriter->writeAttribute('xlink:type', 'simple');
         $objWriter->writeAttribute('xlink:show', 'embed');
         $objWriter->writeAttribute('xlink:actuate', 'onLoad');

--- a/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/AbstractSlide.php
@@ -72,7 +72,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
                         $objWriter,
                         $relId,
                         'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
-                        '../media/' . str_replace(' ', '_', $shape->getIndexedFilename())
+                        '../media/' . str_replace(' ', '_', $this->writtenPart($shape)->getIndexedFilename())
                     );
                     $shape->relationId = 'rId' . $relId;
                     ++$relId;
@@ -82,7 +82,7 @@ abstract class AbstractSlide extends AbstractDecoratorWriter
                         $objWriter,
                         $relId,
                         'http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart',
-                        '../charts/' . $shape->getIndexedFilename()
+                        '../charts/' . $this->writtenPart($shape)->getIndexedFilename()
                     );
                     $shape->relationId = 'rId' . $relId;
                     ++$relId;

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptSlides.php
@@ -107,18 +107,18 @@ class PptSlides extends AbstractSlide
                     if ($currentShape instanceof Media) {
                         // Write relationship for image drawing
                         $currentShape->relationId = 'rId' . $relId;
-                        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/video', '../media/' . $currentShape->getIndexedFilename());
+                        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/video', '../media/' . $this->writtenPart($currentShape)->getIndexedFilename());
                         ++$relId;
-                        $this->writeRelationship($objWriter, $relId, 'http://schemas.microsoft.com/office/2007/relationships/media', '../media/' . $currentShape->getIndexedFilename());
+                        $this->writeRelationship($objWriter, $relId, 'http://schemas.microsoft.com/office/2007/relationships/media', '../media/' . $this->writtenPart($currentShape)->getIndexedFilename());
                         ++$relId;
                     } elseif ($currentShape instanceof ShapeDrawing\AbstractDrawingAdapter) {
                         // Write relationship for image drawing
-                        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', '../media/' . $currentShape->getIndexedFilename());
+                        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image', '../media/' . $this->writtenPart($currentShape)->getIndexedFilename());
                         $currentShape->relationId = 'rId' . $relId;
                         ++$relId;
                     } elseif ($currentShape instanceof ShapeChart) {
                         // Write relationship for chart drawing
-                        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart', '../charts/' . $currentShape->getIndexedFilename());
+                        $this->writeRelationship($objWriter, $relId, 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart', '../charts/' . $this->writtenPart($currentShape)->getIndexedFilename());
                         $currentShape->relationId = 'rId' . $relId;
                         ++$relId;
                     } elseif ($currentShape instanceof ShapeContainerInterface) {

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -2310,4 +2310,28 @@ class ContentTest extends PhpPresentationTestCase
 
         return '/office:document-content/office:automatic-styles/style:style[@style:name=\'' . $styleName . '\']';
     }
+
+    /**
+     * The hash table leaves one `Pictures/` entry for two shapes holding the same image, and the
+     * manifest declares that one entry. `draw:image` was written from `getIndexedFilename()`
+     * instead, so the second shape named a picture the archive does not carry.
+     */
+    public function testTwoIdenticalDrawingsShareOneWrittenPart(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+
+        $oShape1 = $oSlide->createDrawingShape();
+        $oShape1->setPath(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/images/PhpPresentationLogo.png');
+        $oShape2 = $oSlide->createDrawingShape();
+        $oShape2->setPath(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/images/PhpPresentationLogo.png');
+
+        $this->assertZipFileExists('Pictures/' . $oShape1->getIndexedFilename());
+        $this->assertZipFileNotExists('Pictures/' . $oShape2->getIndexedFilename());
+        $element = '/office:document-content/office:body/office:presentation/draw:page/draw:frame[1]/draw:image';
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'xlink:href', 'Pictures/' . $oShape1->getIndexedFilename());
+        $element = '/office:document-content/office:body/office:presentation/draw:page/draw:frame[2]/draw:image';
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'xlink:href', 'Pictures/' . $oShape1->getIndexedFilename());
+        // Invalid because `draw:image` has attribute `loext:mime-type`
+        $this->assertIsSchemaOpenDocumentNotValid('1.2');
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -2209,4 +2209,32 @@ class PptChartsTest extends PhpPresentationTestCase
         $this->assertZipXmlAttributeNotExists('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'prst');
         $this->assertIsSchemaECMA376Valid();
     }
+
+    /**
+     * A chart is not a shareable resource the way an image is: each one owns a relationship, a
+     * `_rels` of its own and an embedded workbook. Two charts holding the same numbers used to
+     * compare alike, so the hash table kept one of them and the slide was left pointing at a part
+     * that was never written -- which is what PowerPoint offers to repair.
+     */
+    public function testTwoIdenticalChartsKeepTheirOwnPart(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+
+        $oChart1 = $oSlide->createChartShape();
+        $oChart1->getPlotArea()->setType(new Bar());
+        $oChart2 = $oSlide->createChartShape();
+        $oChart2->getPlotArea()->setType(new Bar());
+
+        $this->assertZipFileExists('ppt/charts/' . $oChart1->getIndexedFilename());
+        $this->assertZipFileExists('ppt/charts/' . $oChart2->getIndexedFilename());
+        $this->assertZipXmlElementExists(
+            'ppt/slides/_rels/slide1.xml.rels',
+            '/Relationships/Relationship[@Id="rId2"][@Target="../charts/' . $oChart1->getIndexedFilename() . '"]'
+        );
+        $this->assertZipXmlElementExists(
+            'ppt/slides/_rels/slide1.xml.rels',
+            '/Relationships/Relationship[@Id="rId3"][@Target="../charts/' . $oChart2->getIndexedFilename() . '"]'
+        );
+        $this->assertIsSchemaECMA376Valid();
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptMediaTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptMediaTest.php
@@ -116,4 +116,31 @@ class PptMediaTest extends PhpPresentationTestCase
         $this->assertZipFileExists('ppt/media/' . $oShape->getIndexedFilename());
         $this->assertIsSchemaECMA376Valid();
     }
+
+    /**
+     * Two shapes holding the same picture leave one part in the archive that both of them point
+     * at. The reference used to be written from `getIndexedFilename()`, which counts instances and
+     * knows nothing about that collapse, so the second shape named a part nobody had written.
+     */
+    public function testTwoIdenticalDrawingsShareOneWrittenPart(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+
+        $oShape1 = $oSlide->createDrawingShape();
+        $oShape1->setPath(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/images/PhpPresentationLogo.png');
+        $oShape2 = $oSlide->createDrawingShape();
+        $oShape2->setPath(PHPPRESENTATION_TESTS_BASE_DIR . '/resources/images/PhpPresentationLogo.png');
+
+        $this->assertZipFileExists('ppt/media/' . $oShape1->getIndexedFilename());
+        $this->assertZipFileNotExists('ppt/media/' . $oShape2->getIndexedFilename());
+        $this->assertZipXmlElementExists(
+            'ppt/slides/_rels/slide1.xml.rels',
+            '/Relationships/Relationship[@Id="rId2"][@Target="../media/' . $oShape1->getIndexedFilename() . '"]'
+        );
+        $this->assertZipXmlElementExists(
+            'ppt/slides/_rels/slide1.xml.rels',
+            '/Relationships/Relationship[@Id="rId3"][@Target="../media/' . $oShape1->getIndexedFilename() . '"]'
+        );
+        $this->assertIsSchemaECMA376Valid();
+    }
 }


### PR DESCRIPTION
### Description

`HashTable` keeps one entry per hash code, so two graphics that compare alike leave a single part in the archive -- the first of them. Every reference, though, was written from `getIndexedFilename()`, which counts instances and knows nothing about that collapse, so the second shape named a part nobody had written.

Two identical charts on one slide leave `ppt/charts/chart2.xml` referenced and absent, which is the file PowerPoint offers to repair. The same holds for two identical images, in both formats: in PPTX the slide's `.rels` names a `ppt/media/` entry that is not there, in ODP `content.xml` names a `Pictures/` entry missing from the archive. It has to be the same slide -- `AbstractShape` mixes the container into its hash, so shapes on different slides never collide.

Two changes:

- `AbstractDecoratorWriter::writtenPart()` reads back the hash index `HashTable::add()` already hands a collapsed shape, and answers with the graphic whose bytes were written. Where nothing collapsed it answers with the shape itself, so a deck without duplicates is written byte for byte as before. Eight call sites across both writers go through it. `MetaInfManifest` needed nothing: it walks the hash table already, and so only ever declared parts that exist.
- A chart stops deduplicating at all. It is not a shareable resource the way an image is: two charts holding the same numbers are still two charts, each owning a relationship, a `_rels` of its own and an embedded workbook. Mixing the image index into `Chart::getHashCode()` keeps them apart while leaving everything a chart is compared on intact.

Sharing one media part between two shapes is kept -- that part is genuinely shareable, and now both references resolve to it.

Fixes #841

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)

No documentation page describes how parts are named or shared, so there is nothing there to update.
