### PR TITLE
Changelog : Credit the reader of a group of shapes to both who wrote it

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -11,7 +11,7 @@
 - Added an outline on the data points of a chart serie, next to the fill they already had, by [@dkulyk](http://github.com/dkulyk) in [#900](https://github.com/PHPOffice/PHPPresentation/pull/900)
 - `DocumentLayout::convertUnit()` is public and static, so a value that belongs to no layout can be converted too, by [@dkulyk](http://github.com/dkulyk) in [#921](https://github.com/PHPOffice/PHPPresentation/pull/921)
 - Added `Table::setFirstRow()` and `Table::setBandRow()`, so that a table can say whether its first row is a header row, by [@dkulyk](http://github.com/dkulyk) in [#904](https://github.com/PHPOffice/PHPPresentation/pull/904)
-- PowerPoint2007 Reader : Read a group of shapes, and map the shapes it holds out of the coordinate space `a:chOff`/`a:chExt` declares, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
+- PowerPoint2007 Reader : Read a group of shapes, and map the shapes it holds out of the coordinate space `a:chOff`/`a:chExt` declares, by [@Wilkolicious](http://github.com/Wilkolicious) in [#870](https://github.com/PHPOffice/PHPPresentation/pull/870) and [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 
 ## Bug fixes
 - PowerPoint2007 Writer : Fixed a group taking two shape identifiers and using the second, leaving a number no shape carries, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)


### PR DESCRIPTION
### Description

[#870](https://github.com/PHPOffice/PHPPresentation/pull/870) recursed into `p:grpSp` and put the shapes it holds onto the slide, fourteen months before [#947](https://github.com/PHPOffice/PHPPresentation/pull/947) read the same element into a `Shape\Group`. The second is the wider fix -- it keeps the group rather than flattening it, and maps the shapes out of the `a:chOff`/`a:chExt` coordinate space -- but the first named the gap, and the changelog line should say both. One line, no code.

@Progi1984 this goes with #870, which can be closed as covered by #947.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)

The changelog is the whole change, so there is no code to test and no documentation page to update.