### PR TITLE
Style\Font : Raise a superscript by 30% and not by 300%

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -18,6 +18,7 @@
 
 ## Bug fixes
 - PowerPoint2007 Reader : Fixed a node taken out of a node list being treated as an element without being asked whether it is one, which `phpoffice/common` 1.1.0 no longer promises, by [@dkulyk](http://github.com/dkulyk) in [#1000](https://github.com/PHPOffice/PHPPresentation/pull/1000)
+- PowerPoint2007 Writer : Fixed `Font::BASELINE_SUPERSCRIPT` and `Font::BASELINE_SUBSCRIPT` being ten times too large, which raised a superscript by 300% and dropped a subscript by 250%, putting it on a line of its own, by [@dkulyk](http://github.com/dkulyk) fixing [#997](https://github.com/PHPOffice/PHPPresentation/issues/997) in [#998](https://github.com/PHPOffice/PHPPresentation/pull/998)
 - PowerPoint2007 Reader : Fixed a colour with an alpha coming back opaque and one character short, taking the first digit of the colour with it, by [@dkulyk](http://github.com/dkulyk) in [#961](https://github.com/PHPOffice/PHPPresentation/pull/961)
 - Both Writers : Fixed a second shape holding the same picture, and a second chart holding the same numbers, being written as a reference to a part that was never put in the archive, which is what PowerPoint offers to repair, by [@dkulyk](http://github.com/dkulyk) in [#948](https://github.com/PHPOffice/PHPPresentation/pull/948)
 - PowerPoint2007 Writer : Fixed a group taking two shape identifiers and using the second, leaving a number no shape carries, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)

--- a/docs/usage/styles.md
+++ b/docs/usage/styles.md
@@ -158,12 +158,12 @@ echo $alignment->isRTL();
 ### Baseline
 
 The baseline set the position relative to the line.
-The value is a percentage.
+The value is a percentage in thousandths, so `30000` is 30% of the font size.
 
 You can use some predefined values :
 
-* `Font::BASELINE_SUPERSCRIPT` (= 300000 = 300%)
-* `Font::BASELINE_SUBSCRIPT` (= -250000 = -250%)
+* `Font::BASELINE_SUPERSCRIPT` (= 30000 = 30%)
+* `Font::BASELINE_SUBSCRIPT` (= -25000 = -25%)
 
 
 ### Capitalization

--- a/src/PhpPresentation/Style/Font.php
+++ b/src/PhpPresentation/Style/Font.php
@@ -68,8 +68,8 @@ class Font implements ComparableInterface
     public const UNDERLINE_WORDS = 'words';
 
     // Script sub and super values
-    public const BASELINE_SUPERSCRIPT = 300000;
-    public const BASELINE_SUBSCRIPT = -250000;
+    public const BASELINE_SUPERSCRIPT = 30000;
+    public const BASELINE_SUBSCRIPT = -25000;
 
     /**
      * Name.

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptChartsTest.php
@@ -1172,7 +1172,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:bar3DChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-250000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-25000');
         $this->assertIsSchemaECMA376Valid();
     }
 
@@ -1189,7 +1189,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:bar3DChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '300000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '30000');
         $this->assertIsSchemaECMA376Valid();
     }
 
@@ -1597,7 +1597,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:lineChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-250000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-25000');
 
         $this->assertIsSchemaECMA376Valid();
     }
@@ -1615,7 +1615,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:lineChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '300000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '30000');
 
         $this->assertIsSchemaECMA376Valid();
     }
@@ -1723,7 +1723,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:pie3DChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-250000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-25000');
 
         $this->assertIsSchemaECMA376Valid();
     }
@@ -1741,7 +1741,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:pie3DChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '300000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '30000');
 
         $this->assertIsSchemaECMA376Valid();
     }
@@ -2007,7 +2007,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:scatterChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-250000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '-25000');
 
         $this->assertIsSchemaECMA376Valid();
     }
@@ -2025,7 +2025,7 @@ class PptChartsTest extends PhpPresentationTestCase
 
         $element = '/c:chartSpace/c:chart/c:plotArea/c:scatterChart/c:ser/c:dLbls/c:txPr/a:p/a:pPr/a:defRPr';
         $this->assertZipXmlElementExists('ppt/charts/' . $oShape->getIndexedFilename(), $element);
-        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '300000');
+        $this->assertZipXmlAttributeEquals('ppt/charts/' . $oShape->getIndexedFilename(), $element, 'baseline', '30000');
 
         $this->assertIsSchemaECMA376Valid();
     }

--- a/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
+++ b/tests/PhpPresentation/Tests/Writer/PowerPoint2007/PptSlidesTest.php
@@ -1695,7 +1695,7 @@ class PptSlidesTest extends PhpPresentationTestCase
 
         $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr';
         $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'baseline', '-250000');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'baseline', '-25000');
         $this->assertIsSchemaECMA376Valid();
     }
 
@@ -1708,7 +1708,7 @@ class PptSlidesTest extends PhpPresentationTestCase
 
         $element = '/p:sld/p:cSld/p:spTree/p:sp/p:txBody/a:p/a:r/a:rPr';
         $this->assertZipXmlElementExists('ppt/slides/slide1.xml', $element);
-        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'baseline', '300000');
+        $this->assertZipXmlAttributeEquals('ppt/slides/slide1.xml', $element, 'baseline', '30000');
         $this->assertIsSchemaECMA376Valid();
     }
 


### PR DESCRIPTION
### Description

`Font::BASELINE_SUPERSCRIPT` is `300000` and `BASELINE_SUBSCRIPT` is `-250000`. The `baseline`
attribute is written in thousandths of a percent, so those ask for a 300% raise and a 250% drop and
the character lands on a line of its own.

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/baseline-997-pptx-before.png" width="420"> | <img src="https://raw.githubusercontent.com/sapientpro/PHPPresentation/assets/baseline-997-pptx-after.png" width="420"> |

`30000` and `-25000` are what 0.9.0 wrote, before the constants replaced the hard-coded values in
[ec4700e](https://github.com/PHPOffice/PHPPresentation/commit/ec4700e44), and what LibreOffice uses
for the same thing: `oox/source/drawingml/textcharacterpropertiescontext.cxx` maps
`<w:vertAlign w:val="superscript"/>` to `baseline = 30000` and `subscript` to `-25000`. On import it
reads `CharEscapement = baseline / 1000` and treats it as a percentage, which is why 300000 renders
as a 300% raise rather than being ignored.

Note this is not a schema violation -- `baseline` is `ST_Percentage`, unbounded in
`tests/resources/schema/ecma-376/dml-main.xsd`, and a slide carrying `300000` validates. The value
is simply ten times too large.

`.odp` is unaffected: the ODPresentation Writer does not write `style:text-position` at all, so
superscript is dropped there whatever the constant says. Separate matter.

Fixes #997

### Checklist:

- [ ] My CI is :green_circle:
> The unit tests pass, 1123 tests and 9172 assertions. The seven **PHP Static Analysis** jobs fail on `master` itself since `phpoffice/common` 1.1.0. [PHPOffice/Common#64](https://github.com/PHPOffice/Common/pull/64) dropped the `<\DOMElement>` from `XMLReader::getElements()`'s `@return \DOMNodeList`, so a node it yields is now inferred as `DOMNode` -- 18 errors, all in `Reader/PowerPoint2007.php`, none from this branch. `git checkout master && composer update phpoffice/common && vendor/bin/phpstan analyse` reproduces them.
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
> The ten assertions in `PptSlidesTest` and `PptChartsTest` that pinned the written attribute now pin the corrected value.
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs) to describe the changes
> `docs/usage/styles.md` carried the old values and called the unit a percentage.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
> `docs/changes/1.3.0.md`.
