### PR TITLE
ODPresentation Reader : Give a shape the border its style names

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -78,6 +78,7 @@
 - ODPresentation Writer : Shared the graphic and the drawing-page styles between everything that writes the same one, the way the paragraph and the text ones are, by [@dkulyk](http://github.com/dkulyk) in [#936](https://github.com/PHPOffice/PHPPresentation/pull/936)
 - PowerPoint2007 Reader : Fixed a shadow's alignment being read off the effect list rather than off the shadow in it, and its colour and alpha being looked for under a preset colour the Writer never writes, and read a shape's wrap back, by [@dkulyk](http://github.com/dkulyk) in [#982](https://github.com/PHPOffice/PHPPresentation/pull/982)
 - ODPresentation Reader : Fixed a paragraph's line spacing being read out of the margin below it, so that every spacing came back as that margin in centimetres and every mode as points, by [@dkulyk](http://github.com/dkulyk) in [#980](https://github.com/PHPOffice/PHPPresentation/pull/980)
+- ODPresentation Reader : Fixed a shape's border being written as a stroke and never read back, so that every shape loaded from a file wore the default border rather than its own, by [@dkulyk](http://github.com/dkulyk) in [#978](https://github.com/PHPOffice/PHPPresentation/pull/978)
 
 - PowerPoint97 Reader : Fixed a stream being read one byte past its end, raising `Uninitialized string offset` once per byte for each structure the parser walks off the end of, by [@dkulyk](http://github.com/dkulyk) in [#995](https://github.com/PHPOffice/PHPPresentation/pull/995)
 ## BC Breaks

--- a/src/PhpPresentation/AbstractShape.php
+++ b/src/PhpPresentation/AbstractShape.php
@@ -409,6 +409,13 @@ abstract class AbstractShape implements ComparableInterface
         return $this->border;
     }
 
+    public function setBorder(Border $border): self
+    {
+        $this->border = $border;
+
+        return $this;
+    }
+
     public function getShadow(): Shadow
     {
         return $this->shadow;

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -24,6 +24,7 @@ use DateTime;
 use DOMElement;
 use PhpOffice\Common\Drawing as CommonDrawing;
 use PhpOffice\Common\XMLReader;
+use PhpOffice\PhpPresentation\AbstractShape;
 use PhpOffice\PhpPresentation\DocumentProperties;
 use PhpOffice\PhpPresentation\Exception\FileNotFoundException;
 use PhpOffice\PhpPresentation\Exception\InvalidFileFormatException;
@@ -115,14 +116,26 @@ class ODPresentation implements ReaderInterface
      *
      * @var array<int, string>
      */
+    /**
+     * The dash patterns the ODPresentation Writer names a stroke dash after, so that a name it
+     * did not write is not handed to a border as a pattern.
+     *
+     * @var array<int, string>
+     */
+    protected const DASH_STYLES = [
+        Border::DASH_DASH, Border::DASH_DASHDOT, Border::DASH_DOT, Border::DASH_LARGEDASH,
+        Border::DASH_LARGEDASHDOT, Border::DASH_LARGEDASHDOTDOT, Border::DASH_SYSDASH,
+        Border::DASH_SYSDASHDOT, Border::DASH_SYSDASHDOTDOT, Border::DASH_SYSDOT,
+    ];
+
     protected const STYLE_KEYS = [
         'alignment', 'background', 'columns', 'columnSpacing', 'columnsRTL', 'fill', 'font',
         'shadow', 'listStyle', 'spacingAfter', 'spacingBefore', 'lineSpacingMode', 'lineSpacing',
-        'rowHeight', 'borders',
+        'rowHeight', 'borders', 'border',
     ];
 
     /**
-     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, columns: null|int, columnSpacing: null|int, columnsRTL: null|bool, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string, rowHeight: null|int, borders: null|Borders}>
+     * @var array<string, array{alignment: null|Alignment, background: null|BackgroundColor|Image, columns: null|int, columnSpacing: null|int, columnsRTL: null|bool, fill: null|Fill, font: null|Font, shadow: null|Shadow, listStyle: null|array<int, array{alignment: Alignment, bullet: Bullet}>, spacingAfter: null|float, spacingBefore: null|float, lineSpacingMode: null|string, lineSpacing: null|string, rowHeight: null|int, borders: null|Borders, border: null|Border}>
      */
     protected $arrayStyles = [];
 
@@ -422,6 +435,31 @@ class ODPresentation implements ReaderInterface
                         break;
                 }
             }
+            // Read the border, which a shape says as the stroke of its graphic style. OpenDocument
+            // has three strokes and no compound line, so a border comes back single or none; the
+            // dash it names carries the pattern, which is finer than the stroke itself.
+            if ($nodeGraphicProps->hasAttribute('draw:stroke')) {
+                $oBorder = new Border();
+                if ('none' === $nodeGraphicProps->getAttribute('draw:stroke')) {
+                    $oBorder->setLineStyle(Border::LINE_NONE);
+                } else {
+                    $oBorder->setLineStyle(Border::LINE_SINGLE)->setDashStyle(Border::DASH_SOLID);
+                }
+                if ('dash' === $nodeGraphicProps->getAttribute('draw:stroke')) {
+                    $dashStyle = substr($nodeGraphicProps->getAttribute('draw:stroke-dash'), strlen('strokeDash_'));
+                    $oBorder->setDashStyle(in_array($dashStyle, self::DASH_STYLES, true) ? $dashStyle : Border::DASH_DASH);
+                }
+                if ($nodeGraphicProps->hasAttribute('svg:stroke-width')) {
+                    // rounded because a width goes into the file as centimetres, and a whole
+                    // number of points is not a whole number of them
+                    $oBorder->setLineWidth(round(CommonDrawing::centimetersToPoints(
+                        (float) substr($nodeGraphicProps->getAttribute('svg:stroke-width'), 0, -2)
+                    ), 4));
+                }
+                if ($nodeGraphicProps->hasAttribute('svg:stroke-color')) {
+                    $oBorder->setColor(new Color('FF' . substr($nodeGraphicProps->getAttribute('svg:stroke-color'), 1)));
+                }
+            }
             // Read Fill
             if ($nodeGraphicProps->hasAttribute('draw:fill')) {
                 $value = $nodeGraphicProps->getAttribute('draw:fill');
@@ -705,6 +743,7 @@ class ODPresentation implements ReaderInterface
             'lineSpacing' => $lineSpacing ?? null,
             'rowHeight' => $rowHeight ?? null,
             'borders' => $borders ?? null,
+            'border' => $oBorder ?? null,
         ];
 
         return true;
@@ -909,10 +948,30 @@ class ODPresentation implements ReaderInterface
             if (isset($this->arrayStyles[$keyStyle])) {
                 $shape->setShadow($this->arrayStyles[$keyStyle]['shadow']);
                 $shape->setFill($this->arrayStyles[$keyStyle]['fill']);
+                $this->applyShapeBorder($shape, $this->arrayStyles[$keyStyle]['border']);
             }
         }
 
         $this->oPhpPresentation->getActiveSlide()->addShape($shape);
+    }
+
+    /**
+     * Put the border a graphic style names on a shape.
+     *
+     * A shape is born holding its own `Border` and hands it out rather than taking one, so what
+     * the style says is copied onto it.
+     */
+    protected function applyShapeBorder(AbstractShape $shape, ?Border $oBorder): void
+    {
+        if (null === $oBorder) {
+            return;
+        }
+
+        $shape->getBorder()
+            ->setLineStyle($oBorder->getLineStyle())
+            ->setDashStyle($oBorder->getDashStyle())
+            ->setLineWidth($oBorder->getLineWidth())
+            ->setColor($oBorder->getColor());
     }
 
     /**
@@ -943,6 +1002,7 @@ class ODPresentation implements ReaderInterface
                 if (null !== $this->arrayStyles[$keyStyle]['columnsRTL']) {
                     $oShape->setColumnsRTL($this->arrayStyles[$keyStyle]['columnsRTL']);
                 }
+                $this->applyShapeBorder($oShape, $this->arrayStyles[$keyStyle]['border']);
             }
         }
 

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -116,18 +116,6 @@ class ODPresentation implements ReaderInterface
      *
      * @var array<int, string>
      */
-    /**
-     * The dash patterns the ODPresentation Writer names a stroke dash after, so that a name it
-     * did not write is not handed to a border as a pattern.
-     *
-     * @var array<int, string>
-     */
-    protected const DASH_STYLES = [
-        Border::DASH_DASH, Border::DASH_DASHDOT, Border::DASH_DOT, Border::DASH_LARGEDASH,
-        Border::DASH_LARGEDASHDOT, Border::DASH_LARGEDASHDOTDOT, Border::DASH_SYSDASH,
-        Border::DASH_SYSDASHDOT, Border::DASH_SYSDASHDOTDOT, Border::DASH_SYSDOT,
-    ];
-
     protected const STYLE_KEYS = [
         'alignment', 'background', 'columns', 'columnSpacing', 'columnsRTL', 'fill', 'font',
         'shadow', 'listStyle', 'spacingAfter', 'spacingBefore', 'lineSpacingMode', 'lineSpacing',
@@ -439,25 +427,25 @@ class ODPresentation implements ReaderInterface
             // has three strokes and no compound line, so a border comes back single or none; the
             // dash it names carries the pattern, which is finer than the stroke itself.
             if ($nodeGraphicProps->hasAttribute('draw:stroke')) {
-                $oBorder = new Border();
+                $border = new Border();
                 if ('none' === $nodeGraphicProps->getAttribute('draw:stroke')) {
-                    $oBorder->setLineStyle(Border::LINE_NONE);
+                    $border->setLineStyle(Border::LINE_NONE);
                 } else {
-                    $oBorder->setLineStyle(Border::LINE_SINGLE)->setDashStyle(Border::DASH_SOLID);
+                    $border->setLineStyle(Border::LINE_SINGLE)->setDashStyle(Border::DASH_SOLID);
                 }
                 if ('dash' === $nodeGraphicProps->getAttribute('draw:stroke')) {
                     $dashStyle = substr($nodeGraphicProps->getAttribute('draw:stroke-dash'), strlen('strokeDash_'));
-                    $oBorder->setDashStyle(in_array($dashStyle, self::DASH_STYLES, true) ? $dashStyle : Border::DASH_DASH);
+                    $border->setDashStyle(in_array($dashStyle, Border::DASH_STYLES, true) ? $dashStyle : Border::DASH_DASH);
                 }
                 if ($nodeGraphicProps->hasAttribute('svg:stroke-width')) {
                     // rounded because a width goes into the file as centimetres, and a whole
                     // number of points is not a whole number of them
-                    $oBorder->setLineWidth(round(CommonDrawing::centimetersToPoints(
+                    $border->setLineWidth(round(CommonDrawing::centimetersToPoints(
                         (float) substr($nodeGraphicProps->getAttribute('svg:stroke-width'), 0, -2)
                     ), 4));
                 }
                 if ($nodeGraphicProps->hasAttribute('svg:stroke-color')) {
-                    $oBorder->setColor(new Color('FF' . substr($nodeGraphicProps->getAttribute('svg:stroke-color'), 1)));
+                    $border->setColor(new Color('FF' . substr($nodeGraphicProps->getAttribute('svg:stroke-color'), 1)));
                 }
             }
             // Read Fill
@@ -743,7 +731,7 @@ class ODPresentation implements ReaderInterface
             'lineSpacing' => $lineSpacing ?? null,
             'rowHeight' => $rowHeight ?? null,
             'borders' => $borders ?? null,
-            'border' => $oBorder ?? null,
+            'border' => $border ?? null,
         ];
 
         return true;
@@ -956,22 +944,15 @@ class ODPresentation implements ReaderInterface
     }
 
     /**
-     * Put the border a graphic style names on a shape.
-     *
-     * A shape is born holding its own `Border` and hands it out rather than taking one, so what
-     * the style says is copied onto it.
+     * Put the border a graphic style names on a shape, where the style named one.
      */
-    protected function applyShapeBorder(AbstractShape $shape, ?Border $oBorder): void
+    protected function applyShapeBorder(AbstractShape $shape, ?Border $border): void
     {
-        if (null === $oBorder) {
+        if (null === $border) {
             return;
         }
 
-        $shape->getBorder()
-            ->setLineStyle($oBorder->getLineStyle())
-            ->setDashStyle($oBorder->getDashStyle())
-            ->setLineWidth($oBorder->getLineWidth())
-            ->setColor($oBorder->getColor());
+        $shape->setBorder($border);
     }
 
     /**

--- a/src/PhpPresentation/Style/Border.php
+++ b/src/PhpPresentation/Style/Border.php
@@ -46,6 +46,17 @@ class Border implements ComparableInterface
     public const DASH_SYSDOT = 'sysDot';
 
     /**
+     * Every dash style a border can be given.
+     *
+     * @var array<int, string>
+     */
+    public const DASH_STYLES = [
+        self::DASH_DASH, self::DASH_DASHDOT, self::DASH_DOT, self::DASH_LARGEDASH,
+        self::DASH_LARGEDASHDOT, self::DASH_LARGEDASHDOTDOT, self::DASH_SOLID,
+        self::DASH_SYSDASH, self::DASH_SYSDASHDOT, self::DASH_SYSDASHDOTDOT, self::DASH_SYSDOT,
+    ];
+
+    /**
      * Line width.
      *
      * @var float

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -1302,7 +1302,9 @@ class Content extends AbstractDecoratorWriter
                 if (null !== $borderColor) {
                     $objWriter->writeAttribute('svg:stroke-color', '#' . $borderColor->getRGB());
                 }
-                $objWriter->writeAttribute('svg:stroke-width', number_format(CommonDrawing::pointsToCentimeters($shape->getBorder()->getLineWidth()), 3, '.', '') . 'cm');
+                // six decimals rather than three: a point is 127/3600 cm, and three decimals lose
+                // about a seventieth of a point of the width
+                $objWriter->writeAttribute('svg:stroke-width', round(CommonDrawing::pointsToCentimeters($shape->getBorder()->getLineWidth()), 6) . 'cm');
                 switch ($shape->getBorder()->getDashStyle()) {
                     case Border::DASH_SOLID:
                         $objWriter->writeAttribute('draw:stroke', 'solid');
@@ -1433,7 +1435,7 @@ class Content extends AbstractDecoratorWriter
             if (null !== $borderColor) {
                 $objWriter->writeAttribute('svg:stroke-color', '#' . $borderColor->getRGB());
             }
-            $objWriter->writeAttribute('svg:stroke-width', Text::numberFormat(CommonDrawing::pointsToCentimeters($shape->getBorder()->getLineWidth()), 3) . 'cm');
+            $objWriter->writeAttribute('svg:stroke-width', round(CommonDrawing::pointsToCentimeters($shape->getBorder()->getLineWidth()), 6) . 'cm');
             $this->writeStylePartShadow($objWriter, $shape->getShadow());
             $objWriter->endElement();
         }, $shape);

--- a/tests/PhpPresentation/Tests/AbstractShapeTest.php
+++ b/tests/PhpPresentation/Tests/AbstractShapeTest.php
@@ -54,6 +54,15 @@ class AbstractShapeTest extends TestCase
         self::assertInstanceOf(Shadow::class, $object->getShadow());
     }
 
+    public function testBorder(): void
+    {
+        $object = new RichText();
+        $border = (new Border())->setLineStyle(Border::LINE_SINGLE);
+
+        self::assertInstanceOf(AbstractShape::class, $object->setBorder($border));
+        self::assertSame($border, $object->getBorder());
+    }
+
     public function testDecorative(): void
     {
         $object = new RichText();

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1641,4 +1641,46 @@ class ODPresentationTest extends TestCase
         self::assertEquals(11, $arrayShape[0]->getParagraph()->getSpacingBefore());
         self::assertEquals(13, $arrayShape[0]->getParagraph()->getSpacingAfter());
     }
+
+    public function testShapeBorderSurvivesTheRoundTrip(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('Sample');
+        $oShape->getBorder()
+            ->setLineStyle(Border::LINE_SINGLE)
+            ->setDashStyle(Border::DASH_LARGEDASHDOT)
+            ->setLineWidth(4)
+            ->setColor(new Color('FFFF0000'));
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+
+        // the graphic style of a shape says its border as a stroke, and nothing read it back
+        $oBorder = $arrayShape[0]->getBorder();
+        self::assertEquals(Border::LINE_SINGLE, $oBorder->getLineStyle());
+        self::assertEquals(Border::DASH_LARGEDASHDOT, $oBorder->getDashStyle());
+        self::assertEquals(4, $oBorder->getLineWidth());
+        self::assertEquals('FFFF0000', $oBorder->getColor()->getARGB());
+    }
+
+    public function testShapeWithoutABorderSaysSoAfterTheRoundTrip(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oPhpPresentation->getActiveSlide()->createRichTextShape()->createTextRun('Sample');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertEquals(Border::LINE_NONE, $arrayShape[0]->getBorder()->getLineStyle());
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -710,6 +710,25 @@ class ContentTest extends PhpPresentationTestCase
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 
+    /**
+     * A stroke width is written at the precision it comes back at: one point is 0.035278cm, and
+     * the three decimals the lengths beside it carry would put 0.035cm in the file.
+     */
+    public function testBorderWidth(): void
+    {
+        $oSlide = $this->oPresentation->getActiveSlide();
+        $oSlide->createRichTextShape()->getBorder()
+            ->setLineStyle(Border::LINE_SINGLE)->setLineWidth(1);
+        $oSlide->createLineShape(10, 10, 100, 100)->getBorder()
+            ->setLineStyle(Border::LINE_SINGLE)->setLineWidth(1);
+
+        $element = $this->getShapeStyleXPath() . '/style:graphic-properties';
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'svg:stroke-width', '0.035278cm');
+        $element = $this->getLineStyleXPath() . '/style:graphic-properties';
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'svg:stroke-width', '0.035278cm');
+        $this->assertIsSchemaOpenDocumentValid('1.2');
+    }
+
     public function testLineShadow(): void
     {
         $this->oPresentation->getActiveSlide()->createLineShape(10, 10, 100, 100)


### PR DESCRIPTION
### Description

Fixes #977

The Writer writes a shape's border as the stroke of its graphic style -- `draw:stroke`, `svg:stroke-width`, `svg:stroke-color` and `draw:stroke-dash` -- and nothing read any of the four back, so every shape loaded from an ODP wore the border it was born with. This is the ODPresentation half of #969.

The dash carries the pattern in its name, `strokeDash_lgDashDot` and the nine beside it, which is finer than the three strokes OpenDocument itself has. A name this library did not write, such as LibreOffice's `Dash_20_5`, is taken as a plain dash rather than handed to the border as a pattern.

`getLineStyle()` comes back single or none: OpenDocument has no attribute for a compound line, so a border written as `LINE_DOUBLE` cannot say so, the way a shadow cannot say its blur.

A shape is born holding its own `Border` and hands it out rather than taking one, so what the style says is copied onto it.

`svg:stroke-width` goes into the file as centimetres and is now written to six decimals rather than three: a point is 127/3600 cm, and three decimals lose about a seventieth of a point -- enough that a four point border came back as 3.997.

Not in this: `addDrawingStyle()` writes `draw:stroke="none"` on every picture whatever border it carries, so a picture's border is lost on the way out rather than on the way back. That is its own fix.

Found by walking every property of a shape through each Writer/Reader pair and diffing what came back; this closes three of the differences the ODP pair showed.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
> `phpunit`, `phpstan`, `phpmd` and `php-cs-fixer` all clean.
- [x] The new code is covered by unit tests
> A round trip over the four properties, which fails on `develop`, and one over a shape given no border, which guards the change against putting one there.
- [x] I have updated the documentation to describe the changes
> `docs/changes/1.3.0.md`.
- [x] I have added my name to the Changelog
> Same file.
