### PR TITLE
PowerPoint97 Reader : Read past the end of a stream without warning

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -76,6 +76,7 @@
 - ODPresentation Writer : Fixed the paragraph, the text and the graphic style of a slide note being referenced but never written, and shared one automatic style between everything that writes the same one, by [@dkulyk](http://github.com/dkulyk) in [#935](https://github.com/PHPOffice/PHPPresentation/pull/935)
 - ODPresentation Writer : Shared the graphic and the drawing-page styles between everything that writes the same one, the way the paragraph and the text ones are, by [@dkulyk](http://github.com/dkulyk) in [#936](https://github.com/PHPOffice/PHPPresentation/pull/936)
 
+- PowerPoint97 Reader : Fixed a stream being read one byte past its end, raising `Uninitialized string offset` once per byte for each structure the parser walks off the end of, by [@dkulyk](http://github.com/dkulyk) in [#995](https://github.com/PHPOffice/PHPPresentation/pull/995)
 ## BC Breaks
 - `AbstractShape::setShadow()` given `null` now stores a fresh `Shadow` instead of the null, so `AbstractShape::getShadow()` returns `Shadow` rather than `?Shadow`. Code that read it back as null tests the shadow it gets instead (`getShadow()->isVisible()`); a subclass that overrode it with a nullable return type widens it.
 - `\PhpOffice\PhpPresentation\Slide\SlideMaster` is constructed without a background. A deck that relied on the white fill it used to write sets one with `setBackground()`, as [the documentation](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/usage/slides/introduction.md) shows.

--- a/src/PhpPresentation/Reader/PowerPoint97.php
+++ b/src/PhpPresentation/Reader/PowerPoint97.php
@@ -683,7 +683,8 @@ class PowerPoint97 implements ReaderInterface
      */
     private static function getBytes(string $data, int $pos, int $length): string
     {
-        return str_pad(substr($data, $pos, $length), $length, "\x00");
+        // before PHP 8.0 a read that starts past the end of the string answers false, not ''
+        return str_pad((string) substr($data, $pos, $length), $length, "\x00");
     }
 
     /**

--- a/src/PhpPresentation/Reader/PowerPoint97.php
+++ b/src/PhpPresentation/Reader/PowerPoint97.php
@@ -674,11 +674,24 @@ class PowerPoint97 implements ReaderInterface
     }
 
     /**
+     * Read a fixed number of bytes out of a stream, past its end if need be.
+     *
+     * A stream is a chain of sectors, and the last of those is only partly filled: the bytes after
+     * the stream's length are the zeros the sector was padded with. Several of the structures below
+     * are read until a byte fails a sanity check and are terminated by exactly those zeros, so a
+     * read that runs past the end is answered with them rather than with a warning per byte.
+     */
+    private static function getBytes(string $data, int $pos, int $length): string
+    {
+        return str_pad(substr($data, $pos, $length), $length, "\x00");
+    }
+
+    /**
      * Read 8-bit unsigned integer.
      */
     public static function getInt1d(string $data, int $pos): int
     {
-        return ord($data[$pos]);
+        return ord(self::getBytes($data, $pos, 1));
     }
 
     /**
@@ -686,7 +699,9 @@ class PowerPoint97 implements ReaderInterface
      */
     public static function getInt2d(string $data, int $pos): int
     {
-        return ord($data[$pos]) | (ord($data[$pos + 1]) << 8);
+        $data = self::getBytes($data, $pos, 2);
+
+        return ord($data[0]) | (ord($data[1]) << 8);
     }
 
     /**
@@ -694,6 +709,9 @@ class PowerPoint97 implements ReaderInterface
      */
     public static function getInt4d(string $data, int $pos): int
     {
+        $data = self::getBytes($data, $pos, 4);
+        $pos = 0;
+
         // FIX: represent numbers correctly on 64-bit system
         // http://sourceforge.net/tracker/index.php?func=detail&aid=1487372&group_id=99160&atid=623334
         // Hacked by Andreas Rehm 2006 to ensure correct result of the <<24 block on 32 and 64bit systems

--- a/tests/PhpPresentation/Tests/Reader/PowerPoint97Test.php
+++ b/tests/PhpPresentation/Tests/Reader/PowerPoint97Test.php
@@ -153,4 +153,19 @@ class PowerPoint97Test extends TestCase
         $oSlide = $oPhpPresentation->getSlide(0);
         self::assertCount(4, $oSlide->getShapeCollection());
     }
+
+    /**
+     * The structures a stream holds are read until a byte fails a sanity check, and the zeros a
+     * sector was padded with are what stops that. A stream that ends without them is read to its
+     * last byte and one past it, which answers with those zeros rather than with a warning.
+     */
+    public function testReadsPastTheEndOfAStream(): void
+    {
+        $stream = "\x01\x02\x03";
+
+        self::assertSame(0, PowerPoint97::getInt1d($stream, 3));
+        self::assertSame(0x0003, PowerPoint97::getInt2d($stream, 2));
+        self::assertSame(0x00030201, PowerPoint97::getInt4d($stream, 0));
+        self::assertSame(0, PowerPoint97::getInt4d($stream, 8));
+    }
 }


### PR DESCRIPTION
### Description

The structures in a `PowerPoint Document` stream are read until a byte fails a sanity check, and the
zeros the last sector was padded with are what stops that. `getInt1d()`, `getInt2d()` and
`getInt4d()` indexed the string directly:

```php
return ord($data[$pos]);
return ord($data[$pos]) | (ord($data[$pos + 1]) << 8);
```

so a stream that ends without those zeros is read one byte past its end, and PHP raises
`Uninitialized string offset` for every byte of the read -- once per structure the parser walks off
the end of. `loadPicturesStream()` and the `ansiUserName` / `unicodeUserName` loops of
`loadCurrentUserStream()` are the three that do it.

The three now read through `getBytes()`, which pads a short read with the zeros the sector would
have held:

```php
private static function getBytes(string $data, int $pos, int $length): string
{
    return str_pad(substr($data, $pos, $length), $length, "\x00");
}
```

Nothing changes for a stream that carries its padding, which is every stream `OLERead` hands over
today -- it returns the sectors, so the padding comes with them. A stream that does not is read to
its end and stops there, quietly, instead of warning per byte.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
> `phpunit`, `phpstan` and `php-cs-fixer` all clean.
- [x] The new code is covered by unit tests (check build & code coverage report)
> `PowerPoint97Test::testReadsPastTheEndOfAStream` reads the last byte of a three-byte string and one
> past it, through all three integer readers. It raises on `master`.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/master/docs) to describe the changes
> Nothing to describe: the three methods are internal to the reader and their results are unchanged
> for every input that was in range.
- [x] I have added an entry in the CHANGELOG.md file
> Under Bug fixes.
