### PR TITLE
PowerPoint2007 Reader : Read back the alpha a colour was written with

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -14,6 +14,7 @@
 - PowerPoint2007 Reader : Read a group of shapes, and map the shapes it holds out of the coordinate space `a:chOff`/`a:chExt` declares, by [@Wilkolicious](http://github.com/Wilkolicious) in [#870](https://github.com/PHPOffice/PHPPresentation/pull/870) and [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 
 ## Bug fixes
+- PowerPoint2007 Reader : Fixed a colour with an alpha coming back opaque and one character short, taking the first digit of the colour with it, by [@dkulyk](http://github.com/dkulyk) in [#961](https://github.com/PHPOffice/PHPPresentation/pull/961)
 - PowerPoint2007 Writer : Fixed a group taking two shape identifiers and using the second, leaving a number no shape carries, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 - PowerPoint2007 Writer : Fixed a hyperlink, an image, a chart or a comment inside a group inside a group getting no relationship written for it, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 - PowerPoint2007 Writer : Fixed the rotation of a group of shapes being dropped on save, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1942,8 +1942,11 @@ class PowerPoint2007 implements ReaderInterface
         $oColor->setRGB($oElement->getAttribute('val'));
         $oElementAlpha = $xmlReader->getElement('a:alpha', $oElement);
         if ($oElementAlpha instanceof DOMElement && $oElementAlpha->hasAttribute('val')) {
-            $alpha = strtoupper(dechex((int) (((int) $oElementAlpha->getAttribute('val') / 1000) / 100) * 255));
-            $oColor->setRGB($oElement->getAttribute('val'), $alpha);
+            // `a:alpha` counts in thousandths of a percent, which is the percent `setAlpha()` takes
+            // and turns into the hex pair in front of the colour. Doing that arithmetic here read
+            // every alpha but `FF` back as none at all, and wrote it as a single character, which
+            // took the first digit of the colour with it.
+            $oColor->setAlpha((int) round((int) $oElementAlpha->getAttribute('val') / 1000));
         }
 
         return $oColor;

--- a/src/PhpPresentation/Style/Color.php
+++ b/src/PhpPresentation/Style/Color.php
@@ -123,7 +123,8 @@ class Color implements ComparableInterface
             $alpha = 100;
         }
         $alpha = round(($alpha / 100) * 255);
-        $alpha = dechex((int) $alpha);
+        // upper case, as the colour behind it and the `COLOR_*` constants are
+        $alpha = strtoupper(dechex((int) $alpha));
         $alpha = str_pad($alpha, 2, '0', STR_PAD_LEFT);
         // The colour keeps its six characters whether it arrived with an alpha in front of it or not
         $this->argb = $alpha . $this->getRGB();

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1254,6 +1254,51 @@ class PowerPoint2007Test extends TestCase
         self::assertEquals(Fill::FILL_NONE, $seriesRead->getDataPointOutline(1)->getFill()->getFillType());
     }
 
+    /**
+     * @dataProvider dataProviderColorAlpha
+     */
+    #[DataProvider('dataProviderColorAlpha')]
+    public function testColorAlphaIsReadBack(string $argb, int $expectedAlpha): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSeries = new Series('Downloads', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        $oSeries->getFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color($argb));
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oPhpPresentation->getActiveSlide()->createChartShape()->getPlotArea()->setType($oBar);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(Chart::class, $arrayShape[0]);
+        $seriesRead = $arrayShape[0]->getPlotArea()->getType()->getSeries();
+        $seriesRead = reset($seriesRead);
+
+        // the colour comes back whole: an alpha that is not `FF` used to be read as `0`, and as a
+        // single character it took the first digit of the colour with it
+        self::assertEquals($argb, $seriesRead->getFill()->getStartColor()->getARGB());
+        self::assertEquals(substr($argb, 2), $seriesRead->getFill()->getStartColor()->getRGB());
+        self::assertEquals($expectedAlpha, $seriesRead->getFill()->getStartColor()->getAlpha());
+    }
+
+    /**
+     * @return array<array{string, int}>
+     */
+    public static function dataProviderColorAlpha(): array
+    {
+        return [
+            // ARGB written, and the percent it is read back as
+            ['FFFF7700', 100],
+            // 84%: the plate a data label sits on
+            ['D6FFFFFF', 84],
+            // an alpha of one hex digit, which has to keep its leading zero
+            ['0A00FF00', 4],
+        ];
+    }
+
     public function testSeriesDataPointPatternFillIsReadBack(): void
     {
         $oPhpPresentation = new PhpPresentation();


### PR DESCRIPTION
### Description

`loadStyleColor()` did its own arithmetic on `a:alpha` and got it wrong twice. The `(int)` cast bound
to the division rather than to the product, so `(int) 0.84` was `0` and every alpha but `FF` was read
back as none at all; and `dechex(0)` is one character, so the ARGB came out seven characters long and
the colour lost its first digit to the alpha.

```php
$color = new Color('D6FFFFFF');   // <a:srgbClr val="FFFFFF"><a:alpha val="84000"/>
// after a round trip through the reader
$color->getARGB();   // '0FFFFFF'  -- seven characters
$color->getRGB();    // 'FFFFF'    -- the first digit went into the alpha
$color->getAlpha();  // 100        -- the transparency is gone
```

`Color::setAlpha()` already does that arithmetic, and does it correctly: it rounds rather than
truncates, and pads to two characters. The reader hands it the percent and lets it do the work. It
wrote the hex pair in lower case in front of a colour written in upper case everywhere else,
including the `COLOR_*` constants, so it upper-cases it now.

Every colour in this reader goes through that one method -- solid, gradient and pattern fills,
outlines, the fill of a chart serie and of its data points -- so this is not confined to one kind of
shape.

Fixes #960

### Checklist:

- [x] My CI is :green_circle:
> Green locally: 1046 tests, phpstan, phpmd and php-cs-fixer all clean.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
> `testColorAlphaIsReadBack` round-trips three colours through the writer and the reader: an opaque
> one, the 84% a data label plate is written with, and `0A`, whose alpha is a single hex digit and
> has to keep its leading zero.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
> Nothing to describe: this is a fix to reading back what the library already wrote, and no API
> changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
> One line under Bug fixes in `docs/changes/1.3.0.md`.
