### PR TITLE
ODPresentation Reader : Read the speaker notes of a slide

### DIFF
--- a/docs/changes/1.3.0.md
+++ b/docs/changes/1.3.0.md
@@ -80,6 +80,7 @@
 - PowerPoint2007 Reader : Fixed a shadow's alignment being read off the effect list rather than off the shadow in it, and its colour and alpha being looked for under a preset colour the Writer never writes, and read a shape's wrap back, by [@dkulyk](http://github.com/dkulyk) in [#982](https://github.com/PHPOffice/PHPPresentation/pull/982)
 - ODPresentation Reader : Fixed a paragraph's line spacing being read out of the margin below it, so that every spacing came back as that margin in centimetres and every mode as points, by [@dkulyk](http://github.com/dkulyk) in [#980](https://github.com/PHPOffice/PHPPresentation/pull/980)
 - ODPresentation Reader : Fixed a shape's border being written as a stroke and never read back, so that every shape loaded from a file wore the default border rather than its own, by [@dkulyk](http://github.com/dkulyk) in [#978](https://github.com/PHPOffice/PHPPresentation/pull/978)
+- ODPresentation Reader : Fixed the speaker notes of a slide being written and never read back, so that a note written by this library or by LibreOffice was lost on load, by [@dkulyk](http://github.com/dkulyk) fixing [#724](https://github.com/PHPOffice/PHPPresentation/issues/724) in [#1001](https://github.com/PHPOffice/PHPPresentation/pull/1001)
 
 - PowerPoint97 Reader : Fixed a stream being read one byte past its end, raising `Uninitialized string offset` once per byte for each structure the parser walks off the end of, by [@dkulyk](http://github.com/dkulyk) in [#995](https://github.com/PHPOffice/PHPPresentation/pull/995)
 ## BC Breaks

--- a/src/PhpPresentation/Reader/ODPresentation.php
+++ b/src/PhpPresentation/Reader/ODPresentation.php
@@ -37,6 +37,7 @@ use PhpOffice\PhpPresentation\Shape\RichText\Field;
 use PhpOffice\PhpPresentation\Shape\RichText\Paragraph;
 use PhpOffice\PhpPresentation\Shape\Table\Cell;
 use PhpOffice\PhpPresentation\Shape\Table\Row;
+use PhpOffice\PhpPresentation\ShapeContainerInterface;
 use PhpOffice\PhpPresentation\Slide\Background\Color as BackgroundColor;
 use PhpOffice\PhpPresentation\Slide\Background\Image;
 use PhpOffice\PhpPresentation\Style\Alignment;
@@ -852,8 +853,28 @@ class ODPresentation implements ReaderInterface
                 }
             }
         }
+        $this->loadSlideNote($nodeSlide);
 
         return true;
+    }
+
+    /**
+     * Read the speaker notes of a slide, the text a producer puts in presentation:notes.
+     */
+    protected function loadSlideNote(DOMElement $nodeSlide): void
+    {
+        $note = $this->oPhpPresentation->getActiveSlide()->getNote();
+
+        foreach ($this->oXMLReader->getElements('presentation:notes/draw:frame', $nodeSlide) as $oNodeFrame) {
+            if ($oNodeFrame instanceof DOMElement) {
+                // An empty text box is the placeholder every slide carries whether it has notes
+                // or not, so only a box with something in it becomes a shape
+                $oNodeTextBox = $this->oXMLReader->getElement('draw:text-box', $oNodeFrame);
+                if ($oNodeTextBox instanceof DOMElement && $oNodeTextBox->hasChildNodes()) {
+                    $this->loadShapeRichText($oNodeFrame, $note);
+                }
+            }
+        }
     }
 
     /**
@@ -957,11 +978,15 @@ class ODPresentation implements ReaderInterface
 
     /**
      * Read Shape RichText.
+     *
+     * @param null|ShapeContainerInterface $container where the shape goes, the slide itself unless
+     *                                                the frame was read out of the slide note
      */
-    protected function loadShapeRichText(DOMElement $oNodeFrame): void
+    protected function loadShapeRichText(DOMElement $oNodeFrame, ?ShapeContainerInterface $container = null): void
     {
         // Core
-        $oShape = $this->oPhpPresentation->getActiveSlide()->createRichTextShape();
+        $oShape = new RichText();
+        ($container ?? $this->oPhpPresentation->getActiveSlide())->addShape($oShape);
         $oShape->setParagraphs([]);
 
         $oShape->setDescription($this->loadShapeDescription($oNodeFrame));

--- a/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
+++ b/tests/PhpPresentation/Tests/Reader/ODPresentationTest.php
@@ -1683,4 +1683,33 @@ class ODPresentationTest extends TestCase
         self::assertInstanceOf(RichText::class, $arrayShape[0]);
         self::assertEquals(Border::LINE_NONE, $arrayShape[0]->getBorder()->getLineStyle());
     }
+
+    public function testSlideNoteSurvivesTheRoundTrip(): void
+    {
+        $oPhpPresentation = new PhpPresentation();
+        $oPhpPresentation->getActiveSlide()->getNote()->createRichTextShape()
+            ->createTextRun('Speaker note');
+
+        $file = tempnam(sys_get_temp_dir(), 'PhpPresentation');
+        (new ODPresentationWriter($oPhpPresentation))->save($file);
+        $oPhpPresentationRead = (new ODPresentation())->load($file);
+        unlink($file);
+
+        self::assertCount(0, $oPhpPresentationRead->getActiveSlide()->getShapeCollection());
+        $arrayShape = array_values((array) $oPhpPresentationRead->getActiveSlide()->getNote()->getShapeCollection());
+        self::assertCount(1, $arrayShape);
+        self::assertInstanceOf(RichText::class, $arrayShape[0]);
+        self::assertEquals('Speaker note', $arrayShape[0]->getPlainText());
+    }
+
+    public function testEmptySlideNoteWrittenByLibreOffice(): void
+    {
+        // LibreOffice gives every slide a notes placeholder whether it holds anything or not
+        $file = PHPPRESENTATION_TESTS_BASE_DIR . '/resources/files/Issue_00141.odp';
+        $oPhpPresentation = (new ODPresentation())->load($file);
+
+        foreach ($oPhpPresentation->getAllSlides() as $oSlide) {
+            self::assertCount(0, $oSlide->getNote()->getShapeCollection());
+        }
+    }
 }


### PR DESCRIPTION
### Description

The ODPresentation Writer puts the shapes of a slide note in `presentation:notes`, and nothing read them back, so a note written by this library or by LibreOffice was lost on load. The PowerPoint2007 Reader has read notes since `loadSlideNote()`; this gives the ODPresentation Reader the same.

`loadShapeRichText()` now takes the container the shape goes in -- the slide itself unless the frame came out of `presentation:notes`.

An empty text box is skipped. LibreOffice gives every slide a notes placeholder whether it holds anything or not:

```xml
<presentation:notes draw:style-name="dp2">
  <draw:page-thumbnail .../>
  <draw:frame presentation:class="notes" presentation:placeholder="true"><draw:text-box/></draw:frame>
</presentation:notes>
```

Reading that back would put an empty shape on a note that has nothing in it, and `count($slide->getNote()->getShapeCollection())` would answer "this slide has notes" for every slide of every file LibreOffice ever wrote.

Fixes #724

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
> `phpstan` reports `[OK] No errors` and the suite is green at 1129 tests, 9196 assertions.
- [x] The new code is covered by unit tests
> `testSlideNoteSurvivesTheRoundTrip()` writes a note and reads it back; it fails on `master` with `actual size 0 matches expected size 1`. `testEmptySlideNoteWrittenByLibreOffice()` loads `Issue_00141.odp` and asserts the placeholder frames produce no shapes.
- [x] I have updated the documentation to describe the changes
> An entry under `## Bug fixes` in `docs/changes/1.3.0.md`.
- [x] I have added a changelog entry
> Same entry.
