### PR TITLE
CI : Keep PHPStan off 2.2.11, which cannot start on PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=7.0",
         "phpmd/phpmd": "2.*",
-        "phpstan/phpstan": "^2.2",
+        "phpstan/phpstan": "^2.2,!=2.2.11",
         "dompdf/dompdf": "^3.1"
     },
     "suggest": {


### PR DESCRIPTION
### Description

`PHP Static Analysis (7.4)` has been failing on every pull request opened since this morning, for a
reason that belongs to none of them. PHPStan 2.2.11 was released at 10:34 UTC today; it declares
`php: ^7.4|^8.0`, and its Turbo process restarter calls `str_contains()`, which arrived in PHP 8.0.
On the 7.4 runner the phar dies before it analyses a single file:

```
PHP Fatal error: Uncaught Error: Call to undefined function str_contains() in
phar://.../phpstan.phar/src/Turbo/TurboExtensionSelector.php:113
```

`composer.lock` is not committed, so every job resolves the newest release. The last run on `master`
was at 09:32 UTC and is green; everything after 10:34 is red on that one job.

The constraint stays `^2.2` and excludes the single release, so the job takes 2.2.10 today and
takes whatever fixes this as soon as it ships. `composer validate --strict` is happy with it, and
`composer update phpstan/phpstan` resolves to 2.2.10.

Reported upstream as [phpstan/phpstan#15137](https://github.com/phpstan/phpstan/issues/15137).
@Progi1984 the exclusion should be dropped once that is released fixed -- the commit message says so
too, since `composer.json` cannot carry a comment.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)

A one-line constraint change to a dev dependency: nothing to test, no documentation page, and
nothing a release note would carry.
