### PR TITLE
ODPresentation Reader : Read a paragraph's line spacing out of the line height

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -76,6 +76,7 @@
 - ODPresentation Writer : Fixed the paragraph, the text and the graphic style of a slide note being referenced but never written, and shared one automatic style between everything that writes the same one, by [@dkulyk](http://github.com/dkulyk) in [#935](https://github.com/PHPOffice/PHPPresentation/pull/935)
 - ODPresentation Writer : Shared the graphic and the drawing-page styles between everything that writes the same one, the way the paragraph and the text ones are, by [@dkulyk](http://github.com/dkulyk) in [#936](https://github.com/PHPOffice/PHPPresentation/pull/936)
 - PowerPoint2007 Reader : Fixed a shadow's alignment being read off the effect list rather than off the shadow in it, and its colour and alpha being looked for under a preset colour the Writer never writes, and read a shape's wrap back, by [@dkulyk](http://github.com/dkulyk) in [#982](https://github.com/PHPOffice/PHPPresentation/pull/982)
+- ODPresentation Reader : Fixed a paragraph's line spacing being read out of the margin below it, so that every spacing came back as that margin in centimetres and every mode as points, by [@dkulyk](http://github.com/dkulyk) in [#980](https://github.com/PHPOffice/PHPPresentation/pull/980)
 
 ## BC Breaks
 - `AbstractShape::setShadow()` given `null` now stores a fresh `Shadow` instead of the null, so `AbstractShape::getShadow()` returns `Shadow` rather than `?Shadow`. Code that read it back as null tests the shadow it gets instead (`getShadow()->isVisible()`); a subclass that overrode it with a nullable return type widens it.

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -576,15 +576,17 @@ class ODPresentation implements ReaderInterface
         $nodeParagraphProps = $this->oXMLReader->getElement('style:paragraph-properties', $nodeStyle);
         if ($nodeParagraphProps instanceof DOMElement) {
             if ($nodeParagraphProps->hasAttribute('fo:line-height')) {
-                $lineHeightUnit = $this->getExpressionUnit($nodeParagraphProps->getAttribute('fo:margin-bottom'));
+                $lineHeightUnit = $this->getExpressionUnit($nodeParagraphProps->getAttribute('fo:line-height'));
                 $lineSpacingMode = $lineHeightUnit == '%' ? Paragraph::LINE_SPACING_MODE_PERCENT : Paragraph::LINE_SPACING_MODE_POINT;
-                $lineSpacing = $this->getExpressionValue($nodeParagraphProps->getAttribute('fo:margin-bottom'));
+                $lineSpacing = $this->getExpressionValue($nodeParagraphProps->getAttribute('fo:line-height'));
             }
+            // rounded because a spacing goes into the file as centimetres, and a whole number of
+            // points is not a whole number of them
             if ($nodeParagraphProps->hasAttribute('fo:margin-bottom')) {
-                $spacingAfter = self::sizeToPoint($nodeParagraphProps->getAttribute('fo:margin-bottom'));
+                $spacingAfter = round((float) self::sizeToPoint($nodeParagraphProps->getAttribute('fo:margin-bottom')), 4);
             }
             if ($nodeParagraphProps->hasAttribute('fo:margin-top')) {
-                $spacingBefore = self::sizeToPoint($nodeParagraphProps->getAttribute('fo:margin-top'));
+                $spacingBefore = round((float) self::sizeToPoint($nodeParagraphProps->getAttribute('fo:margin-top')), 4);
             }
             $oAlignment = new Alignment();
             if ($nodeParagraphProps->hasAttribute('fo:text-align')) {

--- a/src/PhpPresentation/Writer/ODPresentation/Content.php
+++ b/src/PhpPresentation/Writer/ODPresentation/Content.php
@@ -1145,13 +1145,15 @@ class Content extends AbstractDecoratorWriter
             'fo:line-height',
             $item->getLineSpacing() . 'pt'
         );
+        // six decimals rather than three: a point is 127/3600 cm, and three decimals lose about a
+        // seventieth of a point of the spacing
         $objWriter->writeAttribute(
             'fo:margin-top',
-            Text::numberFormat(CommonDrawing::pointstoCentimeters($item->getSpacingBefore()), 3) . 'cm'
+            round(CommonDrawing::pointstoCentimeters($item->getSpacingBefore()), 6) . 'cm'
         );
         $objWriter->writeAttribute(
             'fo:margin-bottom',
-            Text::numberFormat(CommonDrawing::pointstoCentimeters($item->getSpacingAfter()), 3) . 'cm'
+            round(CommonDrawing::pointstoCentimeters($item->getSpacingAfter()), 6) . 'cm'
         );
         switch ($item->getAlignment()->getHorizontal()) {
             case Alignment::HORIZONTAL_LEFT:

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1584,4 +1584,61 @@ class ODPresentationTest extends TestCase
         self::assertNotInstanceOf(Field::class, $arrayElements[2]);
         self::assertEquals(' of ', $arrayElements[2]->getText());
     }
+
+    /**
+     * @return array<array<int|string>>
+     */
+    public static function dataProviderLineSpacing(): array
+    {
+        return [
+            [Paragraph::LINE_SPACING_MODE_PERCENT, 150],
+            [Paragraph::LINE_SPACING_MODE_POINT, 22],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderLineSpacing
+     */
+    #[DataProvider('dataProviderLineSpacing')]
+    public function testLineSpacingSurvivesTheRoundTrip(string $mode, int $spacing): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('Sample');
+        $oShape->getActiveParagraph()->setLineSpacingMode($mode)->setLineSpacing($spacing);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+
+        // the line height was read out of the margin below the paragraph rather than out of
+        // itself, so every spacing came back as the margin in centimetres, rounded down
+        self::assertEquals($mode, $arrayShape[0]->getParagraph()->getLineSpacingMode());
+        self::assertEquals($spacing, $arrayShape[0]->getParagraph()->getLineSpacing());
+    }
+
+    public function testParagraphSpacingSurvivesTheRoundTrip(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oShape = $oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape->createTextRun('Sample');
+        $oShape->getActiveParagraph()->setSpacingBefore(11)->setSpacingAfter(13);
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+
+        // a spacing is points here and centimetres in the file, and three decimals of a
+        // centimetre were not enough to give a whole number of points back
+        self::assertEquals(11, $arrayShape[0]->getParagraph()->getSpacingBefore());
+        self::assertEquals(13, $arrayShape[0]->getParagraph()->getSpacingAfter());
+    }
 }

--- a/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
+++ b/tests/PhpPresentation/Tests/Writer/ODPresentation/ContentTest.php
@@ -825,7 +825,8 @@ class ContentTest extends PhpPresentationTestCase
 
         $element = $this->getParagraphStyleXPath() . '/style:paragraph-properties';
         $this->assertZipXmlAttributeExists('content.xml', $element, 'fo:margin-top');
-        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:margin-top', '4.339cm');
+        // six decimals of a centimetre, so that 123 points come back as 123 rather than as 122.99
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:margin-top', '4.339167cm');
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 
@@ -836,7 +837,8 @@ class ContentTest extends PhpPresentationTestCase
 
         $element = $this->getParagraphStyleXPath() . '/style:paragraph-properties';
         $this->assertZipXmlAttributeExists('content.xml', $element, 'fo:margin-bottom');
-        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:margin-bottom', '4.339cm');
+        // six decimals of a centimetre, so that 123 points come back as 123 rather than as 122.99
+        $this->assertZipXmlAttributeEquals('content.xml', $element, 'fo:margin-bottom', '4.339167cm');
         $this->assertIsSchemaOpenDocumentValid('1.2');
     }
 


### PR DESCRIPTION
### Description

Fixes #979

`loadStyle()` asks whether `fo:line-height` is there and then takes both the unit and the value out of `fo:margin-bottom`. A line spacing therefore came back as the margin below the paragraph, cut to an integer, and the mode always came back as points, because a margin is written in centimetres and never in per cent.

`fo:margin-top` and `fo:margin-bottom` are written to six decimals rather than three: a point is 127/3600 cm, so three decimals lose about a seventieth of a point, and 11 points came back as 10.998425196850395. The two Writer tests that pinned the old three decimals now pin the six.

`Alignment::getLevel()` is lost as well and is deliberately left alone: a level lives in the nesting of `text:list`, and a list is written only for a paragraph that carries a bullet, so a level on a plain paragraph has nowhere to go. Where it should go is a decision rather than a fix.

Found by walking every property of a shape through each Writer/Reader pair and diffing what came back; this closes four of the differences the ODP pair showed.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
> `phpunit`, `phpstan`, `phpmd` and `php-cs-fixer` all clean.
- [x] The new code is covered by unit tests
> A round trip over the line spacing in both modes and one over the two paragraph spacings. All three fail on `develop`.
- [x] I have updated the documentation to describe the changes
> `docs/changes/1.3.0.md`.
- [x] I have added my name to the Changelog
> Same file.
