### PR TITLE
Shape\Chart\Series : Give the data labels a fill of their own

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -13,6 +13,7 @@
 - Added `Table::setFirstRow()` and `Table::setBandRow()`, so that a table can say whether its first row is a header row, by [@dkulyk](http://github.com/dkulyk) in [#904](https://github.com/PHPOffice/PHPPresentation/pull/904)
 - PowerPoint2007 Reader : Read a group of shapes, and map the shapes it holds out of the coordinate space `a:chOff`/`a:chExt` declares, by [@Wilkolicious](http://github.com/Wilkolicious) in [#870](https://github.com/PHPOffice/PHPPresentation/pull/870) and [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)
 - Added `Shape\RichText\Field`, so that a slide number, a slide count or a date can stand inside a sentence rather than take a whole shape, written and read back by the PowerPoint2007 Writer and Reader and by the ODPresentation Writer and Reader, by [@dkulyk](http://github.com/dkulyk) fixing [#958](https://github.com/PHPOffice/PHPPresentation/issues/958) in [#959](https://github.com/PHPOffice/PHPPresentation/pull/959)
+- PowerPoint2007 Writer & Reader : Added a fill behind the data labels of a chart serie, so that a label stays readable over the chart it sits on, by [@dkulyk](http://github.com/dkulyk) in [#963](https://github.com/PHPOffice/PHPPresentation/pull/963)
 
 ## Bug fixes
 - PowerPoint2007 Reader : Fixed a colour with an alpha coming back opaque and one character short, taking the first digit of the colour with it, by [@dkulyk](http://github.com/dkulyk) in [#961](https://github.com/PHPOffice/PHPPresentation/pull/961)

--- a/docs/usage/shapes/chart.md
+++ b/docs/usage/shapes/chart.md
@@ -344,6 +344,20 @@ $series = new Series('Downloads', $seriesData);
 $series->setLabelPosition(Series::LABEL_INSIDEEND);
 ```
 
+#### Label Fill
+You can draw a plate behind the data labels, so that they stay readable over the chart.
+A series that names no label fill leaves the labels as the application draws them.
+
+``` php
+<?php
+
+$series = new Series('Downloads', $seriesData);
+// White, and see-through enough to read the chart under it
+$series->getLabelFill()
+    ->setFillType(Fill::FILL_SOLID)
+    ->setStartColor(new Color('D6FFFFFF'));
+```
+
 #### Marker
 You can custom the marker of a serie, for Line & Scatter charts.
 

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -1661,6 +1661,13 @@ class PowerPoint2007 implements ReaderInterface
 
         $this->loadSeriesDataPoints($xmlReader, $elementSerie, $series);
 
+        // the plate the data labels sit on, which is a `c:spPr` of its own inside `c:dLbls`
+        if ($elementFill = $xmlReader->getElement('c:dLbls/c:spPr', $elementSerie)) {
+            $series->setLabelFill(
+                $this->loadStyleFill($xmlReader, $elementFill)
+            );
+        }
+
         if ($elementShowLegendKey = $xmlReader->getElement('c:dLbls/c:showLegendKey', $elementSerie)) {
             $series->setShowLegendKey((bool) $elementShowLegendKey->getAttribute('val'));
         }

--- a/src/PhpPresentation/Shape/Chart/Series.php
+++ b/src/PhpPresentation/Shape/Chart/Series.php
@@ -75,6 +75,13 @@ class Series implements ComparableInterface
     protected $font;
 
     /**
+     * The fill behind the data labels, not behind the series itself.
+     *
+     * @var Fill
+     */
+    protected $labelFill;
+
+    /**
      * @var string
      */
     protected $labelPosition = 'ctr';
@@ -158,6 +165,8 @@ class Series implements ComparableInterface
     public function __construct(string $title = 'Series Title', array $values = [])
     {
         $this->fill = new Fill();
+        // the labels are born with no fill of their own: the application draws them as it always did
+        $this->labelFill = (new Fill())->setFillType(Fill::FILL_UNSET);
         $this->font = new Font();
         $this->font->setName('Calibri');
         $this->font->setSize(9);
@@ -227,6 +236,27 @@ class Series implements ComparableInterface
     public function setFill(?Fill $fill = null): self
     {
         $this->fill = $fill ?? (new Fill())->setFillType(Fill::FILL_UNSET);
+
+        return $this;
+    }
+
+    /**
+     * The fill drawn behind the data labels. A series that never named one carries a fill of type
+     * `Fill::FILL_UNSET`, which is written as nothing at all.
+     */
+    public function getLabelFill(): Fill
+    {
+        return $this->labelFill;
+    }
+
+    /**
+     * A semi-transparent plate under the labels is a `Fill::FILL_SOLID` whose colour carries an
+     * alpha, e.g. `new Color('D6FFFFFF')`. Asking for the fill to be taken away replaces it with
+     * one of type `Fill::FILL_UNSET` rather than with a null, as `setFill()` does.
+     */
+    public function setLabelFill(?Fill $fill = null): self
+    {
+        $this->labelFill = $fill ?? (new Fill())->setFillType(Fill::FILL_UNSET);
 
         return $this;
     }

--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -307,6 +307,23 @@ class PptCharts extends AbstractDecoratorWriter
             || $series->hasShowPercentage();
     }
 
+    /**
+     * The plate a data label sits on. A series that never named a label fill writes no `c:spPr`
+     * at all, rather than an empty one, and the application draws the label as it always did.
+     */
+    protected function writeDataLabelsFill(XMLWriter $objWriter, Series $series): void
+    {
+        $fill = $series->getLabelFill();
+        if (Fill::FILL_UNSET == $fill->getFillType()) {
+            return;
+        }
+
+        // c:ser > c:dLbls > c:spPr
+        $objWriter->startElement('c:spPr');
+        $this->writeFill($objWriter, $fill);
+        $objWriter->endElement();
+    }
+
     protected function writeElementWithValAttribute(XMLWriter $objWriter, string $elementName, string $value): void
     {
         $objWriter->startElement($elementName);
@@ -758,6 +775,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->endElement();
                 }
 
+                $this->writeDataLabelsFill($objWriter, $series);
+
                 // c:ser > c:dLbls > c:showVal
                 $this->writeElementWithValAttribute($objWriter, 'c:showVal', $series->hasShowValue() ? '1' : '0');
 
@@ -906,6 +925,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->writeAttribute('sourceLinked', '0');
                     $objWriter->endElement();
                 }
+
+                $this->writeDataLabelsFill($objWriter, $series);
 
                 // c:txPr
                 $objWriter->startElement('c:txPr');
@@ -1133,6 +1154,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->endElement();
                 }
 
+                $this->writeDataLabelsFill($objWriter, $series);
+
                 // c:txPr
                 $objWriter->startElement('c:txPr');
 
@@ -1354,6 +1377,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->endElement();
                 }
 
+                $this->writeDataLabelsFill($objWriter, $series);
+
                 // c:dLbls\c:txPr
                 $objWriter->startElement('c:txPr');
                 $objWriter->writeElement('a:bodyPr', null);
@@ -1496,6 +1521,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->writeAttribute('sourceLinked', '0');
                     $objWriter->endElement();
                 }
+
+                $this->writeDataLabelsFill($objWriter, $series);
 
                 // c:txPr
                 $objWriter->startElement('c:txPr');
@@ -1672,6 +1699,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->endElement();
                 }
 
+                $this->writeDataLabelsFill($objWriter, $series);
+
                 // c:txPr
                 $objWriter->startElement('c:txPr');
 
@@ -1833,6 +1862,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->writeAttribute('sourceLinked', '0');
                     $objWriter->endElement();
                 }
+
+                $this->writeDataLabelsFill($objWriter, $series);
 
                 // c:txPr
                 $objWriter->startElement('c:txPr');
@@ -2022,6 +2053,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->endElement();
                 }
 
+                $this->writeDataLabelsFill($objWriter, $series);
+
                 // c:txPr
                 $objWriter->startElement('c:txPr');
 
@@ -2196,6 +2229,8 @@ class PptCharts extends AbstractDecoratorWriter
                     $objWriter->writeAttribute('sourceLinked', '0');
                     $objWriter->endElement();
                 }
+
+                $this->writeDataLabelsFill($objWriter, $series);
 
                 // c:txPr
                 $objWriter->startElement('c:txPr');

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint2007Test.php
@@ -1300,6 +1300,33 @@ class PowerPoint2007Test extends TestCase
         ];
     }
 
+    public function testSeriesLabelFillIsReadBack(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oSeries = new Series('Downloads', ['Jan' => '1', 'Feb' => '5', 'Mar' => '2']);
+        // the plate the labels sit on: white, and see-through enough to read the chart under it
+        $oSeries->getLabelFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('D6FFFFFF'));
+        $oBar = new Bar();
+        $oBar->addSeries($oSeries);
+        $oPhpPresentation->getActiveSlide()->createChartShape()->getPlotArea()->setType($oBar);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new PowerPoint2007Writer($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new PowerPoint2007())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(Chart::class, $arrayShape[0]);
+        $seriesRead = $arrayShape[0]->getPlotArea()->getType()->getSeries();
+        $seriesRead = reset($seriesRead);
+
+        self::assertEquals(Fill::FILL_SOLID, $seriesRead->getLabelFill()->getFillType());
+        self::assertEquals('FFFFFF', $seriesRead->getLabelFill()->getStartColor()->getRGB());
+        self::assertEquals(84, $seriesRead->getLabelFill()->getStartColor()->getAlpha());
+        // the serie keeps its own fill, which is not the one behind the labels
+        self::assertNotEquals(Fill::FILL_SOLID, $seriesRead->getFill()->getFillType());
+    }
+
     public function testSeriesDataPointPatternFillIsReadBack(): void
     {
         $oPhpPresentation = new PhpPresentation();

--- a/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
+++ b/tests/PhpPresentation/Tests/Shape/Chart/SeriesTest.php
@@ -112,6 +112,18 @@ class SeriesTest extends TestCase
         self::assertEquals(Fill::FILL_NONE, $object->getFill()->getFillType());
     }
 
+    public function testLabelFill(): void
+    {
+        $object = new Series();
+
+        // unlike the series fill, the labels are born with none, and asking for none puts it back
+        self::assertEquals(Fill::FILL_UNSET, $object->getLabelFill()->getFillType());
+        self::assertInstanceOf(Series::class, $object->setLabelFill(new Fill()));
+        self::assertEquals(Fill::FILL_NONE, $object->getLabelFill()->getFillType());
+        self::assertInstanceOf(Series::class, $object->setLabelFill());
+        self::assertEquals(Fill::FILL_UNSET, $object->getLabelFill()->getFillType());
+    }
+
     public function testFont(): void
     {
         $object = new Series();

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -1017,6 +1017,47 @@ class PptChartsTest extends PhpPresentationTestCase
     }
 
     /**
+     * @dataProvider dataProviderDataLabel
+     */
+    #[DataProvider('dataProviderDataLabel')]
+    public function testSeriesDataLabelFill(string $chartType, string $chartElementName): void
+    {
+        $oSeries = new Series('Downloads', $this->seriesData);
+
+        /** @var AbstractType $oChart */
+        $oChart = new $chartType();
+        $oChart->addSeries($oSeries);
+
+        $oShape = $this->oPresentation->getActiveSlide()->createChartShape();
+        $oShape->getPlotArea()->setType($oChart);
+
+        $element = $this->getDataLabelXPath($chartType, $chartElementName) . '/c:spPr';
+
+        // A series that named no label fill leaves the labels as the application draws them.
+        $this->assertZipXmlElementNotExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+        $this->assertIsSchemaECMA376Valid();
+
+        // The plate a label sits on: white, and see-through enough to read the chart under it.
+        $oSeries->getLabelFill()->setFillType(Fill::FILL_SOLID)->setStartColor(new Color('D6FFFFFF'));
+        $this->resetPresentationFile();
+
+        $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
+        $this->assertZipXmlAttributeEquals(
+            'ppt/charts/' . $oShape->getIndexedFilename(),
+            $element . '/a:solidFill/a:srgbClr',
+            'val',
+            'FFFFFF'
+        );
+        $this->assertZipXmlAttributeEquals(
+            'ppt/charts/' . $oShape->getIndexedFilename(),
+            $element . '/a:solidFill/a:srgbClr/a:alpha',
+            'val',
+            '84000'
+        );
+        $this->assertIsSchemaECMA376Valid();
+    }
+
+    /**
      * A doughnut writes one data label block for the whole chart; every other type writes one per series.
      */
     private function getDataLabelXPath(string $chartType, string $chartElementName): string


### PR DESCRIPTION
### Description

A data label is drawn straight over the chart, so it is read against whatever colour the slice under
it happens to be. PowerPoint answers this with a plate behind the text -- a `c:spPr` inside
`c:dLbls`. `Series` had no field for it (`fill`, `dataPointFills`, `font` and `outline` are all about
the slices) and none of the nine `writeType*` methods wrote a `c:spPr` at all, so a presentation read
in with such a plate lost it on save.

```php
$series->getLabelFill()
    ->setFillType(Fill::FILL_SOLID)
    ->setStartColor(new Color('D6FFFFFF'));
```

```xml
<c:dLbls>
  <c:spPr><a:solidFill><a:srgbClr val="FFFFFF"><a:alpha val="84000"/></a:srgbClr></a:solidFill></c:spPr>
  <c:txPr>…
```

The fill is born of type `Fill::FILL_UNSET`, the way a fill nobody named is held everywhere else, so
a serie that does not ask writes no `c:spPr` and nothing changes for a file that never had one.
`FILL_NONE` stays a different answer: the labels sit on nothing, and it writes `a:noFill`. One helper
writes the element at all nine call sites, after `c:numFmt` and before `c:txPr`, which is where
`CT_DLbls` puts it. The reader reads it back beside the `c:spPr` of the serie it already reads.

Checked against LibreOffice in both directions: it reads our `c:dLbls/c:spPr` and re-emits it per
label as `c:dLbl/c:spPr`, keeping the colour and the transparency.

**There is no ODP side to this**, which is worth saying because it looks like an omission. ODF 1.2
has no way to express what a data label sits on; LibreOffice invented `loext:label-fill` and friends
in its own namespace, `jing` rejects those against the OpenDocument 1.2 schema, and LibreOffice
itself drops the transparency when it writes them. The ODPresentation Reader reads no charts at all,
so there is nothing on that side to read it back with either.

This does not depend on #961 and the two can land in either order. The writer test asserts the
`a:alpha` that a semi-transparent plate is written with, which has always been written correctly;
the reader test uses an opaque plate on purpose, because a colour with an alpha does not survive
this reader at all -- that is #960, and #961 fixes it.

Fixes #962

### Checklist:

- [x] My CI is :green_circle:
> Green locally: 1047 tests, phpstan, phpmd and php-cs-fixer all clean.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
> `testSeriesDataLabelFill` runs over all nine chart types through the existing data provider and
> asserts the schema each time, `testSeriesLabelFillIsReadBack` round-trips one through the reader,
> and `SeriesTest::testLabelFill` covers the `FILL_UNSET` default.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
> A "Label Fill" section under Series in `docs/usage/shapes/chart.md`.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.3.0.md)
> One line under Enhancements in `docs/changes/1.3.0.md`.
