### PR TITLE
Presentation : Add moveSlide(), and say how a slide moves

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -16,6 +16,7 @@
 - Added `Shape\RichText\Field`, so that a slide number, a slide count or a date can stand inside a sentence rather than take a whole shape, written and read back by the PowerPoint2007 Writer and Reader and by the ODPresentation Writer and Reader, by [@dkulyk](http://github.com/dkulyk) fixing [#958](https://github.com/PHPOffice/PHPPresentation/issues/958) in [#959](https://github.com/PHPOffice/PHPPresentation/pull/959)
 - PowerPoint2007 Writer & Reader : Added a fill behind the data labels of a chart serie, so that a label stays readable over the chart it sits on, by [@dkulyk](http://github.com/dkulyk) in [#963](https://github.com/PHPOffice/PHPPresentation/pull/963)
 - ODPresentation Writer and Reader : Added the baseline of a font, so that a superscript and a subscript are written as `style:text-position` and read back, in a text run and in a chart font alike, by [@dkulyk](http://github.com/dkulyk) in [#999](https://github.com/PHPOffice/PHPPresentation/pull/999)
+- Documentation : Documented how to move a slide to another position, which the API composes out of `getIndex()`, `removeSlideByIndex()` and `addSlide()` but no page said, by [@dkulyk](http://github.com/dkulyk) in [#966](https://github.com/PHPOffice/PHPPresentation/pull/966)
 
 ## Bug fixes
 - PowerPoint2007 Reader : Fixed a node taken out of a node list being treated as an element without being asked whether it is one, which `phpoffice/common` 1.1.0 no longer promises, by [@dkulyk](http://github.com/dkulyk) in [#1000](https://github.com/PHPOffice/PHPPresentation/pull/1000)

--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -17,6 +17,7 @@
 - PowerPoint2007 Writer & Reader : Added a fill behind the data labels of a chart serie, so that a label stays readable over the chart it sits on, by [@dkulyk](http://github.com/dkulyk) in [#963](https://github.com/PHPOffice/PHPPresentation/pull/963)
 - ODPresentation Writer and Reader : Added the baseline of a font, so that a superscript and a subscript are written as `style:text-position` and read back, in a text run and in a chart font alike, by [@dkulyk](http://github.com/dkulyk) in [#999](https://github.com/PHPOffice/PHPPresentation/pull/999)
 - Documentation : Documented how to move a slide to another position, which the API composes out of `getIndex()`, `removeSlideByIndex()` and `addSlide()` but no page said, by [@dkulyk](http://github.com/dkulyk) in [#966](https://github.com/PHPOffice/PHPPresentation/pull/966)
+- Added `PhpPresentation::moveSlide()`, so that a slide already in the presentation can be moved to another position without being removed and added back by hand, by [@dkulyk](http://github.com/dkulyk) in [#966](https://github.com/PHPOffice/PHPPresentation/pull/966)
 
 ## Bug fixes
 - PowerPoint2007 Reader : Fixed a node taken out of a node list being treated as an element without being asked whether it is one, which `phpoffice/common` 1.1.0 no longer promises, by [@dkulyk](http://github.com/dkulyk) in [#1000](https://github.com/PHPOffice/PHPPresentation/pull/1000)

--- a/docs/usage/slides/introduction.md
+++ b/docs/usage/slides/introduction.md
@@ -14,7 +14,7 @@ $slide = $presentation->createSlide();
 
 ## Add slide to a specific position
 
-Use the method `addSlide` to add an existing slide to a specific position. Without the parameter `$position`, it will be added at the end of slides collection.
+Use the method `addSlide` to add an existing slide to a specific position. Without the parameter `$index`, it will be added at the end of slides collection.
 
 ``` php
 <?php
@@ -29,6 +29,23 @@ $presentation->addSlide($slide, 1);
 ## Add it after all slides
 $presentation->addSlide($slide);
 ```
+
+## Move a slide
+
+There is no single method for it: read the slide's current index, take it out, and add it back
+where you want it.
+
+``` php
+<?php
+
+$index = $presentation->getIndex($slide);
+$presentation->removeSlideByIndex($index);
+$presentation->addSlide($slide, $newIndex);
+```
+
+`getIndex` returns `null` for a slide the presentation does not hold, so check it before removing
+anything. `$newIndex` counts in the collection *without* the slide being moved, which matters when
+a slide moves later in the deck: in `A B C D`, moving `A` to 2 gives `B C A D`.
 
 ## Properties
 

--- a/docs/usage/slides/introduction.md
+++ b/docs/usage/slides/introduction.md
@@ -32,20 +32,19 @@ $presentation->addSlide($slide);
 
 ## Move a slide
 
-There is no single method for it: read the slide's current index, take it out, and add it back
-where you want it.
+Use the method `moveSlide` to move a slide that is already in the presentation to another position.
 
 ``` php
 <?php
 
-$index = $presentation->getIndex($slide);
-$presentation->removeSlideByIndex($index);
-$presentation->addSlide($slide, $newIndex);
+$presentation->moveSlide($slide, 2);
 ```
 
-`getIndex` returns `null` for a slide the presentation does not hold, so check it before removing
-anything. `$newIndex` counts in the collection *without* the slide being moved, which matters when
-a slide moves later in the deck: in `A B C D`, moving `A` to 2 gives `B C A D`.
+The slide is taken out before it is put back, so the index counts in the collection *without* it.
+In a presentation of `A B C D`, moving `A` to 2 gives `B C A D`.
+
+It throws an `OutOfBoundsException` for an index past the last slide, and an
+`InvalidParameterException` for a slide the presentation does not hold.
 
 ## Properties
 

--- a/src/PhpPresentation/PhpPresentation.php
+++ b/src/PhpPresentation/PhpPresentation.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpPresentation;
 
 use ArrayObject;
+use PhpOffice\PhpPresentation\Exception\InvalidParameterException;
 use PhpOffice\PhpPresentation\Exception\OutOfBoundsException;
 use PhpOffice\PhpPresentation\Slide\Iterator;
 use PhpOffice\PhpPresentation\Slide\SlideMaster;
@@ -188,6 +189,28 @@ class PhpPresentation
             throw new OutOfBoundsException(0, count($this->slideCollection) - 1, $index);
         }
         array_splice($this->slideCollection, $index, 1);
+
+        return $this;
+    }
+
+    /**
+     * Move a slide already in the presentation to another position.
+     *
+     * The slide is taken out before it is put back, so `$index` counts in the collection without
+     * it: in a presentation of A B C D, moving A to 2 gives B C A D.
+     *
+     * @param int $index Position to move the slide to
+     */
+    public function moveSlide(Slide $slide, int $index): self
+    {
+        $from = $this->getIndex($slide);
+        if (null === $from) {
+            throw new InvalidParameterException('slide', $slide->getHashCode(), 'The slide is not in this presentation');
+        }
+        if ($index > count($this->slideCollection) - 1) {
+            throw new OutOfBoundsException(0, count($this->slideCollection) - 1, $index);
+        }
+        array_splice($this->slideCollection, $index, 0, array_splice($this->slideCollection, $from, 1));
 
         return $this;
     }

--- a/tests/PhpPresentation/Tests/PhpPresentationTest.php
+++ b/tests/PhpPresentation/Tests/PhpPresentationTest.php
@@ -22,6 +22,7 @@ namespace PhpOffice\PhpPresentation\Tests;
 
 use PhpOffice\PhpPresentation\DocumentLayout;
 use PhpOffice\PhpPresentation\DocumentProperties;
+use PhpOffice\PhpPresentation\Exception\InvalidParameterException;
 use PhpOffice\PhpPresentation\Exception\OutOfBoundsException;
 use PhpOffice\PhpPresentation\PhpPresentation;
 use PhpOffice\PhpPresentation\PresentationProperties;
@@ -190,5 +191,81 @@ class PhpPresentationTest extends TestCase
         self::assertEquals('Slide 1', $presentation->getSlide(0)->getName());
         self::assertEquals('Slide 2', $presentation->getSlide(1)->getName());
         self::assertEquals('Slide 3', $presentation->getSlide(2)->getName());
+    }
+
+    /**
+     * A presentation of slides named A, B, C, D and nothing else.
+     */
+    private function getNamedPresentation(): PhpPresentation
+    {
+        $presentation = new PhpPresentation();
+        $presentation->removeSlideByIndex(0);
+        foreach (['A', 'B', 'C', 'D'] as $name) {
+            $presentation->createSlide()->setName($name);
+        }
+
+        return $presentation;
+    }
+
+    private function getSlideNames(PhpPresentation $presentation): string
+    {
+        $names = [];
+        foreach ($presentation->getAllSlides() as $slide) {
+            $names[] = $slide->getName();
+        }
+
+        return implode(' ', $names);
+    }
+
+    public function testMoveSlideEarlier(): void
+    {
+        $presentation = $this->getNamedPresentation();
+        $presentation->moveSlide($presentation->getSlide(3), 0);
+
+        self::assertEquals('D A B C', $this->getSlideNames($presentation));
+    }
+
+    public function testMoveSlideLater(): void
+    {
+        // the slide is taken out before it is put back, so the index counts in the collection
+        // without it -- A moved to 2 lands between C and D, not between B and C
+        $presentation = $this->getNamedPresentation();
+        $presentation->moveSlide($presentation->getSlide(0), 2);
+
+        self::assertEquals('B C A D', $this->getSlideNames($presentation));
+    }
+
+    public function testMoveSlideToWhereItAlreadyIs(): void
+    {
+        $presentation = $this->getNamedPresentation();
+        $presentation->moveSlide($presentation->getSlide(1), 1);
+
+        self::assertEquals('A B C D', $this->getSlideNames($presentation));
+    }
+
+    public function testMoveSlideReturnsThePresentation(): void
+    {
+        $presentation = $this->getNamedPresentation();
+
+        self::assertSame($presentation, $presentation->moveSlide($presentation->getSlide(0), 1));
+    }
+
+    public function testMoveSlideNotInThePresentation(): void
+    {
+        $presentation = $this->getNamedPresentation();
+        $stranger = new Slide();
+        $stranger->setName('Stranger');
+
+        $this->expectException(InvalidParameterException::class);
+        $presentation->moveSlide($stranger, 0);
+    }
+
+    public function testMoveSlideOutOfBounds(): void
+    {
+        $presentation = $this->getNamedPresentation();
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('The expected value (4) is out of bounds (0, 3)');
+        $presentation->moveSlide($presentation->getSlide(0), 4);
     }
 }


### PR DESCRIPTION
### Description

`addSlide()` has taken a position since #810, and `docs/usage/slides/introduction.md` documents
that. Moving a slide that is **already** in the deck is the other half of the same question, and
the reporter of #477 asked for both. Until now the second one had no method and no page: a caller
had to find `getIndex()`, `removeSlideByIndex()` and `addSlide()` and get the order right.

`PhpPresentation::moveSlide(Slide $slide, int $index)` does it in one call.

```php
$presentation->moveSlide($slide, 2);
```

The index counts in the collection *without* the slide being moved, which is the part worth writing
down: in a presentation of `A B C D`, moving `A` to 2 gives `B C A D`, not `A` landing where it
stood before the removal. It throws `OutOfBoundsException` for an index past the last slide and
`InvalidParameterException` for a slide the presentation does not hold.

One signature rather than two: a union `Slide|int $slide` would let a caller pass either, but a
native union type is PHP 8.0 and the floor is `^7.4`, and `getSlide()` already turns an index into
a slide. `moveSlideByIndex(int $from, int $to)` was the alternative and reads ambiguously -- both
parameters are indices and the name says which is which only by position.

This also fixes the paragraph above the new section, which called the parameter of `addSlide()`
`$position`; the signature calls it `$index`.

Fixes #477

### Checklist:

- [x] My CI is :green_circle:
> 1121 tests / 9152 assertions green locally, with `--fail-on-warning --fail-on-notice
> --fail-on-deprecation --fail-on-phpunit-deprecation`. phpstan, phpmd and php-cs-fixer clean.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
> Six tests in `PhpPresentationTest`: moving earlier, moving later (the index-shift case),
> moving a slide to where it already is, the fluent return, a slide the presentation does not hold,
> and an index past the last slide.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
> `docs/usage/slides/introduction.md` -- a `Move a slide` section, next to the one about adding at
> a position.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
> `docs/changes/1.3.0.md`.
