### PR TITLE
PowerPoint2007 Reader : Take an element out of a node list as one

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -17,6 +17,7 @@
 - PowerPoint2007 Writer & Reader : Added a fill behind the data labels of a chart serie, so that a label stays readable over the chart it sits on, by [@dkulyk](http://github.com/dkulyk) in [#963](https://github.com/PHPOffice/PHPPresentation/pull/963)
 
 ## Bug fixes
+- PowerPoint2007 Reader : Fixed a node taken out of a node list being treated as an element without being asked whether it is one, which `phpoffice/common` 1.1.0 no longer promises, by [@dkulyk](http://github.com/dkulyk) in [#1000](https://github.com/PHPOffice/PHPPresentation/pull/1000)
 - PowerPoint2007 Reader : Fixed a colour with an alpha coming back opaque and one character short, taking the first digit of the colour with it, by [@dkulyk](http://github.com/dkulyk) in [#961](https://github.com/PHPOffice/PHPPresentation/pull/961)
 - Both Writers : Fixed a second shape holding the same picture, and a second chart holding the same numbers, being written as a reference to a part that was never put in the archive, which is what PowerPoint offers to repair, by [@dkulyk](http://github.com/dkulyk) in [#948](https://github.com/PHPOffice/PHPPresentation/pull/948)
 - PowerPoint2007 Writer : Fixed a group taking two shape identifiers and using the second, leaving a number no shape carries, by [@dkulyk](http://github.com/dkulyk) in [#947](https://github.com/PHPOffice/PHPPresentation/pull/947)

--- a/src/PhpPresentation/Reader/PowerPoint2007.php
+++ b/src/PhpPresentation/Reader/PowerPoint2007.php
@@ -329,7 +329,7 @@ class PowerPoint2007 implements ReaderInterface
         // @phpstan-ignore-next-line
         if ($xmlReader->getDomFromString($sPart)) {
             foreach ($xmlReader->getElements('/Properties/property[@fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}"]') as $element) {
-                if (!$element->hasAttribute('name')) {
+                if (!$element instanceof DOMElement || !$element->hasAttribute('name')) {
                     continue;
                 }
                 $propertyName = $element->getAttribute('name');
@@ -1084,6 +1084,9 @@ class PowerPoint2007 implements ReaderInterface
     {
         $aNodes = $document->getElements('*', $node);
         foreach ($aNodes as $nodeShadow) {
+            if (!$nodeShadow instanceof DOMElement) {
+                continue;
+            }
             $type = explode(':', $nodeShadow->tagName);
             $type = array_pop($type);
             if ($type == Shadow::TYPE_SHADOW_INNER || $type == Shadow::TYPE_SHADOW_OUTER || $type == Shadow::TYPE_REFLECTION) {


### PR DESCRIPTION
### Description

The seven **PHP Static Analysis** jobs fail on `master`, and on every branch cut from it, since
`phpoffice/common` 1.1.0 was released on 5 September.
[PHPOffice/Common#64](https://github.com/PHPOffice/Common/pull/64) dropped the `<\DOMElement>` from
`XMLReader::getElements()`'s `@return \DOMNodeList`, so a node it yields is inferred as `DOMNode`
and 18 errors follow, all in `Reader/PowerPoint2007.php`:

```
git checkout master && composer update phpoffice/common && vendor/bin/phpstan analyse -c phpstan.neon.dist
```

The looser type is the honest one, and this repository is what proves it:
`Reader\ODPresentation::readParagraph()` calls `getElements('text()')` and reads the `DOMText`
nodes that come back. So the two loops that read a custom property and a shadow ask each node
whether it is an element before they treat it as one -- which is the idiom already, eight lines
below that call:

```php
foreach ($oDomList as $oNodeRichTextElement) {
    if ($oNodeRichTextElement instanceof DOMElement) {
```

No behaviour changes: both of the queries guarded here select elements (`*` is `child::*`, and a
predicate on `@fmtid` still selects `property` elements), so the guard never fires today. It is
the type that could not promise it, not the document.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
> There is no new behaviour to cover. Both paths are already exercised by `Reader\PowerPoint2007Test` -- `_MarkAsFinal` through `loadCustomProperties()` and the shape shadows through `loadShadow()` -- and the suite is unchanged at 1123 tests and 9172 assertions.
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPPresentation/tree/develop/docs)
> Nothing user-facing changed.
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPPresentation/blob/develop/docs/changes/1.1.0.md)
> `docs/changes/1.3.0.md`.
